### PR TITLE
feat: themePreference field and user preferences API

### DIFF
--- a/__tests__/users.test.ts
+++ b/__tests__/users.test.ts
@@ -1,0 +1,134 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import app from '../src/app';
+import UserModel from '../src/models/User';
+
+let mongod: MongoMemoryServer;
+let authToken: string;
+let userId: string;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+beforeEach(async () => {
+  const user = await UserModel.create({ email: 'user@example.com', password: 'password123' });
+  userId = (user._id as mongoose.Types.ObjectId).toString();
+  authToken = jwt.sign({ userId }, 'test-secret');
+});
+
+afterEach(async () => {
+  for (const col of Object.values(mongoose.connection.collections)) {
+    await col.deleteMany({});
+  }
+});
+
+describe('GET /api/users/me', () => {
+  it('returns user profile without password', async () => {
+    const res = await request(app)
+      .get('/api/users/me')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.user.email).toBe('user@example.com');
+    expect(res.body.user.password).toBeUndefined();
+  });
+
+  it('includes themePreference with default value system', async () => {
+    const res = await request(app)
+      .get('/api/users/me')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.user.themePreference).toBe('system');
+  });
+
+  it('rejects unauthenticated request with 401', async () => {
+    const res = await request(app).get('/api/users/me');
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('PATCH /api/users/preferences', () => {
+  it('updates themePreference to light', async () => {
+    const res = await request(app)
+      .patch('/api/users/preferences')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ themePreference: 'light' });
+    expect(res.status).toBe(200);
+    expect(res.body.user.themePreference).toBe('light');
+  });
+
+  it('updates themePreference to dark', async () => {
+    const res = await request(app)
+      .patch('/api/users/preferences')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ themePreference: 'dark' });
+    expect(res.status).toBe(200);
+    expect(res.body.user.themePreference).toBe('dark');
+  });
+
+  it('updates themePreference to system', async () => {
+    const res = await request(app)
+      .patch('/api/users/preferences')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ themePreference: 'system' });
+    expect(res.status).toBe(200);
+    expect(res.body.user.themePreference).toBe('system');
+  });
+
+  it('persists themePreference — visible on GET /me after update', async () => {
+    await request(app)
+      .patch('/api/users/preferences')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ themePreference: 'dark' });
+
+    const res = await request(app)
+      .get('/api/users/me')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.user.themePreference).toBe('dark');
+  });
+
+  it('rejects invalid themePreference value with 400', async () => {
+    const res = await request(app)
+      .patch('/api/users/preferences')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ themePreference: 'purple' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/themePreference/);
+  });
+
+  it('rejects missing themePreference with 400', async () => {
+    const res = await request(app)
+      .patch('/api/users/preferences')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('does not return password in response', async () => {
+    const res = await request(app)
+      .patch('/api/users/preferences')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ themePreference: 'light' });
+    expect(res.status).toBe(200);
+    expect(res.body.user.password).toBeUndefined();
+  });
+
+  it('rejects unauthenticated request with 401', async () => {
+    const res = await request(app)
+      .patch('/api/users/preferences')
+      .send({ themePreference: 'light' });
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,7 @@ import importRoutes from './routes/import';
 import recurringRoutes from './routes/recurring';
 import reportRoutes from './routes/reports';
 import exchangeRateRoutes from './routes/exchange-rates';
+import userRoutes from './routes/users';
 import { startAlertScheduler } from './jobs/processAlerts';
 import { startRecurringScheduler } from './jobs/processRecurring';
 import { startWeeklyDigestScheduler } from './jobs/weeklyDigest';
@@ -50,6 +51,7 @@ app.use('/api/import', importRoutes);
 app.use('/api/recurring', recurringRoutes);
 app.use('/api/reports', reportRoutes);
 app.use('/api/exchange-rates', exchangeRateRoutes);
+app.use('/api/users', userRoutes);
 
 Sentry.setupExpressErrorHandler(app);
 

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -8,12 +8,15 @@ export interface IBudget {
   enable_alerts?: boolean;
 }
 
+export type ThemePreference = 'light' | 'dark' | 'system';
+
 export interface IUser extends Document {
   email: string;
   password: string;
   budgets: IBudget[];
   telegramChatId?: string;
   weeklyDigestEnabled: boolean;
+  themePreference: ThemePreference;
   createdAt: Date;
   comparePassword(candidate: string): Promise<boolean>;
 }
@@ -35,6 +38,7 @@ const UserSchema = new mongoose.Schema(
     },
     telegramChatId: { type: String, default: undefined },
     weeklyDigestEnabled: { type: Boolean, default: false },
+    themePreference: { type: String, enum: ['light', 'dark', 'system'], default: 'system' },
   },
   { timestamps: true }
 );

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -1,0 +1,62 @@
+import { Router, Response } from 'express';
+import { body, validationResult } from 'express-validator';
+import UserModel from '../models/User';
+import { protect, AuthRequest } from '../middleware/auth';
+
+const router = Router();
+
+router.use(protect);
+
+// GET /api/users/me
+router.get('/me', async (req: AuthRequest, res: Response) => {
+  try {
+    const user = await UserModel.findById(req.userId).select('-password').lean();
+    if (!user) {
+      res.status(404).json({ error: 'User not found' });
+      return;
+    }
+    res.json({ user });
+  } catch {
+    res.status(500).json({ error: 'Failed to fetch user' });
+  }
+});
+
+// PATCH /api/users/preferences
+router.patch(
+  '/preferences',
+  [
+    body('themePreference')
+      .isIn(['light', 'dark', 'system'])
+      .withMessage('themePreference must be one of: light, dark, system'),
+  ],
+  async (req: AuthRequest, res: Response) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({ error: errors.array()[0].msg });
+      return;
+    }
+
+    try {
+      const { themePreference } = req.body as { themePreference: 'light' | 'dark' | 'system' };
+
+      const user = await UserModel.findByIdAndUpdate(
+        req.userId,
+        { $set: { themePreference } },
+        { new: true, runValidators: true }
+      )
+        .select('-password')
+        .lean();
+
+      if (!user) {
+        res.status(404).json({ error: 'User not found' });
+        return;
+      }
+
+      res.json({ user });
+    } catch {
+      res.status(500).json({ error: 'Failed to update preferences' });
+    }
+  }
+);
+
+export default router;


