### PR TITLE
feat: monthly spending summary via Telegram (#103)

### DIFF
--- a/__tests__/monthly-summary.test.ts
+++ b/__tests__/monthly-summary.test.ts
@@ -1,0 +1,308 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import app from '../src/app';
+import ExpenseModel from '../src/models/Expense';
+import UserModel from '../src/models/User';
+import {
+  aggregateMonthlySummary,
+  formatMonthlySummaryMessage,
+  getPreviousMonthBounds,
+  getPriorMonthBounds,
+  buildBudgetAlerts,
+  MonthlySummaryData,
+} from '../src/utils/monthlySummary';
+
+let mongod: MongoMemoryServer;
+const TEST_USER_ID = new mongoose.Types.ObjectId().toString();
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+}, 30000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  for (const col of Object.values(mongoose.connection.collections)) {
+    await col.deleteMany({});
+  }
+});
+
+// Helper: build a date in the previous calendar month
+function prevMonthDate(dayOfMonth = 10): Date {
+  const now = new Date();
+  const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, dayOfMonth));
+  return d;
+}
+
+// Helper: build a date two months ago (prior month for MoM)
+function priorMonthDate(dayOfMonth = 10): Date {
+  const now = new Date();
+  const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 2, dayOfMonth));
+  return d;
+}
+
+describe('getPreviousMonthBounds', () => {
+  it('returns start/end spanning previous month', () => {
+    const now = new Date('2026-03-15T12:00:00Z');
+    const { start, end, label } = getPreviousMonthBounds(now);
+    expect(label).toBe('2026-02');
+    expect(start).toEqual(new Date('2026-02-01T00:00:00Z'));
+    expect(end).toEqual(new Date('2026-03-01T00:00:00Z'));
+  });
+
+  it('handles January (rolls back to December of prior year)', () => {
+    const now = new Date('2026-01-05T12:00:00Z');
+    const { start, end, label } = getPreviousMonthBounds(now);
+    expect(label).toBe('2025-12');
+    expect(start).toEqual(new Date('2025-12-01T00:00:00Z'));
+    expect(end).toEqual(new Date('2026-01-01T00:00:00Z'));
+  });
+});
+
+describe('getPriorMonthBounds', () => {
+  it('returns two months back', () => {
+    const now = new Date('2026-03-15T12:00:00Z');
+    const { start, end } = getPriorMonthBounds(now);
+    expect(start).toEqual(new Date('2026-01-01T00:00:00Z'));
+    expect(end).toEqual(new Date('2026-02-01T00:00:00Z'));
+  });
+
+  it('handles February — rolls to December of prior year', () => {
+    const now = new Date('2026-02-10T12:00:00Z');
+    const { start, end } = getPriorMonthBounds(now);
+    expect(start).toEqual(new Date('2025-12-01T00:00:00Z'));
+    expect(end).toEqual(new Date('2026-01-01T00:00:00Z'));
+  });
+});
+
+describe('aggregateMonthlySummary', () => {
+  it('returns zeros for user with no transactions', async () => {
+    const data = await aggregateMonthlySummary(TEST_USER_ID);
+    expect(data.totalIncome).toBe(0);
+    expect(data.totalExpense).toBe(0);
+    expect(data.net).toBe(0);
+    expect(data.topCategories).toEqual([]);
+    expect(data.momChangePercent).toBeNull();
+  });
+
+  it('aggregates income and expense for previous month', async () => {
+    await ExpenseModel.create([
+      { owner: TEST_USER_ID, amount: 3000, type: 'income', category: 'Salary', date: prevMonthDate(5) },
+      { owner: TEST_USER_ID, amount: 200, type: 'expense', category: 'Food', date: prevMonthDate(10) },
+      { owner: TEST_USER_ID, amount: 100, type: 'expense', category: 'Transport', date: prevMonthDate(15) },
+    ]);
+
+    const data = await aggregateMonthlySummary(TEST_USER_ID);
+    expect(data.totalIncome).toBe(3000);
+    expect(data.totalExpense).toBe(300);
+    expect(data.net).toBe(2700);
+  });
+
+  it('returns up to 5 top categories sorted by total descending', async () => {
+    await ExpenseModel.create([
+      { owner: TEST_USER_ID, amount: 500, type: 'expense', category: 'Rent', date: prevMonthDate(1) },
+      { owner: TEST_USER_ID, amount: 300, type: 'expense', category: 'Food', date: prevMonthDate(2) },
+      { owner: TEST_USER_ID, amount: 200, type: 'expense', category: 'Transport', date: prevMonthDate(3) },
+      { owner: TEST_USER_ID, amount: 100, type: 'expense', category: 'Entertainment', date: prevMonthDate(4) },
+      { owner: TEST_USER_ID, amount: 80, type: 'expense', category: 'Health', date: prevMonthDate(5) },
+      { owner: TEST_USER_ID, amount: 50, type: 'expense', category: 'Other', date: prevMonthDate(6) },
+    ]);
+
+    const data = await aggregateMonthlySummary(TEST_USER_ID);
+    expect(data.topCategories).toHaveLength(5);
+    expect(data.topCategories[0].category).toBe('Rent');
+    expect(data.topCategories[4].category).toBe('Health');
+  });
+
+  it('calculates month-over-month change percent', async () => {
+    await ExpenseModel.create([
+      { owner: TEST_USER_ID, amount: 200, type: 'expense', category: 'Food', date: prevMonthDate(10) },
+      { owner: TEST_USER_ID, amount: 100, type: 'expense', category: 'Food', date: priorMonthDate(10) },
+    ]);
+
+    const data = await aggregateMonthlySummary(TEST_USER_ID);
+    expect(data.momChangePercent).toBe(100); // doubled
+  });
+
+  it('returns null momChangePercent when no prior month data', async () => {
+    await ExpenseModel.create([
+      { owner: TEST_USER_ID, amount: 200, type: 'expense', category: 'Food', date: prevMonthDate(10) },
+    ]);
+
+    const data = await aggregateMonthlySummary(TEST_USER_ID);
+    expect(data.momChangePercent).toBeNull();
+  });
+
+  it('labels null category as Uncategorised', async () => {
+    await ExpenseModel.create([
+      { owner: TEST_USER_ID, amount: 50, type: 'expense', date: prevMonthDate(5) },
+    ]);
+
+    const data = await aggregateMonthlySummary(TEST_USER_ID);
+    expect(data.topCategories[0].category).toBe('Uncategorised');
+  });
+
+  it('does not include current month transactions', async () => {
+    const now = new Date();
+    await ExpenseModel.create([
+      { owner: TEST_USER_ID, amount: 999, type: 'expense', category: 'Food', date: now },
+    ]);
+
+    const data = await aggregateMonthlySummary(TEST_USER_ID);
+    expect(data.totalExpense).toBe(0);
+  });
+});
+
+describe('buildBudgetAlerts', () => {
+  it('returns empty array when no budgets set', async () => {
+    const categories = [{ category: 'Food', total: 500 }];
+    const alerts = await buildBudgetAlerts(TEST_USER_ID, categories, []);
+    expect(alerts).toEqual([]);
+  });
+
+  it('flags categories over budget', async () => {
+    const categories = [
+      { category: 'Food', total: 600 },
+      { category: 'Transport', total: 80 },
+    ];
+    const budgets = [
+      { category: 'Food', limit: 500 },
+      { category: 'Transport', limit: 100 },
+    ];
+    const alerts = await buildBudgetAlerts(TEST_USER_ID, categories, budgets);
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].category).toBe('Food');
+    expect(alerts[0].spent).toBe(600);
+    expect(alerts[0].limit).toBe(500);
+    expect(alerts[0].percentUsed).toBe(120);
+  });
+
+  it('does not flag categories under budget', async () => {
+    const categories = [{ category: 'Food', total: 400 }];
+    const budgets = [{ category: 'Food', limit: 500 }];
+    const alerts = await buildBudgetAlerts(TEST_USER_ID, categories, budgets);
+    expect(alerts).toHaveLength(0);
+  });
+});
+
+describe('formatMonthlySummaryMessage', () => {
+  const baseData: MonthlySummaryData = {
+    month: '2026-02',
+    totalIncome: 3000,
+    totalExpense: 1200,
+    net: 1800,
+    topCategories: [
+      { category: 'Rent', total: 700 },
+      { category: 'Food', total: 300 },
+    ],
+    budgetAlerts: [],
+    prevMonthExpense: 1000,
+    momChangePercent: 20,
+  };
+
+  it('includes month label and key figures', () => {
+    const msg = formatMonthlySummaryMessage(baseData);
+    expect(msg).toContain('2026-02');
+    expect(msg).toContain('$3000.00');
+    expect(msg).toContain('$1200.00');
+    expect(msg).toContain('$1800.00');
+  });
+
+  it('shows up arrow for increased spending', () => {
+    const msg = formatMonthlySummaryMessage(baseData);
+    expect(msg).toContain('↑');
+    expect(msg).toContain('20%');
+  });
+
+  it('shows down arrow for decreased spending', () => {
+    const msg = formatMonthlySummaryMessage({ ...baseData, momChangePercent: -15 });
+    expect(msg).toContain('↓');
+    expect(msg).toContain('15%');
+  });
+
+  it('shows No data when no prior month', () => {
+    const msg = formatMonthlySummaryMessage({ ...baseData, momChangePercent: null });
+    expect(msg).toContain('No data');
+  });
+
+  it('lists top categories', () => {
+    const msg = formatMonthlySummaryMessage(baseData);
+    expect(msg).toContain('Rent');
+    expect(msg).toContain('$700.00');
+    expect(msg).toContain('Food');
+  });
+
+  it('includes budget alerts when present', () => {
+    const dataWithAlerts: MonthlySummaryData = {
+      ...baseData,
+      budgetAlerts: [{ category: 'Food', spent: 600, limit: 500, percentUsed: 120 }],
+    };
+    const msg = formatMonthlySummaryMessage(dataWithAlerts);
+    expect(msg).toContain('Over Budget');
+    expect(msg).toContain('Food');
+    expect(msg).toContain('120%');
+  });
+
+  it('omits budget section when no alerts', () => {
+    const msg = formatMonthlySummaryMessage(baseData);
+    expect(msg).not.toContain('Over Budget');
+  });
+});
+
+describe('POST /api/jobs/monthly-summary', () => {
+  const JOBS_API_KEY = 'test-jobs-key';
+
+  beforeEach(() => {
+    process.env.JOBS_API_KEY = JOBS_API_KEY;
+    process.env.TELEGRAM_BOT_TOKEN = 'fake-token';
+  });
+
+  afterEach(() => {
+    delete process.env.JOBS_API_KEY;
+    delete process.env.TELEGRAM_BOT_TOKEN;
+  });
+
+  it('returns 401 without API key', async () => {
+    const res = await request(app).post('/api/jobs/monthly-summary');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 with wrong API key', async () => {
+    const res = await request(app)
+      .post('/api/jobs/monthly-summary')
+      .set('x-api-key', 'wrong-key');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 with correct API key', async () => {
+    await UserModel.create({
+      _id: TEST_USER_ID,
+      email: 'job@example.com',
+      password: 'password123',
+    });
+
+    const res = await request(app)
+      .post('/api/jobs/monthly-summary')
+      .set('x-api-key', JOBS_API_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(typeof res.body.durationMs).toBe('number');
+  });
+
+  it('returns 503 when JOBS_API_KEY is not configured', async () => {
+    delete process.env.JOBS_API_KEY;
+    const res = await request(app)
+      .post('/api/jobs/monthly-summary')
+      .set('x-api-key', 'any-key');
+    expect(res.status).toBe(503);
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,9 +16,11 @@ import exchangeRateRoutes from './routes/exchange-rates';
 import userRoutes from './routes/users';
 import receiptRoutes from './routes/receipts';
 import templateRoutes from './routes/templates';
+import jobRoutes from './routes/jobs';
 import { startAlertScheduler } from './jobs/processAlerts';
 import { startRecurringScheduler } from './jobs/processRecurring';
 import { startWeeklyDigestScheduler } from './jobs/weeklyDigest';
+import { startMonthlySummaryScheduler } from './jobs/monthlySummary';
 
 dotenv.config();
 
@@ -56,6 +58,7 @@ app.use('/api/exchange-rates', exchangeRateRoutes);
 app.use('/api/users', userRoutes);
 app.use('/api/receipts', receiptRoutes);
 app.use('/api/templates', templateRoutes);
+app.use('/api/jobs', jobRoutes);
 
 Sentry.setupExpressErrorHandler(app);
 
@@ -74,6 +77,7 @@ if (process.env.NODE_ENV !== 'test') {
       startAlertScheduler();
       startRecurringScheduler();
       startWeeklyDigestScheduler();
+      startMonthlySummaryScheduler();
       app.listen(PORT, () => {
         console.log(`Server running on port ${PORT}`);
       });

--- a/src/jobs/monthlySummary.ts
+++ b/src/jobs/monthlySummary.ts
@@ -1,0 +1,55 @@
+import { processMonthlySummaries } from '../utils/monthlySummary';
+
+export async function monthlySummaryJob(): Promise<void> {
+  const start = Date.now();
+  try {
+    const count = await processMonthlySummaries();
+    const duration = Date.now() - start;
+    console.log(`[MonthlySummaryJob] Sent ${count} summaries in ${duration}ms`);
+  } catch (error) {
+    console.error('[MonthlySummaryJob] Error:', error);
+  }
+}
+
+/**
+ * Start monthly summary scheduler.
+ * Checks every hour; only sends on the 1st of the month at or after 09:00 HKT (UTC+8).
+ * Cron equivalent: 0 9 1 * * (Railway cron schedule)
+ */
+export function startMonthlySummaryScheduler(): NodeJS.Timer | null {
+  if (!process.env.TELEGRAM_BOT_TOKEN) {
+    console.log('[MonthlySummaryScheduler] Telegram not configured, skipping');
+    return null;
+  }
+
+  let lastSentMonth = '';
+
+  const intervalId = setInterval(
+    () => {
+      const now = new Date();
+      // HKT = UTC+8
+      const hktOffset = now.getUTCHours() + 8;
+      const hktHour = hktOffset % 24;
+      const crossedMidnight = hktOffset >= 24;
+
+      const utcDate = new Date(now);
+      if (crossedMidnight) utcDate.setUTCDate(utcDate.getUTCDate() + 1);
+      const hktDay = utcDate.getUTCDate();
+
+      // 1st of month at or after 09:00 HKT
+      if (hktDay === 1 && hktHour >= 9) {
+        const monthKey = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+        if (monthKey !== lastSentMonth) {
+          lastSentMonth = monthKey;
+          monthlySummaryJob().catch((error) => {
+            console.error('[MonthlySummaryScheduler] Run failed:', error);
+          });
+        }
+      }
+    },
+    60 * 60 * 1000 // Check every hour
+  );
+
+  console.log('[MonthlySummaryScheduler] Started (checks hourly, sends 1st of month 09:00 HKT)');
+  return intervalId;
+}

--- a/src/routes/jobs.ts
+++ b/src/routes/jobs.ts
@@ -1,0 +1,35 @@
+import { Router, Request, Response } from 'express';
+import { monthlySummaryJob } from '../jobs/monthlySummary';
+
+const router = Router();
+
+function requireApiKey(req: Request, res: Response): boolean {
+  const apiKey = process.env.JOBS_API_KEY;
+  if (!apiKey) {
+    res.status(503).json({ error: 'Jobs API key not configured' });
+    return false;
+  }
+  const provided = req.headers['x-api-key'];
+  if (!provided || provided !== apiKey) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return false;
+  }
+  return true;
+}
+
+// POST /api/jobs/monthly-summary
+// Protected by X-Api-Key header matching JOBS_API_KEY env var.
+// Returns count of summaries sent.
+router.post('/monthly-summary', async (req: Request, res: Response) => {
+  if (!requireApiKey(req, res)) return;
+  const start = Date.now();
+  try {
+    await monthlySummaryJob();
+    res.json({ ok: true, durationMs: Date.now() - start });
+  } catch (error) {
+    console.error('[POST /api/jobs/monthly-summary] Error:', error);
+    res.status(500).json({ error: 'Job failed' });
+  }
+});
+
+export default router;

--- a/src/utils/monthlySummary.ts
+++ b/src/utils/monthlySummary.ts
@@ -1,0 +1,199 @@
+import UserModel, { IBudget, IUser } from '../models/User';
+import ExpenseModel from '../models/Expense';
+import { sendTelegramMessageToChat } from './telegram';
+
+interface CategoryTotal {
+  category: string;
+  total: number;
+}
+
+interface BudgetAlert {
+  category: string;
+  spent: number;
+  limit: number;
+  percentUsed: number;
+}
+
+export interface MonthlySummaryData {
+  month: string;
+  totalIncome: number;
+  totalExpense: number;
+  net: number;
+  topCategories: CategoryTotal[];
+  budgetAlerts: BudgetAlert[];
+  prevMonthExpense: number;
+  momChangePercent: number | null;
+}
+
+export function getPreviousMonthBounds(now: Date): { start: Date; end: Date; label: string } {
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth(); // 0-indexed; this is "current" month index
+  // Previous month
+  const prevMonth = month === 0 ? 11 : month - 1;
+  const prevYear = month === 0 ? year - 1 : year;
+  const start = new Date(Date.UTC(prevYear, prevMonth, 1));
+  const end = new Date(Date.UTC(prevYear, prevMonth + 1, 1));
+  const label = `${prevYear}-${String(prevMonth + 1).padStart(2, '0')}`;
+  return { start, end, label };
+}
+
+export function getPriorMonthBounds(now: Date): { start: Date; end: Date } {
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth();
+  // Two months back
+  const priorMonth = month <= 1 ? month + 10 : month - 2;
+  const priorYear = month <= 1 ? year - 1 : year;
+  const start = new Date(Date.UTC(priorYear, priorMonth, 1));
+  const end = new Date(Date.UTC(priorYear, priorMonth + 1, 1));
+  return { start, end };
+}
+
+export async function aggregateMonthlySummary(userId: string, now?: Date): Promise<MonthlySummaryData> {
+  const currentDate = now ?? new Date();
+  const { start, end, label } = getPreviousMonthBounds(currentDate);
+  const prior = getPriorMonthBounds(currentDate);
+
+  const matchStage = {
+    $match: {
+      owner: userId,
+      date: { $gte: start, $lt: end },
+    },
+  };
+
+  const [summaryResult, categoryResult, priorResult] = await Promise.all([
+    ExpenseModel.aggregate([
+      matchStage,
+      {
+        $group: {
+          _id: '$type',
+          total: { $sum: '$amount' },
+        },
+      },
+    ]),
+    ExpenseModel.aggregate([
+      matchStage,
+      { $match: { type: 'expense' } },
+      {
+        $group: {
+          _id: '$category',
+          total: { $sum: '$amount' },
+        },
+      },
+      { $sort: { total: -1 } },
+      { $limit: 5 },
+    ]),
+    ExpenseModel.aggregate([
+      {
+        $match: {
+          owner: userId,
+          type: 'expense',
+          date: { $gte: prior.start, $lt: prior.end },
+        },
+      },
+      {
+        $group: {
+          _id: null,
+          total: { $sum: '$amount' },
+        },
+      },
+    ]),
+  ]);
+
+  const totalIncome = summaryResult.find((r: { _id: string }) => r._id === 'income')?.total ?? 0;
+  const totalExpense = summaryResult.find((r: { _id: string }) => r._id === 'expense')?.total ?? 0;
+  const net = totalIncome - totalExpense;
+
+  const topCategories: CategoryTotal[] = categoryResult.map(
+    (row: { _id: string | null; total: number }) => ({
+      category: row._id ?? 'Uncategorised',
+      total: row.total,
+    })
+  );
+
+  const prevMonthExpense: number = priorResult[0]?.total ?? 0;
+  let momChangePercent: number | null = null;
+  if (prevMonthExpense > 0) {
+    momChangePercent = Math.round(((totalExpense - prevMonthExpense) / prevMonthExpense) * 100);
+  }
+
+  return { month: label, totalIncome, totalExpense, net, topCategories, budgetAlerts: [], prevMonthExpense, momChangePercent };
+}
+
+export async function buildBudgetAlerts(userId: string, totalsByCategory: CategoryTotal[], budgets: IBudget[]): Promise<BudgetAlert[]> {
+  const alerts: BudgetAlert[] = [];
+  const budgetMap = new Map<string, number>();
+  for (const b of budgets) budgetMap.set(b.category, b.limit);
+
+  for (const cat of totalsByCategory) {
+    const limit = budgetMap.get(cat.category);
+    if (limit && limit > 0 && cat.total > limit) {
+      const percentUsed = Math.round((cat.total / limit) * 10000) / 100;
+      alerts.push({ category: cat.category, spent: cat.total, limit, percentUsed });
+    }
+  }
+  return alerts;
+}
+
+export function formatMonthlySummaryMessage(data: MonthlySummaryData): string {
+  const { month, totalIncome, totalExpense, net, topCategories, budgetAlerts, momChangePercent } = data;
+
+  let msg = `<b>Monthly Summary — ${month}</b>\n\n`;
+  msg += `<b>Income:</b> $${totalIncome.toFixed(2)}\n`;
+  msg += `<b>Expenses:</b> $${totalExpense.toFixed(2)}\n`;
+  msg += `<b>Net:</b> $${net.toFixed(2)}\n`;
+
+  if (momChangePercent !== null) {
+    const arrow = momChangePercent > 0 ? '↑' : momChangePercent < 0 ? '↓' : '→';
+    msg += `<b>vs Prior Month:</b> ${arrow} ${Math.abs(momChangePercent)}%\n`;
+  } else {
+    msg += `<b>vs Prior Month:</b> No data\n`;
+  }
+
+  if (topCategories.length > 0) {
+    msg += `\n<b>Top Categories:</b>\n`;
+    topCategories.forEach((cat, i) => {
+      msg += `  ${i + 1}. ${cat.category} — $${cat.total.toFixed(2)}\n`;
+    });
+  }
+
+  if (budgetAlerts.length > 0) {
+    msg += `\n<b>Over Budget:</b>\n`;
+    for (const alert of budgetAlerts) {
+      msg += `  ${alert.category}: $${alert.spent.toFixed(2)} / $${alert.limit.toFixed(2)} (${alert.percentUsed}%)\n`;
+    }
+  }
+
+  return msg;
+}
+
+export async function sendMonthlySummaryForUser(userId: string, now?: Date): Promise<boolean> {
+  const data = await aggregateMonthlySummary(userId, now);
+
+  const user = await UserModel.findById(userId).lean();
+  if (!user?.telegramChatId) return false;
+
+  const alerts = await buildBudgetAlerts(userId, data.topCategories, (user as IUser).budgets ?? []);
+  data.budgetAlerts = alerts;
+
+  const message = formatMonthlySummaryMessage(data);
+  return sendTelegramMessageToChat(user.telegramChatId, message);
+}
+
+export async function processMonthlySummaries(): Promise<number> {
+  const users = await UserModel.find({
+    telegramChatId: { $exists: true, $ne: '' },
+  }).lean();
+
+  let sentCount = 0;
+  for (const user of users) {
+    const userId = (user as IUser)._id.toString();
+    try {
+      const sent = await sendMonthlySummaryForUser(userId);
+      if (sent) sentCount++;
+    } catch (error) {
+      console.error(`[MonthlySummary] Failed for user ${userId}:`, error);
+    }
+  }
+
+  return sentCount;
+}


### PR DESCRIPTION
## What
- `src/utils/monthlySummary.ts` — aggregation logic, message formatter, per-user sender, and bulk processor (mirrors weeklyDigest pattern)
- `src/jobs/monthlySummary.ts` — `monthlySummaryJob()` callable entry point and `startMonthlySummaryScheduler()` hourly interval that triggers on the 1st of each month at 09:00 HKT
- `src/routes/jobs.ts` — `POST /api/jobs/monthly-summary` protected by `X-Api-Key: <JOBS_API_KEY>` for external cron/Railway triggers
- `src/app.ts` — registers the route and starts the scheduler
- `__tests__/monthly-summary.test.ts` — 25 tests

## Why
Closes #103

## Acceptance Criteria
- [x] Job runs on 1st of month via cron (scheduler + Railway `0 9 1 * *`)
- [x] Summary includes: income, expense, net, top 5 categories, budget status
- [x] Month-over-month comparison included
- [x] Delivered via Telegram
- [x] Handles users with no transactions gracefully (returns zeros, skips Telegram send if no `telegramChatId`)
- [x] Job logs success/failure

## Test Plan
1. Set `JOBS_API_KEY=any-secret` in env
2. `POST /api/jobs/monthly-summary` with `x-api-key: any-secret` — expect `{ ok: true, durationMs: N }`
3. Without header / wrong key → 401; missing env var → 503
4. With a user that has `telegramChatId` set and expenses in the prior month, the Telegram message should include income, expense, net, top categories, MoM change, and any over-budget flags