### PR TITLE
perf: add compound indexes to Expense collection

### DIFF
--- a/src/models/Expense.ts
+++ b/src/models/Expense.ts
@@ -39,5 +39,8 @@ const ExpenseSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
+ExpenseSchema.index({ owner: 1, date: -1 });
+ExpenseSchema.index({ owner: 1, _id: 1 });
+
 export const ExpenseModel = mongoose.model<IExpense>('Expense', ExpenseSchema);
 export default ExpenseModel;


### PR DESCRIPTION
## Summary
- Adds `{ owner: 1, date: -1 }` compound index — used by GET /api/expenses main query
- Adds `{ owner: 1, _id: 1 }` compound index — used by GET /:id and PUT /:id

## Why
Without indexes, every GET request does a full collection scan. As transaction count grows this becomes a noticeable latency issue.

## Test plan
- [x] TypeScript compiles (0 new errors)
- [ ] GET /api/expenses returns correct results after deploy
- [ ] MongoDB Atlas index panel shows indexes created on next server start

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)