### PR DESCRIPTION
## What
- Added `themePreference` field to the User model (`'light' | 'dark' | 'system'`, default `'system'`)
- New `GET /api/users/me` endpoint: returns the authenticated user's full profile including `themePreference` (password excluded)
- New `PATCH /api/users/preferences` endpoint: accepts `{ themePreference }`, validates the value, saves to user document, returns updated user
- Both routes are auth-protected via JWT middleware
- 11 tests covering all happy paths, persistence, invalid input, and unauthenticated rejection

## Why
Closes #121 (wkliwk/money-flow-frontend) — theme preference was only stored in `localStorage`, so it was device-local. Persisting it on the backend allows cross-device sync.

## Acceptance Criteria
- [x] `themePreference` field on User model with enum `['light', 'dark', 'system']` and default `'system'`
- [x] `PATCH /api/users/preferences` saves `themePreference`, auth-protected, validates input
- [x] `GET /api/users/me` returns `themePreference` in response
- [x] Tests written and passing (11/11)
- [x] TypeScript build clean

## Test Plan
1. Register a user: `POST /auth/register`
2. Login and get token: `POST /auth/login`
3. `GET /api/users/me` — verify response includes `themePreference: 'system'`
4. `PATCH /api/users/preferences` with `{ "themePreference": "dark" }` — verify 200, `themePreference: 'dark'` in response
5. `GET /api/users/me` again — verify `themePreference: 'dark'` is persisted
6. `PATCH /api/users/preferences` with `{ "themePreference": "purple" }` — verify 400 with validation error
7. Same PATCH without Authorization header — verify 401