### PR TITLE
feat: add budget vs actual summary endpoint

### DIFF
--- a/__tests__/budget-summary.test.ts
+++ b/__tests__/budget-summary.test.ts
@@ -1,0 +1,169 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import app from '../src/app';
+import UserModel from '../src/models/User';
+import ExpenseModel from '../src/models/Expense';
+
+let mongod: MongoMemoryServer;
+let authToken: string;
+let userId: string;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+
+  const res = await request(app)
+    .post('/auth/register')
+    .send({ email: 'budget@test.com', password: 'password123' });
+  authToken = res.body.token;
+
+  const user = await UserModel.findOne({ email: 'budget@test.com' });
+  userId = user!._id.toString();
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  await ExpenseModel.deleteMany({});
+  await UserModel.findByIdAndUpdate(userId, { budgets: [] });
+});
+
+describe('GET /api/reports/budget-summary', () => {
+  it('returns budget vs actual for current month', async () => {
+    await UserModel.findByIdAndUpdate(userId, {
+      budgets: [
+        { category: 'Food', limit: 500 },
+        { category: 'Transport', limit: 200 },
+      ],
+    });
+
+    const now = new Date();
+    await ExpenseModel.create([
+      { owner: userId, amount: 150, type: 'expense', category: 'Food', date: now },
+      { owner: userId, amount: 100, type: 'expense', category: 'Food', date: now },
+      { owner: userId, amount: 80, type: 'expense', category: 'Transport', date: now },
+    ]);
+
+    const res = await request(app)
+      .get('/api/reports/budget-summary')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.totalBudgeted).toBe(700);
+    expect(res.body.totalSpent).toBe(330);
+    expect(res.body.totalRemaining).toBe(370);
+
+    const food = res.body.data.find((d: { category: string }) => d.category === 'Food');
+    expect(food.spent).toBe(250);
+    expect(food.budgetLimit).toBe(500);
+    expect(food.percentUsed).toBe(50);
+    expect(food.overBudget).toBe(false);
+  });
+
+  it('flags over-budget categories', async () => {
+    await UserModel.findByIdAndUpdate(userId, {
+      budgets: [{ category: 'Shopping', limit: 100 }],
+    });
+
+    const now = new Date();
+    await ExpenseModel.create({
+      owner: userId, amount: 150, type: 'expense', category: 'Shopping', date: now,
+    });
+
+    const res = await request(app)
+      .get('/api/reports/budget-summary')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.body.data[0].overBudget).toBe(true);
+    expect(res.body.data[0].percentUsed).toBe(150);
+    expect(res.body.data[0].remaining).toBe(-50);
+  });
+
+  it('includes categories with spending but no budget', async () => {
+    const now = new Date();
+    await ExpenseModel.create({
+      owner: userId, amount: 50, type: 'expense', category: 'Entertainment', date: now,
+    });
+
+    const res = await request(app)
+      .get('/api/reports/budget-summary')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].category).toBe('Entertainment');
+    expect(res.body.data[0].spent).toBe(50);
+    expect(res.body.data[0].budgetLimit).toBe(0);
+  });
+
+  it('returns empty data when no budgets and no spending', async () => {
+    const res = await request(app)
+      .get('/api/reports/budget-summary')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(0);
+    expect(res.body.totalBudgeted).toBe(0);
+    expect(res.body.totalSpent).toBe(0);
+  });
+
+  it('filters by specific month', async () => {
+    await UserModel.findByIdAndUpdate(userId, {
+      budgets: [{ category: 'Food', limit: 300 }],
+    });
+
+    await ExpenseModel.create([
+      { owner: userId, amount: 100, type: 'expense', category: 'Food', date: new Date('2026-02-15') },
+      { owner: userId, amount: 200, type: 'expense', category: 'Food', date: new Date('2026-03-15') },
+    ]);
+
+    const res = await request(app)
+      .get('/api/reports/budget-summary?month=2026-02')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    const food = res.body.data.find((d: { category: string }) => d.category === 'Food');
+    expect(food.spent).toBe(100);
+  });
+
+  it('rejects invalid month format', async () => {
+    const res = await request(app)
+      .get('/api/reports/budget-summary?month=invalid')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('requires authentication', async () => {
+    const res = await request(app).get('/api/reports/budget-summary');
+    expect(res.status).toBe(401);
+  });
+
+  it('sorts by percentUsed descending', async () => {
+    await UserModel.findByIdAndUpdate(userId, {
+      budgets: [
+        { category: 'Food', limit: 500 },
+        { category: 'Transport', limit: 100 },
+      ],
+    });
+
+    const now = new Date();
+    await ExpenseModel.create([
+      { owner: userId, amount: 100, type: 'expense', category: 'Food', date: now },
+      { owner: userId, amount: 90, type: 'expense', category: 'Transport', date: now },
+    ]);
+
+    const res = await request(app)
+      .get('/api/reports/budget-summary')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.body.data[0].category).toBe('Transport');
+    expect(res.body.data[1].category).toBe('Food');
+  });
+});

