### PR TITLE
feat: budget alerts — add alert configuration and summary endpoint

### DIFF
--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -4,6 +4,8 @@ import bcrypt from 'bcryptjs';
 export interface IBudget {
   category: string;
   limit: number;
+  alert_threshold?: number;
+  enable_alerts?: boolean;
 }
 
 export interface IUser extends Document {
@@ -18,7 +20,17 @@ const UserSchema = new mongoose.Schema(
   {
     email: { type: String, required: true, unique: true, lowercase: true, trim: true },
     password: { type: String, required: true, minlength: 6 },
-    budgets: { type: [{ category: String, limit: Number }], default: [] },
+    budgets: {
+      type: [
+        {
+          category: String,
+          limit: Number,
+          alert_threshold: { type: Number, default: 0.9 },
+          enable_alerts: { type: Boolean, default: false },
+        },
+      ],
+      default: [],
+    },
   },
   { timestamps: true }
 );

--- a/src/routes/budgets.ts
+++ b/src/routes/budgets.ts
@@ -1,6 +1,7 @@
 import { Router, Response } from 'express';
 import { body, validationResult } from 'express-validator';
 import UserModel from '../models/User';
+import ExpenseModel from '../models/Expense';
 import { protect, AuthRequest } from '../middleware/auth';
 
 const router = Router();
@@ -21,6 +22,67 @@ router.get('/', async (req: AuthRequest, res: Response) => {
   }
 });
 
+// GET /api/budgets/summary - returns current spend vs limits
+router.get('/summary', async (req: AuthRequest, res: Response) => {
+  try {
+    const user = await UserModel.findById(req.userId).lean();
+    if (!user) {
+      res.status(404).json({ error: 'User not found' });
+      return;
+    }
+
+    const budgets = user.budgets || [];
+    if (budgets.length === 0) {
+      res.json({ summary: [] });
+      return;
+    }
+
+    // Get current month start and end
+    const now = new Date();
+    const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+    const monthEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0);
+
+    // Get expenses for current month grouped by category
+    const expenses = await ExpenseModel.find(
+      {
+        userId: req.userId,
+        type: 'expense',
+        date: { $gte: monthStart, $lte: monthEnd },
+      },
+      { category: 1, amount: 1 }
+    ).lean();
+
+    const categorySpend: { [key: string]: number } = {};
+    expenses.forEach((exp) => {
+      const cat = exp.category || 'Uncategorized';
+      categorySpend[cat] = (categorySpend[cat] || 0) + exp.amount;
+    });
+
+    const summary = budgets.map((b) => {
+      const spend = categorySpend[b.category] || 0;
+      const threshold = b.alert_threshold || 0.9;
+      const remaining = Math.max(0, b.limit - spend);
+      const exceeds = spend > b.limit;
+      const percentUsed = b.limit > 0 ? (spend / b.limit) * 100 : 0;
+
+      return {
+        category: b.category,
+        limit: b.limit,
+        spend,
+        remaining,
+        percentUsed: Math.round(percentUsed),
+        exceeds,
+        alertTriggered: exceeds && b.enable_alerts,
+        thresholdPercentage: threshold * 100,
+      };
+    });
+
+    res.json({ summary });
+  } catch {
+    res.status(500).json({ error: 'Failed to fetch budget summary' });
+  }
+});
+
 // PUT /api/budgets
 router.put(
   '/',
@@ -36,9 +98,15 @@ router.put(
       return;
     }
     try {
-      const budgets = (req.body.budgets as { category: string; limit: number }[]).filter(
-        (b) => b.limit > 0
-      );
+      const budgets = (
+        req.body.budgets as {
+          category: string;
+          limit: number;
+          alert_threshold?: number;
+          enable_alerts?: boolean;
+        }[]
+      ).filter((b) => b.limit > 0);
+
       await UserModel.findByIdAndUpdate(req.userId, { $set: { budgets } });
       res.json({ budgets });
     } catch {


### PR DESCRIPTION
## Summary
- Added `alert_threshold` (default 0.9) and `enable_alerts` (default false) fields to Budget schema
- New endpoint: GET /api/budgets/summary returns current spend vs limits for all categories
- Updated User model to support alert configuration
- All tests passing

## Changes
- User model: added alert_threshold and enable_alerts to IBudget interface and schema
- Budgets route: added GET /api/budgets/summary endpoint that calculates current month spend vs limits
- Updated PUT /api/budgets to accept alert settings in requests

## Test Results
- All 94 tests passing
- TypeScript compile successful

## Next Steps
- Frontend: implement budget alerts UI
- Implement Telegram notification background job (separate PR)
- Add audit log for alert events (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)