### PR TITLE
perf: add compound indexes to Expense collection

### DIFF
--- a/src/models/Expense.ts
+++ b/src/models/Expense.ts
@@ -31,5 +31,8 @@ const ExpenseSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
+ExpenseSchema.index({ owner: 1, date: -1 });
+ExpenseSchema.index({ owner: 1, _id: 1 });
+
 export const ExpenseModel = mongoose.model<IExpense>('Expense', ExpenseSchema);
 export default ExpenseModel;


### PR DESCRIPTION
## Summary
- Adds `{ owner: 1, date: -1 }` compound index — used by the main GET query
- Adds `{ owner: 1, _id: 1 }` compound index — used by GET /:id and PUT /:id

## Test plan
- [ ] TypeScript compiles clean (0 new errors introduced)
- [ ] GET /api/expenses returns correct results after deploy
- [ ] MongoDB Atlas index panel shows new indexes created on next connect

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)