--- a/src/routes/reports.ts
+++ b/src/routes/reports.ts
@@ -1,5 +1,6 @@
 import { Router, Response } from 'express';
 import ExpenseModel from '../models/Expense';
+import UserModel from '../models/User';
 import { protect, AuthRequest } from '../middleware/auth';
 import { sendWeeklyDigestForUser, aggregateWeeklyData, formatDigestMessage } from '../utils/weeklyDigest';
 
@@ -74,6 +75,79 @@ router.get('/monthly', async (req: AuthRequest, res: Response) => {
     res.json({ data });
   } catch {
     res.status(500).json({ error: 'Failed to fetch monthly report' });
+  }
+});
+
+router.get('/budget-summary', async (req: AuthRequest, res: Response) => {
+  try {
+    const monthParam = req.query.month as string | undefined;
+    let year: number;
+    let month: number;
+
+    if (monthParam) {
+      if (!/^\d{4}-(0[1-9]|1[0-2])$/.test(monthParam)) {
+        res.status(400).json({ error: 'month must be in YYYY-MM format' });
+        return;
+      }
+      [year, month] = monthParam.split('-').map(Number);
+    } else {
+      const now = new Date();
+      year = now.getFullYear();
+      month = now.getMonth() + 1;
+    }
+
+    const startDate = new Date(year, month - 1, 1);
+    const endDate = new Date(year, month, 1);
+
+    const user = await UserModel.findById(req.userId).lean();
+    const budgets = user?.budgets || [];
+
+    const spendingRows = await ExpenseModel.aggregate([
+      {
+        $match: {
+          owner: req.userId,
+          type: 'expense',
+          date: { $gte: startDate, $lt: endDate },
+        },
+      },
+      {
+        $group: {
+          _id: '$category',
+          spent: { $sum: '$amount' },
+        },
+      },
+    ]);
+
+    const spendingMap = new Map<string, number>();
+    for (const row of spendingRows) {
+      spendingMap.set(row._id || 'Uncategorised', row.spent);
+    }
+
+    const categories = new Set<string>();
+    for (const b of budgets) categories.add(b.category);
+    for (const [cat] of spendingMap) categories.add(cat);
+
+    const budgetMap = new Map<string, number>();
+    for (const b of budgets) budgetMap.set(b.category, b.limit);
+
+    const data = Array.from(categories).map((category) => {
+      const budgetLimit = budgetMap.get(category) ?? 0;
+      const spent = spendingMap.get(category) ?? 0;
+      const remaining = budgetLimit - spent;
+      const percentUsed = budgetLimit > 0 ? Math.round((spent / budgetLimit) * 10000) / 100 : 0;
+      const overBudget = budgetLimit > 0 && spent > budgetLimit;
+      return { category, budgetLimit, spent, remaining, percentUsed, overBudget };
+    });
+
+    data.sort((a, b) => b.percentUsed - a.percentUsed);
+
+    const totalBudgeted = data.reduce((sum, d) => sum + d.budgetLimit, 0);
+    const totalSpent = data.reduce((sum, d) => sum + d.spent, 0);
+    const totalRemaining = totalBudgeted - totalSpent;
+
+    res.json({ data, totalBudgeted, totalSpent, totalRemaining });
+  } catch {
+    res.status(500).json({ error: 'Failed to fetch budget summary' });
   }
 });
 


### PR DESCRIPTION
## Summary
- Add `GET /api/reports/budget-summary` endpoint
- Returns per-category budget vs actual spending comparison
- Includes percentUsed, overBudget flag, remaining amount
- Sorted by most over-budget first
- Supports `month` query param (YYYY-MM), defaults to current month
- 8 tests

## Closes
Closes #96

## Test plan
- [ ] `yarn build` passes
- [ ] All 8 budget-summary tests pass
- [ ] Existing report tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)