### PR TITLE
fix: include item field in expense create/update

### DIFF
--- a/src/routes/expenses.ts
+++ b/src/routes/expenses.ts
@@ -129,7 +129,7 @@ router.post('/', expenseValidation, async (req: AuthRequest, res: Response) => {
     return;
   }
   try {
-    const { description, amount, type, category, date, notes, participants, isRecurring, recurringFrequency, paymentMethod, currency, originalAmount, exchangeRate, splitBill } = req.body;
+    const { description, amount, type, category, item, date, notes, participants, isRecurring, recurringFrequency, paymentMethod, currency, originalAmount, exchangeRate, splitBill } = req.body;
 
     // Check for potential duplicates
     if (req.userId && typeof description === 'string' && typeof amount === 'number') {
@@ -143,7 +143,7 @@ router.post('/', expenseValidation, async (req: AuthRequest, res: Response) => {
 
     const expense = new ExpenseModel({
       owner: req.userId,
-      description, amount, type, category, date, notes,
+      description, amount, type, category, item, date, notes,
       participants: Array.isArray(participants) ? participants : [],
       ...(isRecurring !== undefined && { isRecurring }),
       ...(recurringFrequency !== undefined && { recurringFrequency }),
@@ -181,11 +181,12 @@ router.put('/:id', expenseValidation, async (req: AuthRequest, res: Response) =>
       res.status(404).json({ error: 'Expense not found' });
       return;
     }
-    const { description, amount, type, category, date, participants, paymentMethod, currency, originalAmount, exchangeRate, splitBill } = req.body;
+    const { description, amount, type, category, item, date, participants, paymentMethod, currency, originalAmount, exchangeRate, splitBill } = req.body;
     expense.description = description;
     expense.amount = amount;
     expense.type = type;
     expense.category = category;
+    expense.item = item;
     expense.date = date;
     expense.participants = Array.isArray(participants) ? participants : [];
     if (paymentMethod !== undefined) expense.paymentMethod = paymentMethod;


### PR DESCRIPTION
## Summary
- Added `item` to destructured fields in POST `/api/expenses` route — now saved to DB on create
- Added `item` to destructured fields in PUT `/api/expenses/:id` route — now persisted on update

The `item` field was defined in the Mongoose schema but never extracted from `req.body`, so it was silently dropped on every save.

Closes wkliwk/money-flow-frontend#159

## Test plan
- [x] Existing 24 expense tests pass
- [ ] Create a transaction with an item → verify item appears in GET response
- [ ] Edit a transaction's item → verify updated item persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)