### PR TITLE
feat: monthly report API — GET /api/reports/monthly

### DIFF
--- a/__tests__/reports.test.ts
+++ b/__tests__/reports.test.ts
@@ -1,0 +1,103 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import app from '../src/app';
+import ExpenseModel from '../src/models/Expense';
+
+let mongod: MongoMemoryServer;
+const TEST_USER_ID = 'user_test_123';
+const authToken = jwt.sign({ userId: TEST_USER_ID }, 'test-secret');
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  for (const col of Object.values(mongoose.connection.collections)) {
+    await col.deleteMany({});
+  }
+});
+
+describe('GET /api/reports/monthly', () => {
+  it('returns 401 without auth', async () => {
+    const res = await request(app).get('/api/reports/monthly');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns empty data for new user', async () => {
+    const res = await request(app)
+      .get('/api/reports/monthly')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.data)).toBe(true);
+  });
+
+  it('defaults to 6 months', async () => {
+    const res = await request(app)
+      .get('/api/reports/monthly')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.body.data.length).toBe(6);
+  });
+
+  it('respects months param', async () => {
+    const res = await request(app)
+      .get('/api/reports/monthly?months=3')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.body.data.length).toBe(3);
+  });
+
+  it('caps at 24 months', async () => {
+    const res = await request(app)
+      .get('/api/reports/monthly?months=50')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.body.data.length).toBe(24);
+  });
+
+  it('aggregates income and expenses', async () => {
+    const now = new Date();
+    await ExpenseModel.create([
+      { owner: TEST_USER_ID, description: 'Salary', amount: 5000, type: 'income', date: now },
+      { owner: TEST_USER_ID, description: 'Rent', amount: 2000, type: 'expense', date: now },
+    ]);
+    const res = await request(app)
+      .get('/api/reports/monthly?months=1')
+      .set('Authorization', `Bearer ${authToken}`);
+    const m = res.body.data[0];
+    expect(m.income).toBe(5000);
+    expect(m.expenses).toBe(2000);
+    expect(m.net).toBe(3000);
+    expect(m.transactionCount).toBe(2);
+  });
+
+  it('has correct field structure', async () => {
+    const res = await request(app)
+      .get('/api/reports/monthly?months=1')
+      .set('Authorization', `Bearer ${authToken}`);
+    const e = res.body.data[0];
+    expect(e.month).toMatch(/^\d{4}-\d{2}$/);
+    expect(e).toHaveProperty('income');
+    expect(e).toHaveProperty('expenses');
+    expect(e).toHaveProperty('net');
+    expect(e).toHaveProperty('transactionCount');
+  });
+
+  it('zeros for empty months', async () => {
+    const res = await request(app)
+      .get('/api/reports/monthly?months=2')
+      .set('Authorization', `Bearer ${authToken}`);
+    for (const e of res.body.data) {
+      expect(e.income).toBe(0);
+      expect(e.expenses).toBe(0);
+    }
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -11,6 +11,7 @@ import netWorthRoutes from './routes/net-worth';
 import exportRoutes from './routes/export';
 import importRoutes from './routes/import';
 import recurringRoutes from './routes/recurring';
+import reportRoutes from './routes/reports';
 import { startAlertScheduler } from './jobs/processAlerts';
 import { startRecurringScheduler } from './jobs/processRecurring';
 
@@ -37,6 +38,7 @@ app.use('/api/net-worth', netWorthRoutes);
 app.use('/api/export', exportRoutes);
 app.use('/api/import', importRoutes);
 app.use('/api/recurring', recurringRoutes);
+app.use('/api/reports', reportRoutes);
 
 Sentry.setupExpressErrorHandler(app);
 

--- a/src/routes/reports.ts
+++ b/src/routes/reports.ts
@@ -1,0 +1,79 @@
+import { Router, Response } from 'express';
+import ExpenseModel from '../models/Expense';
+import { protect, AuthRequest } from '../middleware/auth';
+
+const router = Router();
+
+router.use(protect);
+
+function monthLabel(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  return `${y}-${m}`;
+}
+
+function subtractMonths(date: Date, n: number): Date {
+  const d = new Date(date);
+  d.setDate(1);
+  d.setMonth(d.getMonth() - n);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+router.get('/monthly', async (req: AuthRequest, res: Response) => {
+  try {
+    const months = Math.min(parseInt(req.query.months as string) || 6, 24);
+    const now = new Date();
+    const startDate = subtractMonths(now, months - 1);
+
+    const rows = await ExpenseModel.aggregate([
+      {
+        $match: {
+          owner: req.userId,
+          date: { $gte: startDate },
+        },
+      },
+      {
+        $group: {
+          _id: { $dateToString: { format: '%Y-%m', date: '$date' } },
+          income: {
+            $sum: { $cond: [{ $eq: ['$type', 'income'] }, '$amount', 0] },
+          },
+          expenses: {
+            $sum: { $cond: [{ $eq: ['$type', 'expense'] }, '$amount', 0] },
+          },
+          transactionCount: { $sum: 1 },
+        },
+      },
+      { $sort: { _id: 1 } },
+    ]);
+
+    const monthMap: Record<string, { income: number; expenses: number; transactionCount: number }> = {};
+    for (const row of rows) {
+      monthMap[row._id] = {
+        income: row.income,
+        expenses: row.expenses,
+        transactionCount: row.transactionCount,
+      };
+    }
+
+    const data = Array.from({ length: months }, (_, i) => {
+      const d = subtractMonths(now, months - 1 - i);
+      const label = monthLabel(d);
+      const entry = monthMap[label] || { income: 0, expenses: 0, transactionCount: 0 };
+      return {
+        month: label,
+        income: entry.income,
+        expenses: entry.expenses,
+        net: entry.income - entry.expenses,
+        transactionCount: entry.transactionCount,
+      };
+    });
+
+    res.json({ data });
+  } catch {
+    res.status(500).json({ error: 'Failed to fetch monthly report' });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- New endpoint: `GET /api/reports/monthly?months=6`
- Aggregates income, expenses, net, and transaction count by month
- Configurable month range (default 6, max 24)
- 8 integration tests covering auth, aggregation, and edge cases

Replaces #31 (which had accumulated merge conflicts and unrelated changes).

## Test plan
- [x] Auth: returns 401 without token
- [x] Default 6 months of data
- [x] Configurable months parameter
- [x] Caps at 24 months
- [x] Aggregates income/expenses correctly
- [x] Correct response field structure
- [x] Empty months return zeroes

🤖 Generated with [Claude Code](https://claude.com/claude-code)