### PR TITLE
feat: add receipt OCR endpoint for transaction extraction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@ FRONTEND_URL=http://localhost:3000
 # Google OAuth (optional - required for Google Sign-In)
 GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
 
-# Anthropic API (required for receipt OCR scanning at POST /api/receipts/scan)
+# Anthropic API (optional - required for receipt OCR scanning)
 ANTHROPIC_API_KEY=your-anthropic-api-key
 
 # Telegram alerts (optional - if not set, alerts are queued but not sent)

--- a/__tests__/receipts.test.ts
+++ b/__tests__/receipts.test.ts
@@ -1,0 +1,146 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+process.env.ANTHROPIC_API_KEY = 'test-api-key';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import app from '../src/app';
+
+jest.mock('@anthropic-ai/sdk', () => {
+  const mockCreate = jest.fn();
+  return jest.fn().mockImplementation(() => ({
+    messages: { create: mockCreate },
+  }));
+});
+
+import Anthropic from '@anthropic-ai/sdk';
+const MockedAnthropic = Anthropic as jest.MockedClass<typeof Anthropic>;
+
+let mongod: MongoMemoryServer;
+let authToken: string;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+
+  const res = await request(app)
+    .post('/auth/register')
+    .send({ email: 'test@example.com', password: 'password123' });
+  authToken = res.body.token;
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+const getMockCreate = () => {
+  const instance = MockedAnthropic.mock.results[0]?.value;
+  return instance?.messages?.create as jest.Mock;
+};
+
+describe('POST /api/receipts/scan', () => {
+  it('extracts transaction data from receipt image', async () => {
+    const extractedData = {
+      amount: 42.50,
+      description: 'Grocery shopping',
+      category: 'Food',
+      date: '2026-03-27',
+      merchant: 'Park n Shop',
+      currency: 'HKD',
+      confidence: 'high',
+    };
+
+    const res = await request(app)
+      .post('/api/receipts/scan')
+      .set('Authorization', `Bearer ${authToken}`)
+      .attach('receipt', Buffer.from('fake-image-data'), {
+        filename: 'receipt.jpg',
+        contentType: 'image/jpeg',
+      });
+
+    const mockCreate = getMockCreate();
+    if (mockCreate) {
+      mockCreate.mockResolvedValue({
+        content: [{ type: 'text', text: JSON.stringify(extractedData) }],
+      });
+    }
+
+    // Re-run with properly mocked create
+    const mockCreateFn = jest.fn().mockResolvedValue({
+      content: [{ type: 'text', text: JSON.stringify(extractedData) }],
+    });
+    MockedAnthropic.mockImplementation(() => ({
+      messages: { create: mockCreateFn },
+    }) as unknown as Anthropic);
+
+    const res2 = await request(app)
+      .post('/api/receipts/scan')
+      .set('Authorization', `Bearer ${authToken}`)
+      .attach('receipt', Buffer.from('fake-image-data'), {
+        filename: 'receipt.jpg',
+        contentType: 'image/jpeg',
+      });
+
+    expect(res2.status).toBe(200);
+    expect(res2.body.amount).toBe(42.50);
+    expect(res2.body.merchant).toBe('Park n Shop');
+    expect(res2.body.confidence).toBe('high');
+  });
+
+  it('rejects request without auth', async () => {
+    const res = await request(app)
+      .post('/api/receipts/scan')
+      .attach('receipt', Buffer.from('fake-image-data'), {
+        filename: 'receipt.jpg',
+        contentType: 'image/jpeg',
+      });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects request without file', async () => {
+    const res = await request(app)
+      .post('/api/receipts/scan')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('No receipt image provided');
+  });
+
+  it('rejects non-image file types', async () => {
+    const res = await request(app)
+      .post('/api/receipts/scan')
+      .set('Authorization', `Bearer ${authToken}`)
+      .attach('receipt', Buffer.from('not-an-image'), {
+        filename: 'document.pdf',
+        contentType: 'application/pdf',
+      });
+
+    expect(res.status).toBe(500);
+  });
+
+  it('returns 422 when extraction fails', async () => {
+    MockedAnthropic.mockImplementation(() => ({
+      messages: {
+        create: jest.fn().mockRejectedValue(new Error('API error')),
+      },
+    }) as unknown as Anthropic);
+
+    const res = await request(app)
+      .post('/api/receipts/scan')
+      .set('Authorization', `Bearer ${authToken}`)
+      .attach('receipt', Buffer.from('fake-image-data'), {
+        filename: 'receipt.jpg',
+        contentType: 'image/jpeg',
+      });
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toBe('Could not extract data from receipt');
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -14,6 +14,7 @@ import recurringRoutes from './routes/recurring';
 import reportRoutes from './routes/reports';
 import exchangeRateRoutes from './routes/exchange-rates';
 import userRoutes from './routes/users';
+import receiptRoutes from './routes/receipts';
 import { startAlertScheduler } from './jobs/processAlerts';
 import { startRecurringScheduler } from './jobs/processRecurring';
 import { startWeeklyDigestScheduler } from './jobs/weeklyDigest';
@@ -52,6 +53,7 @@ app.use('/api/recurring', recurringRoutes);
 app.use('/api/reports', reportRoutes);
 app.use('/api/exchange-rates', exchangeRateRoutes);
 app.use('/api/users', userRoutes);
+app.use('/api/receipts', receiptRoutes);
 
 Sentry.setupExpressErrorHandler(app);
 

--- a/src/routes/receipts.ts
+++ b/src/routes/receipts.ts
@@ -1,0 +1,107 @@
+import { Router, Response } from 'express';
+import multer from 'multer';
+import Anthropic from '@anthropic-ai/sdk';
+import { protect, AuthRequest } from '../middleware/auth';
+
+const router = Router();
+router.use(protect);
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 10 * 1024 * 1024 },
+  fileFilter: (_req, file, cb) => {
+    const allowed = ['image/jpeg', 'image/png', 'image/heic', 'image/heif'];
+    if (allowed.includes(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(new Error('Only JPEG, PNG, and HEIC images are accepted'));
+    }
+  },
+});
+
+const scanRateLimit = new Map<string, number[]>();
+
+const checkScanRateLimit = (userId: string): boolean => {
+  const now = Date.now();
+  const hour = 60 * 60 * 1000;
+  const timestamps = (scanRateLimit.get(userId) || []).filter((t) => now - t < hour);
+  if (timestamps.length >= 10) return false;
+  timestamps.push(now);
+  scanRateLimit.set(userId, timestamps);
+  return true;
+};
+
+const EXTRACTION_PROMPT = `You are a receipt data extractor. Analyze this receipt image and extract the following fields as JSON:
+
+{
+  "amount": <total amount as a number>,
+  "description": "<brief description of the purchase>",
+  "category": "<suggest one: Food, Transport, Shopping, Entertainment, Bills, Health, Education, Travel, Other>",
+  "date": "<date in YYYY-MM-DD format>",
+  "merchant": "<store/merchant name>",
+  "currency": "<3-letter currency code, e.g. HKD, USD, TWD>",
+  "confidence": "<high if all fields clearly extracted, medium if some guessed, low if many unclear>"
+}
+
+Rules:
+- Extract the TOTAL amount (not subtotal)
+- If the receipt is in Chinese (Traditional or Simplified), still extract all fields
+- If a field cannot be determined, use null
+- Return ONLY valid JSON, no other text`;
+
+// POST /api/receipts/scan
+router.post('/scan', upload.single('receipt'), async (req: AuthRequest, res: Response) => {
+  if (!req.file) {
+    res.status(400).json({ error: 'No receipt image provided' });
+    return;
+  }
+
+  if (!req.userId || !checkScanRateLimit(req.userId)) {
+    res.status(429).json({ error: 'Rate limit exceeded. Max 10 scans per hour.' });
+    return;
+  }
+
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    res.status(500).json({ error: 'Receipt scanning not configured' });
+    return;
+  }
+
+  try {
+    const client = new Anthropic({ apiKey });
+    const base64Image = req.file.buffer.toString('base64');
+    const mediaType = req.file.mimetype === 'image/heic' || req.file.mimetype === 'image/heif'
+      ? 'image/jpeg' as const
+      : req.file.mimetype as 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp';
+
+    const message = await client.messages.create({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 1024,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'image',
+              source: { type: 'base64', media_type: mediaType, data: base64Image },
+            },
+            { type: 'text', text: EXTRACTION_PROMPT },
+          ],
+        },
+      ],
+    });
+
+    const textBlock = message.content.find((b) => b.type === 'text');
+    if (!textBlock || textBlock.type !== 'text') {
+      res.status(422).json({ error: 'Could not extract data from receipt' });
+      return;
+    }
+
+    const parsed = JSON.parse(textBlock.text);
+    res.json(parsed);
+  } catch {
+    res.status(422).json({ error: 'Could not extract data from receipt' });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- Add `POST /api/receipts/scan` endpoint that extracts transaction data from receipt images
- Uses Claude Haiku vision API for OCR extraction
- Returns structured JSON: amount, description, category, date, merchant, currency, confidence
- Supports JPEG, PNG, HEIC (max 10MB), English and Traditional Chinese receipts

## Closes
Closes #84 (parent: #77)

## Setup required
- Set `ANTHROPIC_API_KEY` env var in Railway

## Test plan
- [ ] Verify `yarn build` passes
- [ ] Verify all 5 receipt tests pass
- [ ] Manual test with real receipt image after setting up ANTHROPIC_API_KEY

🤖 Generated with [Claude Code](https://claude.com/claude-code)