### PR TITLE
feat: multi-currency support for foreign expenses

### DIFF
--- a/__tests__/multi-currency.test.ts
+++ b/__tests__/multi-currency.test.ts
@@ -1,0 +1,245 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import app from '../src/app';
+import ExpenseModel from '../src/models/Expense';
+import { convertToHKD, clearRateCache } from '../src/utils/exchangeRates';
+
+let mongod: MongoMemoryServer;
+const TEST_USER_ID = 'user_currency_test';
+const authToken = jwt.sign({ userId: TEST_USER_ID }, 'test-secret');
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  for (const col of Object.values(mongoose.connection.collections)) {
+    await col.deleteMany({});
+  }
+  clearRateCache();
+});
+
+describe('Expense model currency fields', () => {
+  it('defaults currency to HKD when not specified', async () => {
+    const res = await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ description: 'Lunch', amount: 50, type: 'expense', category: 'Food' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.currency).toBe('HKD');
+    expect(res.body.originalAmount).toBeNull();
+    expect(res.body.exchangeRate).toBeNull();
+  });
+
+  it('stores foreign currency expense with originalAmount and exchangeRate', async () => {
+    const res = await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        description: 'Tokyo ramen',
+        amount: 62.4, // HKD equivalent
+        type: 'expense',
+        category: 'Food',
+        currency: 'JPY',
+        originalAmount: 1200,
+        exchangeRate: 0.052,
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.currency).toBe('JPY');
+    expect(res.body.originalAmount).toBe(1200);
+    expect(res.body.exchangeRate).toBe(0.052);
+    expect(res.body.amount).toBe(62.4);
+  });
+
+  it('rejects invalid currency code', async () => {
+    const res = await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        description: 'Bad currency',
+        amount: 100,
+        type: 'expense',
+        currency: 'XYZ',
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/currency must be one of/);
+  });
+
+  it('updates currency fields via PUT', async () => {
+    const create = await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ description: 'Original', amount: 100, type: 'expense' });
+
+    const res = await request(app)
+      .put(`/api/expenses/${create.body._id}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        description: 'Updated',
+        amount: 78,
+        type: 'expense',
+        currency: 'USD',
+        originalAmount: 10,
+        exchangeRate: 7.8,
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.currency).toBe('USD');
+    expect(res.body.originalAmount).toBe(10);
+    expect(res.body.exchangeRate).toBe(7.8);
+  });
+
+  it('existing expenses without currency default to HKD on read', async () => {
+    // Insert directly without currency field to simulate legacy data
+    await ExpenseModel.create({
+      owner: TEST_USER_ID,
+      description: 'Legacy expense',
+      amount: 200,
+    });
+
+    const res = await request(app)
+      .get('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data[0].currency).toBe('HKD');
+    expect(res.body.data[0].originalAmount).toBeNull();
+  });
+});
+
+describe('GET /api/exchange-rates', () => {
+  it('returns 401 without auth', async () => {
+    const res = await request(app).get('/api/exchange-rates');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns rates object with source and updatedAt', async () => {
+    const res = await request(app)
+      .get('/api/exchange-rates')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.rates).toBeDefined();
+    expect(res.body.source).toBeDefined();
+    expect(res.body.updatedAt).toBeDefined();
+    expect(typeof res.body.rates.USD).toBe('number');
+    expect(typeof res.body.rates.JPY).toBe('number');
+    expect(typeof res.body.rates.CNY).toBe('number');
+  });
+});
+
+describe('CSV export with currency columns', () => {
+  it('includes currency headers and data in CSV', async () => {
+    await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        description: 'USD purchase',
+        amount: 78,
+        type: 'expense',
+        category: 'Shopping',
+        currency: 'USD',
+        originalAmount: 10,
+        exchangeRate: 7.8,
+      });
+
+    const res = await request(app)
+      .get('/api/export/csv')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Amount (HKD)');
+    expect(res.text).toContain('Currency');
+    expect(res.text).toContain('Original Amount');
+    expect(res.text).toContain('Exchange Rate');
+    expect(res.text).toContain('USD');
+    expect(res.text).toContain('10');
+    expect(res.text).toContain('7.8');
+  });
+
+  it('shows HKD and empty original fields for HKD expenses', async () => {
+    await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ description: 'Local food', amount: 50, type: 'expense' });
+
+    const res = await request(app)
+      .get('/api/export/csv')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    const lines = res.text.trim().split('\n');
+    expect(lines.length).toBe(2);
+    // HKD expense should have HKD in currency column and empty original/rate
+    expect(lines[1]).toContain('HKD');
+  });
+});
+
+describe('convertToHKD utility', () => {
+  it('returns same amount for HKD', () => {
+    expect(convertToHKD(100, 'HKD', 1)).toBe(100);
+  });
+
+  it('converts foreign currency to HKD', () => {
+    expect(convertToHKD(10, 'USD', 7.8)).toBe(78);
+  });
+
+  it('rounds to 2 decimal places', () => {
+    expect(convertToHKD(1000, 'JPY', 0.052)).toBe(52);
+    expect(convertToHKD(100, 'EUR', 8.537)).toBe(853.7);
+  });
+});
+
+describe('Dashboard aggregation backward compatibility', () => {
+  it('monthly report aggregates amount field (always HKD)', async () => {
+    // Create one HKD and one foreign currency expense
+    await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        description: 'Local meal',
+        amount: 50,
+        type: 'expense',
+        category: 'Food',
+        date: new Date().toISOString(),
+      });
+
+    await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        description: 'Japan meal',
+        amount: 62.4,
+        type: 'expense',
+        category: 'Food',
+        currency: 'JPY',
+        originalAmount: 1200,
+        exchangeRate: 0.052,
+        date: new Date().toISOString(),
+      });
+
+    const res = await request(app)
+      .get('/api/reports/monthly?months=1')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBeGreaterThanOrEqual(1);
+    const currentMonth = res.body.data[res.body.data.length - 1];
+    // Both expenses should be summed in HKD: 50 + 62.4 = 112.4
+    expect(currentMonth.expenses).toBeCloseTo(112.4, 1);
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -12,6 +12,7 @@ import exportRoutes from './routes/export';
 import importRoutes from './routes/import';
 import recurringRoutes from './routes/recurring';
 import reportRoutes from './routes/reports';
+import exchangeRateRoutes from './routes/exchange-rates';
 import { startAlertScheduler } from './jobs/processAlerts';
 import { startRecurringScheduler } from './jobs/processRecurring';
 import { startWeeklyDigestScheduler } from './jobs/weeklyDigest';
@@ -48,6 +49,7 @@ app.use('/api/export', exportRoutes);
 app.use('/api/import', importRoutes);
 app.use('/api/recurring', recurringRoutes);
 app.use('/api/reports', reportRoutes);
+app.use('/api/exchange-rates', exchangeRateRoutes);
 
 Sentry.setupExpressErrorHandler(app);
 

--- a/src/models/Expense.ts
+++ b/src/models/Expense.ts
@@ -14,6 +14,12 @@ const PAYMENT_METHODS = [
 
 type PaymentMethod = typeof PAYMENT_METHODS[number];
 
+const SUPPORTED_CURRENCIES = [
+  'HKD', 'CNY', 'JPY', 'USD', 'EUR', 'GBP', 'TWD', 'THB', 'KRW',
+] as const;
+
+type SupportedCurrency = typeof SUPPORTED_CURRENCIES[number];
+
 interface IExpense extends Document {
   owner: string;
   description?: string;
@@ -30,6 +36,9 @@ interface IExpense extends Document {
   endDate?: Date | null;
   date?: Date;
   amount: number;
+  currency?: SupportedCurrency;
+  originalAmount?: number | null;
+  exchangeRate?: number | null;
   paymentMethod?: PaymentMethod | null;
   createdAt?: Date;
   updatedAt?: Date;
@@ -52,6 +61,13 @@ const ExpenseSchema = new mongoose.Schema(
     item: String,
     participants: [String],
     amount: { type: Number, required: true },
+    currency: {
+      type: String,
+      enum: SUPPORTED_CURRENCIES,
+      default: 'HKD',
+    },
+    originalAmount: { type: Number, default: null },
+    exchangeRate: { type: Number, default: null },
     paymentMethod: {
       type: String,
       enum: [...PAYMENT_METHODS, null],
@@ -64,6 +80,7 @@ const ExpenseSchema = new mongoose.Schema(
 ExpenseSchema.index({ owner: 1, date: -1 });
 ExpenseSchema.index({ owner: 1, _id: 1 });
 
-export { PAYMENT_METHODS };
+export { PAYMENT_METHODS, SUPPORTED_CURRENCIES };
+export type { SupportedCurrency };
 export const ExpenseModel = mongoose.model<IExpense>('Expense', ExpenseSchema);
 export default ExpenseModel;

--- a/src/routes/exchange-rates.ts
+++ b/src/routes/exchange-rates.ts
@@ -1,0 +1,19 @@
+import { Router, Response } from 'express';
+import { protect, AuthRequest } from '../middleware/auth';
+import { getExchangeRates } from '../utils/exchangeRates';
+
+const router = Router();
+
+router.use(protect);
+
+// GET /api/exchange-rates
+router.get('/', async (_req: AuthRequest, res: Response) => {
+  try {
+    const data = await getExchangeRates();
+    res.json(data);
+  } catch {
+    res.status(500).json({ error: 'Failed to fetch exchange rates' });
+  }
+});
+
+export default router;

--- a/src/routes/expenses.ts
+++ b/src/routes/expenses.ts
@@ -1,7 +1,7 @@
 import { Router, Response } from 'express';
 import { body, validationResult } from 'express-validator';
 import { compareTwoStrings } from 'string-similarity';
-import ExpenseModel, { PAYMENT_METHODS } from '../models/Expense';
+import ExpenseModel, { PAYMENT_METHODS, SUPPORTED_CURRENCIES } from '../models/Expense';
 import { protect, AuthRequest } from '../middleware/auth';
 import { checkAndQueueBudgetAlerts } from '../utils/alerts';
 
@@ -50,8 +50,26 @@ const paymentMethodValidation = body('paymentMethod')
   .isIn([...PAYMENT_METHODS])
   .withMessage(`paymentMethod must be one of: ${PAYMENT_METHODS.join(', ')}`);
 
+const currencyValidation = body('currency')
+  .optional()
+  .isIn([...SUPPORTED_CURRENCIES])
+  .withMessage(`currency must be one of: ${SUPPORTED_CURRENCIES.join(', ')}`);
+
+const originalAmountValidation = body('originalAmount')
+  .optional({ values: 'null' })
+  .isNumeric()
+  .withMessage('originalAmount must be a number');
+
+const exchangeRateValidation = body('exchangeRate')
+  .optional({ values: 'null' })
+  .isNumeric()
+  .withMessage('exchangeRate must be a number');
+
 const expenseValidation = [
   body('amount').isNumeric().withMessage('Amount must be a number'),
+  currencyValidation,
+  originalAmountValidation,
+  exchangeRateValidation,
   participantsValidation,
   paymentMethodValidation,
 ];
@@ -111,7 +129,7 @@ router.post('/', expenseValidation, async (req: AuthRequest, res: Response) => {
     return;
   }
   try {
-    const { description, amount, type, category, date, notes, participants, isRecurring, recurringFrequency, paymentMethod } = req.body;
+    const { description, amount, type, category, date, notes, participants, isRecurring, recurringFrequency, paymentMethod, currency, originalAmount, exchangeRate } = req.body;
 
     // Check for potential duplicates
     if (req.userId && typeof description === 'string' && typeof amount === 'number') {
@@ -130,6 +148,9 @@ router.post('/', expenseValidation, async (req: AuthRequest, res: Response) => {
       ...(isRecurring !== undefined && { isRecurring }),
       ...(recurringFrequency !== undefined && { recurringFrequency }),
       ...(paymentMethod !== undefined && { paymentMethod }),
+      ...(currency !== undefined && { currency }),
+      ...(originalAmount !== undefined && { originalAmount }),
+      ...(exchangeRate !== undefined && { exchangeRate }),
     });
     const saved = await expense.save();
     const result = saved.toObject();
@@ -154,12 +175,15 @@ router.put('/:id', expenseValidation, async (req: AuthRequest, res: Response) =>
     return;
   }
   try {
-    const { description, amount, type, category, date, notes, participants, isRecurring, recurringFrequency, paymentMethod } = req.body;
+    const { description, amount, type, category, date, notes, participants, isRecurring, recurringFrequency, paymentMethod, currency, originalAmount, exchangeRate } = req.body;
     const updateData: Record<string, unknown> = { description, amount, type, category, date, notes };
     if (Array.isArray(participants)) updateData.participants = participants; else updateData.participants = [];
     if (isRecurring !== undefined) updateData.isRecurring = isRecurring;
     if (recurringFrequency !== undefined) updateData.recurringFrequency = recurringFrequency;
     if (paymentMethod !== undefined) updateData.paymentMethod = paymentMethod;
+    if (currency !== undefined) updateData.currency = currency;
+    if (originalAmount !== undefined) updateData.originalAmount = originalAmount;
+    if (exchangeRate !== undefined) updateData.exchangeRate = exchangeRate;
     const updated = await ExpenseModel.findOneAndUpdate(
       { _id: req.params.id, owner: req.userId },
       { $set: updateData },

--- a/src/routes/export.ts
+++ b/src/routes/export.ts
@@ -30,13 +30,16 @@ router.get('/csv', async (req: AuthRequest, res) => {
       .lean();
 
     // Build CSV
-    const headers = ['Date', 'Description', 'Category', 'Type', 'Amount', 'Payment Method', 'Participants'];
+    const headers = ['Date', 'Description', 'Category', 'Type', 'Amount (HKD)', 'Currency', 'Original Amount', 'Exchange Rate', 'Payment Method', 'Participants'];
     const rows = expenses.map((e: Record<string, unknown>) => [
       new Date((e.date || e.createdAt) as string).toISOString().split('T')[0],
       (e.description as string) || '',
       (e.category as string) || '',
       (e.type as string) || '',
       (e.amount as number) || 0,
+      (e.currency as string) || 'HKD',
+      (e.originalAmount as number) ?? '',
+      (e.exchangeRate as number) ?? '',
       (e.paymentMethod as string) || '',
       (e.participants as string[])?.join(';') || '',
     ]);

--- a/src/utils/exchangeRates.ts
+++ b/src/utils/exchangeRates.ts
@@ -1,0 +1,93 @@
+import type { SupportedCurrency } from '../models/Expense';
+
+// Fallback approximate rates: how many HKD per 1 unit of foreign currency
+// These are approximate as of early 2026 and serve as fallback when API is unavailable
+const FALLBACK_RATES: Record<string, number> = {
+  CNY: 1.08,
+  JPY: 0.052,
+  USD: 7.80,
+  EUR: 8.50,
+  GBP: 9.90,
+  TWD: 0.24,
+  THB: 0.22,
+  KRW: 0.0057,
+};
+
+const EXCHANGE_RATE_API_URL = process.env.EXCHANGE_RATE_API_URL || 'https://open.er-api.com/v6/latest/HKD';
+
+interface ExchangeRateResponse {
+  rates: Record<string, number>;
+  source: 'api' | 'fallback';
+  updatedAt: string;
+}
+
+let cachedRates: ExchangeRateResponse | null = null;
+let cacheExpiry = 0;
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+export async function getExchangeRates(): Promise<ExchangeRateResponse> {
+  if (cachedRates && Date.now() < cacheExpiry) {
+    return cachedRates;
+  }
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+
+    const response = await fetch(EXCHANGE_RATE_API_URL, { signal: controller.signal });
+    clearTimeout(timeout);
+
+    if (!response.ok) {
+      throw new Error(`API returned ${response.status}`);
+    }
+
+    const data = await response.json() as { result: string; rates: Record<string, number> };
+
+    if (data.result !== 'success' || !data.rates) {
+      throw new Error('Invalid API response');
+    }
+
+    // API returns rates FROM HKD, e.g. HKD->USD = 0.128
+    // We need rates TO HKD, e.g. 1 USD = 7.8 HKD
+    const targetCurrencies = ['CNY', 'JPY', 'USD', 'EUR', 'GBP', 'TWD', 'THB', 'KRW'];
+    const rates: Record<string, number> = {};
+
+    for (const currency of targetCurrencies) {
+      const apiRate = data.rates[currency];
+      if (apiRate && apiRate > 0) {
+        rates[currency] = Math.round((1 / apiRate) * 10000) / 10000;
+      } else {
+        rates[currency] = FALLBACK_RATES[currency];
+      }
+    }
+
+    cachedRates = {
+      rates,
+      source: 'api',
+      updatedAt: new Date().toISOString(),
+    };
+    cacheExpiry = Date.now() + CACHE_TTL_MS;
+
+    return cachedRates;
+  } catch {
+    // Fallback to hardcoded rates
+    const fallback: ExchangeRateResponse = {
+      rates: { ...FALLBACK_RATES },
+      source: 'fallback',
+      updatedAt: new Date().toISOString(),
+    };
+    cachedRates = fallback;
+    cacheExpiry = Date.now() + 5 * 60 * 1000; // Cache fallback for 5 minutes
+    return fallback;
+  }
+}
+
+export function convertToHKD(amount: number, currency: SupportedCurrency, rate: number): number {
+  if (currency === 'HKD') return amount;
+  return Math.round(amount * rate * 100) / 100;
+}
+
+export function clearRateCache(): void {
+  cachedRates = null;
+  cacheExpiry = 0;
+}


### PR DESCRIPTION
## What
Multi-currency support allowing users to log expenses in foreign currencies (CNY, JPY, USD, EUR, GBP, TWD, THB, KRW) while keeping all aggregation in HKD.

## Why
Closes #70

## Acceptance Criteria
- [x] `currency` field on Expense schema (ISO 4217, default: HKD)
- [x] `originalAmount` field (amount in foreign currency) and `exchangeRate` field
- [x] `amount` field always stores HKD equivalent for consistent aggregation
- [x] GET /api/exchange-rates endpoint with fallback to hardcoded rates
- [x] Dashboard aggregation endpoints continue to work in HKD (no breaking changes)
- [x] CSV export includes Currency, Original Amount, and Exchange Rate columns
- [x] Backward compatible — existing expenses without currency default to HKD
- [x] Input validation on currency, originalAmount, exchangeRate fields

## Test Plan
- 13 new tests in `__tests__/multi-currency.test.ts`
- Create HKD expense — verify currency defaults to HKD, originalAmount/exchangeRate are null
- Create foreign currency expense — verify all three fields stored correctly
- Reject invalid currency code (e.g. XYZ)
- Update expense with currency fields via PUT
- Legacy expenses (no currency field) default to HKD on read
- GET /api/exchange-rates returns rates with source and timestamp
- CSV export includes new columns for both HKD and foreign currency expenses
- Monthly report aggregates correctly across mixed currencies
- `convertToHKD` utility handles edge cases and rounding
- Full test suite (253 tests) passes with no regressions