### PR TITLE
feat: add Apple Sign-In endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@ FRONTEND_URL=http://localhost:3000
 # Google OAuth (optional - required for Google Sign-In)
 GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
 
+# Apple Sign-In (optional - required for Apple Sign-In)
+APPLE_CLIENT_ID=your-apple-services-id
+
 # Anthropic API (required for receipt OCR scanning at POST /api/receipts/scan)
 ANTHROPIC_API_KEY=your-anthropic-api-key
 

--- a/__tests__/auth-apple.test.ts
+++ b/__tests__/auth-apple.test.ts
@@ -1,0 +1,139 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+process.env.APPLE_CLIENT_ID = 'test-apple-client-id';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import app from '../src/app';
+import UserModel from '../src/models/User';
+
+jest.mock('apple-signin-auth', () => ({
+  verifyIdToken: jest.fn(),
+}));
+
+import appleSignin from 'apple-signin-auth';
+const mockVerify = appleSignin.verifyIdToken as jest.Mock;
+
+let mongod: MongoMemoryServer;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  for (const col of Object.values(mongoose.connection.collections)) {
+    await col.deleteMany({});
+  }
+  mockVerify.mockReset();
+});
+
+describe('POST /auth/apple', () => {
+  it('creates new user and returns token for new Apple user', async () => {
+    mockVerify.mockResolvedValue({
+      email: 'apple@example.com',
+      sub: 'apple-uid-123',
+    });
+
+    const res = await request(app)
+      .post('/auth/apple')
+      .send({ idToken: 'valid-apple-token' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.token).toBeDefined();
+
+    const user = await UserModel.findOne({ email: 'apple@example.com' });
+    expect(user).toBeTruthy();
+    expect(user!.appleId).toBe('apple-uid-123');
+    expect(user!.password).toBeUndefined();
+  });
+
+  it('returns token for existing Apple user', async () => {
+    await UserModel.create({
+      email: 'existing@example.com',
+      appleId: 'apple-uid-456',
+    });
+    mockVerify.mockResolvedValue({
+      email: 'existing@example.com',
+      sub: 'apple-uid-456',
+    });
+
+    const res = await request(app)
+      .post('/auth/apple')
+      .send({ idToken: 'valid-apple-token' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.token).toBeDefined();
+  });
+
+  it('links Apple account to existing email/password user', async () => {
+    await request(app)
+      .post('/auth/register')
+      .send({ email: 'linkme@example.com', password: 'password123' });
+
+    mockVerify.mockResolvedValue({
+      email: 'linkme@example.com',
+      sub: 'apple-uid-789',
+    });
+
+    const res = await request(app)
+      .post('/auth/apple')
+      .send({ idToken: 'valid-apple-token' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.token).toBeDefined();
+
+    const user = await UserModel.findOne({ email: 'linkme@example.com' });
+    expect(user!.appleId).toBe('apple-uid-789');
+    expect(user!.password).toBeDefined();
+  });
+
+  it('handles Apple relay email addresses', async () => {
+    mockVerify.mockResolvedValue({
+      email: 'abcdef@privaterelay.appleid.com',
+      sub: 'apple-uid-relay',
+    });
+
+    const res = await request(app)
+      .post('/auth/apple')
+      .send({ idToken: 'valid-apple-token' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.token).toBeDefined();
+
+    const user = await UserModel.findOne({ email: 'abcdef@privaterelay.appleid.com' });
+    expect(user).toBeTruthy();
+    expect(user!.appleId).toBe('apple-uid-relay');
+  });
+
+  it('rejects missing idToken with 400', async () => {
+    const res = await request(app).post('/auth/apple').send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects invalid Apple token with 401', async () => {
+    mockVerify.mockRejectedValue(new Error('Invalid token'));
+
+    const res = await request(app)
+      .post('/auth/apple')
+      .send({ idToken: 'invalid-token' });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects token with no email with 401', async () => {
+    mockVerify.mockResolvedValue({ sub: 'no-email-user' });
+
+    const res = await request(app)
+      .post('/auth/apple')
+      .send({ idToken: 'token-no-email' });
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/__tests__/receipts.test.ts
+++ b/__tests__/receipts.test.ts
@@ -1,0 +1,232 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+process.env.ANTHROPIC_API_KEY = 'test-api-key';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import app from '../src/app';
+
+// Mock the Anthropic SDK
+jest.mock('@anthropic-ai/sdk', () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => ({
+      messages: {
+        create: jest.fn(),
+      },
+    })),
+  };
+});
+
+import Anthropic from '@anthropic-ai/sdk';
+
+let mongod: MongoMemoryServer;
+const TEST_USER_ID = 'receipt_user_123';
+const authToken = jwt.sign({ userId: TEST_USER_ID }, 'test-secret');
+
+// Minimal valid JPEG buffer (1x1 px)
+const JPEG_BUFFER = Buffer.from(
+  '/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAABAAEBAREA/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8AVIP/2Q==',
+  'base64'
+);
+
+const PNG_BUFFER = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+  'base64'
+);
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+function mockSuccessfulExtraction(overrides: Record<string, unknown> = {}) {
+  const payload = {
+    amount: 125.5,
+    description: 'Grocery shopping at ParknShop',
+    merchant: 'ParknShop',
+    date: '2024-03-15',
+    category: 'Groceries',
+    currency: 'HKD',
+    ...overrides,
+  };
+  return {
+    content: [{ type: 'text', text: JSON.stringify(payload) }],
+  };
+}
+
+describe('POST /api/receipts/scan', () => {
+  it('requires JWT auth', async () => {
+    const res = await request(app)
+      .post('/api/receipts/scan')
+      .attach('image', JPEG_BUFFER, { filename: 'receipt.jpg', contentType: 'image/jpeg' });
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects request with no file', async () => {
+    const res = await request(app)
+      .post('/api/receipts/scan')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBeDefined();
+  });
+
+  it('rejects unsupported file type', async () => {
+    const pdfBuffer = Buffer.from('%PDF-1.4 test');
+    const res = await request(app)
+      .post('/api/receipts/scan')
+      .set('Authorization', `Bearer ${authToken}`)
+      .attach('image', pdfBuffer, { filename: 'receipt.pdf', contentType: 'application/pdf' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects oversized file', async () => {
+    const bigBuffer = Buffer.alloc(11 * 1024 * 1024); // 11MB
+    const res = await request(app)
+      .post('/api/receipts/scan')
+      .set('Authorization', `Bearer ${authToken}`)
+      .attach('image', bigBuffer, { filename: 'big.jpg', contentType: 'image/jpeg' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns structured JSON for a successful JPEG extraction', async () => {
+    (Anthropic as jest.MockedClass<typeof Anthropic>).mockImplementationOnce(() => ({
+      messages: { create: jest.fn().mockResolvedValue(mockSuccessfulExtraction()) },
+    } as unknown as Anthropic));
+
+    const res = await request(app)
+      .post('/api/receipts/scan')
+      .set('Authorization', `Bearer ${authToken}`)
+      .attach('image', JPEG_BUFFER, { filename: 'receipt.jpg', contentType: 'image/jpeg' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      amount: 125.5,
+      description: 'Grocery shopping at ParknShop',
+      merchant: 'ParknShop',
+      date: '2024-03-15',
+      category: 'Groceries',
+      currency: 'HKD',
+      confidence: 'high',
+    });
+  });
+
+  it('returns structured JSON for a PNG image', async () => {
+    (Anthropic as jest.MockedClass<typeof Anthropic>).mockImplementationOnce(() => ({
+      messages: { create: jest.fn().mockResolvedValue(mockSuccessfulExtraction()) },
+    } as unknown as Anthropic));
+
+    const res = await request(app)
+      .post('/api/receipts/scan')
+      .set('Authorization', `Bearer ${authToken}`)
+      .attach('image', PNG_BUFFER, { filename: 'receipt.png', contentType: 'image/png' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.amount).toBe(125.5);
+  });
+
+  it('returns confidence=medium when date is missing', async () => {
+    (Anthropic as jest.MockedClass<typeof Anthropic>).mockImplementationOnce(() => ({
+      messages: { create: jest.fn().mockResolvedValue(mockSuccessfulExtraction({ date: null })) },
+    } as unknown as Anthropic));
+
+    const res = await request(app)
+      .post('/api/receipts/scan')
+      .set('Authorization', `Bearer ${authToken}`)
+      .attach('image', JPEG_BUFFER, { filename: 'receipt.jpg', contentType: 'image/jpeg' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.confidence).toBe('medium');
+  });
+
+  it('returns confidence=low when only amount is extractable', async () => {
+    (Anthropic as jest.MockedClass<typeof Anthropic>).mockImplementationOnce(() => ({
+      messages: { create: jest.fn().mockResolvedValue(mockSuccessfulExtraction({ date: null, merchant: null })) },
+    } as unknown as Anthropic));
+
+    const res = await request(app)
+      .post('/api/receipts/scan')
+      .set('Authorization', `Bearer ${authToken}`)
+      .attach('image', JPEG_BUFFER, { filename: 'receipt.jpg', contentType: 'image/jpeg' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.confidence).toBe('low');
+  });
+
+  it('returns 422 when Claude cannot extract amount', async () => {
+    const payload = { content: [{ type: 'text', text: '{"amount":null,"merchant":"Test","date":"2024-01-01","category":"Other","currency":"HKD","description":"test"}' }] };
+    (Anthropic as jest.MockedClass<typeof Anthropic>).mockImplementationOnce(() => ({
+      messages: { create: jest.fn().mockResolvedValue(payload) },
+    } as unknown as Anthropic));
+
+    const res = await request(app)
+      .post('/api/receipts/scan')
+      .set('Authorization', `Bearer ${authToken}`)
+      .attach('image', JPEG_BUFFER, { filename: 'receipt.jpg', contentType: 'image/jpeg' });
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toBe('Could not extract data from receipt');
+  });
+
+  it('returns 422 when Claude API throws', async () => {
+    (Anthropic as jest.MockedClass<typeof Anthropic>).mockImplementationOnce(() => ({
+      messages: { create: jest.fn().mockRejectedValue(new Error('API error')) },
+    } as unknown as Anthropic));
+
+    const res = await request(app)
+      .post('/api/receipts/scan')
+      .set('Authorization', `Bearer ${authToken}`)
+      .attach('image', JPEG_BUFFER, { filename: 'receipt.jpg', contentType: 'image/jpeg' });
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toBe('Could not extract data from receipt');
+  });
+
+  it('returns 422 when Claude returns non-JSON text', async () => {
+    const payload = { content: [{ type: 'text', text: 'Sorry, I cannot process this image.' }] };
+    (Anthropic as jest.MockedClass<typeof Anthropic>).mockImplementationOnce(() => ({
+      messages: { create: jest.fn().mockResolvedValue(payload) },
+    } as unknown as Anthropic));
+
+    const res = await request(app)
+      .post('/api/receipts/scan')
+      .set('Authorization', `Bearer ${authToken}`)
+      .attach('image', JPEG_BUFFER, { filename: 'receipt.jpg', contentType: 'image/jpeg' });
+
+    expect(res.status).toBe(422);
+  });
+
+  it('enforces rate limit of 10 scans per hour', async () => {
+    const rateLimitUser = 'rate_limit_user_' + Date.now();
+    const rateLimitToken = jwt.sign({ userId: rateLimitUser }, 'test-secret');
+
+    (Anthropic as jest.MockedClass<typeof Anthropic>).mockImplementation(() => ({
+      messages: { create: jest.fn().mockResolvedValue(mockSuccessfulExtraction()) },
+    } as unknown as Anthropic));
+
+    for (let i = 0; i < 10; i++) {
+      const res = await request(app)
+        .post('/api/receipts/scan')
+        .set('Authorization', `Bearer ${rateLimitToken}`)
+        .attach('image', JPEG_BUFFER, { filename: 'receipt.jpg', contentType: 'image/jpeg' });
+      expect(res.status).not.toBe(429);
+    }
+
+    const res = await request(app)
+      .post('/api/receipts/scan')
+      .set('Authorization', `Bearer ${rateLimitToken}`)
+      .attach('image', JPEG_BUFFER, { filename: 'receipt.jpg', contentType: 'image/jpeg' });
+    expect(res.status).toBe(429);
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -14,6 +14,7 @@ import recurringRoutes from './routes/recurring';
 import reportRoutes from './routes/reports';
 import exchangeRateRoutes from './routes/exchange-rates';
 import userRoutes from './routes/users';
+import receiptRoutes from './routes/receipts';
 import { startAlertScheduler } from './jobs/processAlerts';
 import { startRecurringScheduler } from './jobs/processRecurring';
 import { startWeeklyDigestScheduler } from './jobs/weeklyDigest';
@@ -52,6 +53,7 @@ app.use('/api/recurring', recurringRoutes);
 app.use('/api/reports', reportRoutes);
 app.use('/api/exchange-rates', exchangeRateRoutes);
 app.use('/api/users', userRoutes);
+app.use('/api/receipts', receiptRoutes);
 
 Sentry.setupExpressErrorHandler(app);
 

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -14,6 +14,7 @@ export interface IUser extends Document {
   email: string;
   password?: string;
   googleId?: string;
+  appleId?: string;
   budgets: IBudget[];
   telegramChatId?: string;
   weeklyDigestEnabled: boolean;
@@ -27,6 +28,7 @@ const UserSchema = new mongoose.Schema(
     email: { type: String, required: true, unique: true, lowercase: true, trim: true },
     password: { type: String, minlength: 6 },
     googleId: { type: String, sparse: true },
+    appleId: { type: String, sparse: true },
     budgets: {
       type: [
         {

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express';
 import jwt from 'jsonwebtoken';
 import { body, validationResult } from 'express-validator';
 import { OAuth2Client } from 'google-auth-library';
+import appleSignin from 'apple-signin-auth';
 import UserModel from '../models/User';
 
 const router = Router();
@@ -123,6 +124,59 @@ router.post(
       res.json({ token });
     } catch {
       res.status(401).json({ error: 'Google authentication failed' });
+    }
+  }
+);
+
+// POST /auth/apple
+router.post(
+  '/apple',
+  [body('idToken').notEmpty()],
+  async (req: Request, res: Response) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({ error: 'idToken is required' });
+      return;
+    }
+
+    try {
+      const { idToken } = req.body as { idToken: string };
+      const clientId = process.env.APPLE_CLIENT_ID;
+      if (!clientId) {
+        res.status(500).json({ error: 'Apple Sign-In not configured' });
+        return;
+      }
+
+      const payload = await appleSignin.verifyIdToken(idToken, {
+        audience: clientId,
+      });
+
+      const { email, sub: appleId } = payload;
+      if (!email) {
+        res.status(401).json({ error: 'Invalid Apple token' });
+        return;
+      }
+
+      let user = await UserModel.findOne({
+        $or: [{ appleId }, { email: email.toLowerCase() }],
+      });
+
+      if (user) {
+        if (!user.appleId) {
+          user.appleId = appleId;
+          await user.save();
+        }
+      } else {
+        user = await UserModel.create({
+          email: email.toLowerCase(),
+          appleId,
+        });
+      }
+
+      const token = signToken(user.id as string);
+      res.json({ token });
+    } catch {
+      res.status(401).json({ error: 'Apple authentication failed' });
     }
   }
 );

--- a/src/routes/receipts.ts
+++ b/src/routes/receipts.ts
@@ -1,0 +1,185 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import multer, { MulterError } from 'multer';
+import Anthropic from '@anthropic-ai/sdk';
+import { protect, AuthRequest } from '../middleware/auth';
+
+const router = Router();
+router.use(protect);
+
+// In-memory rate limiter: userId -> timestamps of scans in the last hour
+const scanTimestamps = new Map<string, number[]>();
+const RATE_LIMIT = 10;
+const RATE_WINDOW_MS = 60 * 60 * 1000;
+
+function isRateLimited(userId: string): boolean {
+  const now = Date.now();
+  const cutoff = now - RATE_WINDOW_MS;
+  const times = (scanTimestamps.get(userId) ?? []).filter((t) => t > cutoff);
+  if (times.length >= RATE_LIMIT) return true;
+  times.push(now);
+  scanTimestamps.set(userId, times);
+  return false;
+}
+
+const ACCEPTED_MIMETYPES = ['image/jpeg', 'image/png', 'image/heic', 'image/heif'];
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 10 * 1024 * 1024 },
+  fileFilter: (_req, file, cb) => {
+    if (ACCEPTED_MIMETYPES.includes(file.mimetype) || file.originalname.match(/\.(jpg|jpeg|png|heic|heif)$/i)) {
+      cb(null, true);
+    } else {
+      cb(new Error('Only JPEG, PNG, and HEIC images are accepted'));
+    }
+  },
+});
+
+const CATEGORIES = [
+  'Food', 'Transport', 'Shopping', 'Entertainment', 'Health',
+  'Utilities', 'Groceries', 'Travel', 'Education', 'Dining',
+  'Subscriptions', 'Housing', 'Insurance', 'Personal Care', 'Other',
+];
+
+const EXTRACTION_PROMPT = `You are a receipt data extraction assistant. Extract transaction data from this receipt image.
+
+The receipt may be in English or Traditional Chinese (繁體中文).
+
+Return ONLY a valid JSON object with these fields:
+- amount: number (total amount paid, required)
+- description: string (short description of purchase, e.g. "Grocery shopping at ParknShop")
+- merchant: string | null (store/merchant name)
+- date: string | null (ISO 8601 date YYYY-MM-DD, or null if not found)
+- category: string (best matching category from: ${CATEGORIES.join(', ')})
+- currency: string (3-letter ISO currency code, e.g. HKD, USD, CNY — default to HKD if unclear)
+
+Rules:
+- amount must be the final total paid (including tax, excluding tips if itemised separately)
+- For Traditional Chinese receipts, translate merchant and description to English
+- If amount cannot be determined, return null for amount
+- Return ONLY the JSON object, no explanation`;
+
+function computeConfidence(data: {
+  amount: number | null;
+  date: string | null;
+  merchant: string | null;
+  description: string | null;
+}): 'high' | 'medium' | 'low' {
+  if (data.amount && data.date && data.merchant) return 'high';
+  if (data.amount && (data.date || data.merchant)) return 'medium';
+  return 'low';
+}
+
+function resolveMediaType(mimetype: string): 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp' {
+  if (mimetype === 'image/png') return 'image/png';
+  // HEIC/HEIF are JPEG-compatible containers — pass as jpeg; Claude will attempt to process
+  return 'image/jpeg';
+}
+
+// POST /api/receipts/scan
+router.post('/scan', (req: Request, res: Response, next: NextFunction) => {
+  upload.single('image')(req, res, (err) => {
+    if (err instanceof MulterError) {
+      res.status(400).json({ error: err.code === 'LIMIT_FILE_SIZE' ? 'File too large. Maximum size is 10MB.' : err.message });
+      return;
+    }
+    if (err) {
+      res.status(400).json({ error: (err as Error).message });
+      return;
+    }
+    next();
+  });
+}, async (req: AuthRequest, res: Response): Promise<void> => {
+  if (!req.file) {
+    res.status(400).json({ error: 'No image uploaded' });
+    return;
+  }
+
+  const userId = req.userId!;
+
+  if (isRateLimited(userId)) {
+    res.status(429).json({ error: 'Rate limit exceeded. Maximum 10 scans per hour.' });
+    return;
+  }
+
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    res.status(500).json({ error: 'Receipt scanning is not configured' });
+    return;
+  }
+
+  const client = new Anthropic({ apiKey });
+  const imageBase64 = req.file.buffer.toString('base64');
+  const mediaType = resolveMediaType(req.file.mimetype);
+
+  let rawText: string;
+  try {
+    const message = await client.messages.create({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 512,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'image',
+              source: {
+                type: 'base64',
+                media_type: mediaType,
+                data: imageBase64,
+              },
+            },
+            {
+              type: 'text',
+              text: EXTRACTION_PROMPT,
+            },
+          ],
+        },
+      ],
+    });
+
+    const block = message.content[0];
+    rawText = block.type === 'text' ? block.text : '';
+  } catch (err) {
+    console.error('Claude API error:', err);
+    res.status(422).json({ error: 'Could not extract data from receipt' });
+    return;
+  }
+
+  let extracted: {
+    amount: number | null;
+    description: string | null;
+    merchant: string | null;
+    date: string | null;
+    category: string;
+    currency: string;
+  };
+
+  try {
+    const jsonMatch = rawText.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) throw new Error('No JSON found');
+    extracted = JSON.parse(jsonMatch[0]);
+  } catch {
+    res.status(422).json({ error: 'Could not extract data from receipt' });
+    return;
+  }
+
+  if (extracted.amount === null || extracted.amount === undefined) {
+    res.status(422).json({ error: 'Could not extract data from receipt' });
+    return;
+  }
+
+  const confidence = computeConfidence(extracted);
+
+  res.json({
+    amount: extracted.amount,
+    description: extracted.description ?? null,
+    category: extracted.category ?? 'Other',
+    date: extracted.date ?? null,
+    merchant: extracted.merchant ?? null,
+    currency: extracted.currency ?? 'HKD',
+    confidence,
+  });
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- Add `POST /auth/apple` endpoint that verifies Apple `id_token` via JWKS and returns a JWT
- Add `appleId` field to User model
- Support new user creation, existing user login, account linking, and Apple relay emails
- 7 tests covering all flows

## Closes
Closes #83 (parent: #80, depends on #82)

## Setup required
- Set `APPLE_CLIENT_ID` env var in Railway (Apple Services ID from Apple Developer Console)

## Note
This PR targets `feat/google-oauth` branch (not `main`) since it builds on the User model changes from #82.

## Test plan
- [ ] Verify `yarn build` passes
- [ ] Verify all 7 auth-apple tests pass
- [ ] Verify existing auth + auth-google tests still pass
- [ ] Manual test with real Apple token after setting up APPLE_CLIENT_ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)