### PR TITLE
feat: add paymentMethod field to Expense model

### DIFF
--- a/__tests__/payment-method.test.ts
+++ b/__tests__/payment-method.test.ts
@@ -1,0 +1,179 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import app from '../src/app';
+
+let mongod: MongoMemoryServer;
+const TEST_USER_ID = 'user_payment_method';
+const authToken = jwt.sign({ userId: TEST_USER_ID }, 'test-secret');
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  for (const col of Object.values(mongoose.connection.collections)) {
+    await col.deleteMany({});
+  }
+});
+
+const basePayload = {
+  description: 'Test expense',
+  amount: 100,
+  type: 'expense',
+  category: 'Food',
+};
+
+async function createExpense(overrides: Record<string, unknown> = {}) {
+  const res = await request(app)
+    .post('/api/expenses')
+    .set('Authorization', `Bearer ${authToken}`)
+    .send({ ...basePayload, ...overrides });
+  return res.body;
+}
+
+describe('paymentMethod field', () => {
+  it('creates expense without paymentMethod (defaults to null)', async () => {
+    const created = await createExpense();
+    expect(created.paymentMethod).toBeNull();
+  });
+
+  it('creates expense with valid paymentMethod', async () => {
+    const created = await createExpense({ paymentMethod: 'octopus' });
+    expect(created.paymentMethod).toBe('octopus');
+  });
+
+  it('rejects invalid paymentMethod on create', async () => {
+    const res = await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ...basePayload, paymentMethod: 'bitcoin' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('paymentMethod must be one of');
+  });
+
+  it('updates expense with paymentMethod', async () => {
+    const created = await createExpense({ description: 'For update' });
+    const res = await request(app)
+      .put(`/api/expenses/${created._id}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ...basePayload, description: 'For update', paymentMethod: 'fps' });
+    expect(res.status).toBe(200);
+    expect(res.body.paymentMethod).toBe('fps');
+  });
+
+  it('rejects invalid paymentMethod on update', async () => {
+    const created = await createExpense({ paymentMethod: 'cash' });
+    const res = await request(app)
+      .put(`/api/expenses/${created._id}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ...basePayload, paymentMethod: 'venmo' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('paymentMethod must be one of');
+  });
+
+  it('clears paymentMethod by setting to null', async () => {
+    const created = await createExpense({ paymentMethod: 'payme' });
+    expect(created.paymentMethod).toBe('payme');
+    const res = await request(app)
+      .put(`/api/expenses/${created._id}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ...basePayload, paymentMethod: null });
+    expect(res.status).toBe(200);
+    expect(res.body.paymentMethod).toBeNull();
+  });
+
+  it('returns paymentMethod in GET /api/expenses', async () => {
+    await createExpense({ paymentMethod: 'credit_card' });
+    const res = await request(app)
+      .get('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.data[0].paymentMethod).toBe('credit_card');
+  });
+
+  it('returns paymentMethod in GET /api/expenses/:id', async () => {
+    const created = await createExpense({ paymentMethod: 'debit_card' });
+    const res = await request(app)
+      .get(`/api/expenses/${created._id}`)
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.paymentMethod).toBe('debit_card');
+  });
+});
+
+describe('GET /api/expenses?paymentMethod filter', () => {
+  it('filters by paymentMethod', async () => {
+    await createExpense({ description: 'Bus', paymentMethod: 'octopus' });
+    await createExpense({ description: 'Lunch', paymentMethod: 'credit_card' });
+    await createExpense({ description: 'Groceries', paymentMethod: 'octopus' });
+
+    const res = await request(app)
+      .get('/api/expenses?paymentMethod=octopus')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.total).toBe(2);
+    for (const expense of res.body.data) {
+      expect(expense.paymentMethod).toBe('octopus');
+    }
+  });
+
+  it('rejects invalid paymentMethod filter', async () => {
+    const res = await request(app)
+      .get('/api/expenses?paymentMethod=bitcoin')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('Invalid paymentMethod filter');
+  });
+
+  it('returns empty when no expenses match filter', async () => {
+    await createExpense({ description: 'Bus', paymentMethod: 'octopus' });
+    const res = await request(app)
+      .get('/api/expenses?paymentMethod=fps')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(0);
+    expect(res.body.total).toBe(0);
+  });
+});
+
+describe('CSV export includes paymentMethod', () => {
+  it('includes Payment Method column header', async () => {
+    const res = await request(app)
+      .get('/api/export/csv')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Payment Method');
+  });
+
+  it('includes paymentMethod value in CSV rows', async () => {
+    await createExpense({ description: 'Train', paymentMethod: 'octopus' });
+    const res = await request(app)
+      .get('/api/export/csv')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('octopus');
+  });
+
+  it('handles null paymentMethod in CSV', async () => {
+    await createExpense({ description: 'Cash purchase' });
+    const res = await request(app)
+      .get('/api/export/csv')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    const lines = res.text.trim().split('\n');
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain('Payment Method');
+  });
+});

--- a/src/models/Expense.ts
+++ b/src/models/Expense.ts
@@ -1,5 +1,19 @@
 import mongoose, { Document } from 'mongoose';
 
+const PAYMENT_METHODS = [
+  'cash',
+  'credit_card',
+  'debit_card',
+  'octopus',
+  'payme',
+  'fps',
+  'alipay_hk',
+  'wechat_pay',
+  'other',
+] as const;
+
+type PaymentMethod = typeof PAYMENT_METHODS[number];
+
 interface IExpense extends Document {
   owner: string;
   description?: string;
@@ -16,6 +30,7 @@ interface IExpense extends Document {
   endDate?: Date | null;
   date?: Date;
   amount: number;
+  paymentMethod?: PaymentMethod | null;
   createdAt?: Date;
   updatedAt?: Date;
 }
@@ -37,6 +52,11 @@ const ExpenseSchema = new mongoose.Schema(
     item: String,
     participants: [String],
     amount: { type: Number, required: true },
+    paymentMethod: {
+      type: String,
+      enum: [...PAYMENT_METHODS, null],
+      default: null,
+    },
   },
   { timestamps: true }
 );
@@ -44,5 +64,6 @@ const ExpenseSchema = new mongoose.Schema(
 ExpenseSchema.index({ owner: 1, date: -1 });
 ExpenseSchema.index({ owner: 1, _id: 1 });
 
+export { PAYMENT_METHODS };
 export const ExpenseModel = mongoose.model<IExpense>('Expense', ExpenseSchema);
 export default ExpenseModel;

--- a/src/routes/expenses.ts
+++ b/src/routes/expenses.ts
@@ -1,7 +1,7 @@
 import { Router, Response } from 'express';
 import { body, validationResult } from 'express-validator';
 import { compareTwoStrings } from 'string-similarity';
-import ExpenseModel from '../models/Expense';
+import ExpenseModel, { PAYMENT_METHODS } from '../models/Expense';
 import { protect, AuthRequest } from '../middleware/auth';
 import { checkAndQueueBudgetAlerts } from '../utils/alerts';
 
@@ -45,9 +45,15 @@ const participantsValidation = body('participants')
     return true;
   });
 
+const paymentMethodValidation = body('paymentMethod')
+  .optional({ values: 'null' })
+  .isIn([...PAYMENT_METHODS])
+  .withMessage(`paymentMethod must be one of: ${PAYMENT_METHODS.join(', ')}`);
+
 const expenseValidation = [
   body('amount').isNumeric().withMessage('Amount must be a number'),
   participantsValidation,
+  paymentMethodValidation,
 ];
 
 // GET /api/expenses with pagination
@@ -57,13 +63,23 @@ router.get('/', async (req: AuthRequest, res: Response) => {
     const limit = Math.min(100, Math.max(1, parseInt(req.query.limit as string) || 20));
     const skip = (page - 1) * limit;
 
+    const filter: Record<string, unknown> = { owner: req.userId };
+    const paymentMethodQuery = req.query.paymentMethod as string | undefined;
+    if (paymentMethodQuery) {
+      if (!PAYMENT_METHODS.includes(paymentMethodQuery as typeof PAYMENT_METHODS[number])) {
+        res.status(400).json({ error: `Invalid paymentMethod filter. Must be one of: ${PAYMENT_METHODS.join(', ')}` });
+        return;
+      }
+      filter.paymentMethod = paymentMethodQuery;
+    }
+
     const [expenses, total] = await Promise.all([
-      ExpenseModel.find({ owner: req.userId })
+      ExpenseModel.find(filter)
         .sort({ date: -1, createdAt: -1 })
         .skip(skip)
         .limit(limit)
         .lean(),
-      ExpenseModel.countDocuments({ owner: req.userId }),
+      ExpenseModel.countDocuments(filter),
     ]);
 
     const pages = Math.ceil(total / limit);
@@ -95,7 +111,7 @@ router.post('/', expenseValidation, async (req: AuthRequest, res: Response) => {
     return;
   }
   try {
-    const { description, amount, type, category, date, notes, participants, isRecurring, recurringFrequency } = req.body;
+    const { description, amount, type, category, date, notes, participants, isRecurring, recurringFrequency, paymentMethod } = req.body;
 
     // Check for potential duplicates
     if (req.userId && typeof description === 'string' && typeof amount === 'number') {
@@ -113,6 +129,7 @@ router.post('/', expenseValidation, async (req: AuthRequest, res: Response) => {
       participants: Array.isArray(participants) ? participants : [],
       ...(isRecurring !== undefined && { isRecurring }),
       ...(recurringFrequency !== undefined && { recurringFrequency }),
+      ...(paymentMethod !== undefined && { paymentMethod }),
     });
     const saved = await expense.save();
     const result = saved.toObject();
@@ -137,11 +154,12 @@ router.put('/:id', expenseValidation, async (req: AuthRequest, res: Response) =>
     return;
   }
   try {
-    const { description, amount, type, category, date, notes, participants, isRecurring, recurringFrequency } = req.body;
+    const { description, amount, type, category, date, notes, participants, isRecurring, recurringFrequency, paymentMethod } = req.body;
     const updateData: Record<string, unknown> = { description, amount, type, category, date, notes };
     if (Array.isArray(participants)) updateData.participants = participants; else updateData.participants = [];
     if (isRecurring !== undefined) updateData.isRecurring = isRecurring;
     if (recurringFrequency !== undefined) updateData.recurringFrequency = recurringFrequency;
+    if (paymentMethod !== undefined) updateData.paymentMethod = paymentMethod;
     const updated = await ExpenseModel.findOneAndUpdate(
       { _id: req.params.id, owner: req.userId },
       { $set: updateData },

--- a/src/routes/export.ts
+++ b/src/routes/export.ts
@@ -30,14 +30,15 @@ router.get('/csv', async (req: AuthRequest, res) => {
       .lean();
 
     // Build CSV
-    const headers = ['Date', 'Description', 'Category', 'Type', 'Amount', 'Participants'];
-    const rows = expenses.map((e: any) => [
-      new Date(e.date || e.createdAt).toISOString().split('T')[0],
-      e.description || '',
-      e.category || '',
-      e.type || '',
-      e.amount || 0,
-      e.participants?.join(';') || '',
+    const headers = ['Date', 'Description', 'Category', 'Type', 'Amount', 'Payment Method', 'Participants'];
+    const rows = expenses.map((e: Record<string, unknown>) => [
+      new Date((e.date || e.createdAt) as string).toISOString().split('T')[0],
+      (e.description as string) || '',
+      (e.category as string) || '',
+      (e.type as string) || '',
+      (e.amount as number) || 0,
+      (e.paymentMethod as string) || '',
+      (e.participants as string[])?.join(';') || '',
     ]);
 
     // Build CSV content


### PR DESCRIPTION
## What
Add optional `paymentMethod` enum field to the Expense model with full CRUD support, query filtering, CSV export, and input validation.

## Why
Closes #68

Hong Kong users juggle multiple payment methods daily. Tracking where money leaves (Octopus, PayMe, FPS, credit card, etc.) is essential context that competitors already provide.

## Acceptance Criteria
- [x] Add `paymentMethod` field to Expense schema (enum: `cash`, `credit_card`, `debit_card`, `octopus`, `payme`, `fps`, `alipay_hk`, `wechat_pay`, `other`)
- [x] Field is optional with default `null` (backward compatible)
- [x] Existing CRUD endpoints accept and return `paymentMethod`
- [x] GET /api/expenses supports `?paymentMethod=octopus` filter query param
- [x] CSV export includes payment method column
- [x] Input validation rejects unknown payment method values

## Test Plan
- 14 new tests in `__tests__/payment-method.test.ts` covering:
  - Default null when not provided
  - Create/update with valid payment method
  - Rejection of invalid values on create and update
  - Clearing payment method by setting to null
  - Payment method returned in GET list and GET by ID
  - Filter query param with valid, invalid, and no-match cases
  - CSV export header, value inclusion, and null handling
- All 36 tests in expenses, export, and payment-method suites pass
- `yarn build` compiles without errors