### PR TITLE
feat: NLP transaction parsing endpoint (issue #109)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -7,6 +7,7 @@ import dotenv from 'dotenv';
 import authRoutes from './routes/auth';
 import expenseRoutes from './routes/expenses';
 import budgetRoutes from './routes/budgets';
+import transactionRoutes from './routes/transactions';
 
 dotenv.config();
 
@@ -27,6 +28,7 @@ app.get('/health', (_req, res) => {
 app.use('/auth', authRoutes);
 app.use('/api/expenses', expenseRoutes);
 app.use('/api/budgets', budgetRoutes);
+app.use('/api/transactions', transactionRoutes);
 
 Sentry.setupExpressErrorHandler(app);
 

--- a/src/routes/transactions.test.ts
+++ b/src/routes/transactions.test.ts
@@ -1,0 +1,284 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+process.env.ANTHROPIC_API_KEY = 'test-api-key';
+
+import request from 'supertest';
+import express from 'express';
+import cors from 'cors';
+import jwt from 'jsonwebtoken';
+import transactionRoutes from './transactions';
+
+// Mock the Anthropic SDK
+jest.mock('@anthropic-ai/sdk', () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => ({
+      messages: {
+        create: jest.fn(),
+      },
+    })),
+  };
+});
+
+import Anthropic from '@anthropic-ai/sdk';
+
+const JWT_SECRET = 'test-secret';
+
+const app = express();
+app.use(express.json());
+app.use(cors());
+app.use('/api/transactions', transactionRoutes);
+
+const authToken = jwt.sign({ userId: 'user_123' }, JWT_SECRET);
+
+function mockClaudeResponse(payload: Record<string, unknown>) {
+  (Anthropic as jest.MockedClass<typeof Anthropic>).mockImplementationOnce(() => ({
+    messages: {
+      create: jest.fn().mockResolvedValue({
+        content: [{ type: 'text', text: JSON.stringify(payload) }],
+      }),
+    },
+  } as unknown as Anthropic));
+}
+
+const FULL_PARSE_RESPONSE = {
+  merchant: "McDonald's",
+  amount: 65,
+  currency: 'HKD',
+  category: 'Food',
+  subcategory: 'Fast Food',
+  participants: ['Casey'],
+  date: '2026-03-27',
+  notes: 'Big Mac Meal',
+  confidence: 0.95,
+  missing_fields: [],
+};
+
+beforeEach(() => {
+  (Anthropic as jest.MockedClass<typeof Anthropic>).mockReset();
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('POST /api/transactions/parse-text', () => {
+  it('requires JWT auth', async () => {
+    const res = await request(app).post('/api/transactions/parse-text').send({ text: 'test' });
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects missing text', async () => {
+    const res = await request(app)
+      .post('/api/transactions/parse-text')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBeDefined();
+  });
+
+  it('rejects empty text', async () => {
+    const res = await request(app)
+      .post('/api/transactions/parse-text')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ text: '   ' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects text over 1000 characters', async () => {
+    const res = await request(app)
+      .post('/api/transactions/parse-text')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ text: 'a'.repeat(1001) });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects invalid locale', async () => {
+    mockClaudeResponse(FULL_PARSE_RESPONSE);
+    const res = await request(app)
+      .post('/api/transactions/parse-text')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ text: 'test', locale: 'fr-FR' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns structured JSON for a Cantonese transaction', async () => {
+    mockClaudeResponse(FULL_PARSE_RESPONSE);
+
+    const res = await request(app)
+      .post('/api/transactions/parse-text')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ text: '我今日同Casey食咗麥當勞巨無霸餐 $65', locale: 'zh-HK' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      merchant: "McDonald's",
+      amount: 65,
+      currency: 'HKD',
+      category: 'Food',
+      subcategory: 'Fast Food',
+      participants: ['Casey'],
+      confidence: 0.95,
+      missing_fields: [],
+    });
+  });
+
+  it('returns null for amount when missing', async () => {
+    mockClaudeResponse({
+      ...FULL_PARSE_RESPONSE,
+      amount: null,
+      confidence: 0.5,
+      missing_fields: ['amount'],
+    });
+
+    const res = await request(app)
+      .post('/api/transactions/parse-text')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ text: '食咗麥當勞', locale: 'zh-HK' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.amount).toBeNull();
+    expect(res.body.missing_fields).toContain('amount');
+  });
+
+  it('defaults currency to HKD when not specified', async () => {
+    mockClaudeResponse({ ...FULL_PARSE_RESPONSE, currency: undefined });
+
+    const res = await request(app)
+      .post('/api/transactions/parse-text')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ text: 'bought coffee $30' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.currency).toBe('HKD');
+  });
+
+  it('defaults category to Other for unknown category', async () => {
+    mockClaudeResponse({ ...FULL_PARSE_RESPONSE, category: 'Gambling' });
+
+    const res = await request(app)
+      .post('/api/transactions/parse-text')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ text: 'bet $100' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.category).toBe('Other');
+  });
+
+  it('returns 422 when Claude API throws', async () => {
+    (Anthropic as jest.MockedClass<typeof Anthropic>).mockImplementationOnce(() => ({
+      messages: { create: jest.fn().mockRejectedValue(new Error('API error')) },
+    } as unknown as Anthropic));
+
+    const res = await request(app)
+      .post('/api/transactions/parse-text')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ text: 'lunch $50' });
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toBe('Could not parse transaction text');
+  });
+
+  it('returns 422 when Claude returns non-JSON text', async () => {
+    (Anthropic as jest.MockedClass<typeof Anthropic>).mockImplementationOnce(() => ({
+      messages: {
+        create: jest.fn().mockResolvedValue({
+          content: [{ type: 'text', text: 'I cannot parse this.' }],
+        }),
+      },
+    } as unknown as Anthropic));
+
+    const res = await request(app)
+      .post('/api/transactions/parse-text')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ text: 'lunch $50' });
+
+    expect(res.status).toBe(422);
+  });
+
+  it('enforces rate limit of 30 parses per hour', async () => {
+    const userId = 'rate_limit_user_' + Date.now();
+    const token = jwt.sign({ userId }, JWT_SECRET);
+
+    (Anthropic as jest.MockedClass<typeof Anthropic>).mockImplementation(() => ({
+      messages: {
+        create: jest.fn().mockResolvedValue({
+          content: [{ type: 'text', text: JSON.stringify(FULL_PARSE_RESPONSE) }],
+        }),
+      },
+    } as unknown as Anthropic));
+
+    for (let i = 0; i < 30; i++) {
+      const res = await request(app)
+        .post('/api/transactions/parse-text')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ text: 'lunch $50' });
+      expect(res.status).not.toBe(429);
+    }
+
+    const res = await request(app)
+      .post('/api/transactions/parse-text')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ text: 'lunch $50' });
+    expect(res.status).toBe(429);
+  });
+
+  it('accepts valid locale zh-HK', async () => {
+    mockClaudeResponse(FULL_PARSE_RESPONSE);
+
+    const res = await request(app)
+      .post('/api/transactions/parse-text')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ text: 'coffee $30', locale: 'zh-HK' });
+
+    expect(res.status).toBe(200);
+  });
+
+  it('accepts valid locale en', async () => {
+    mockClaudeResponse(FULL_PARSE_RESPONSE);
+
+    const res = await request(app)
+      .post('/api/transactions/parse-text')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ text: 'coffee $30', locale: 'en' });
+
+    expect(res.status).toBe(200);
+  });
+
+  it('clamps confidence to 0–1 range', async () => {
+    mockClaudeResponse({ ...FULL_PARSE_RESPONSE, confidence: 1.5 });
+
+    const res = await request(app)
+      .post('/api/transactions/parse-text')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ text: 'lunch $50' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.confidence).toBeLessThanOrEqual(1);
+  });
+
+  it('returns empty participants array when none mentioned', async () => {
+    mockClaudeResponse({ ...FULL_PARSE_RESPONSE, participants: [] });
+
+    const res = await request(app)
+      .post('/api/transactions/parse-text')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ text: 'bought coffee $30' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.participants).toEqual([]);
+  });
+
+  it('returns 500 when ANTHROPIC_API_KEY is not set', async () => {
+    const savedKey = process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+
+    const res = await request(app)
+      .post('/api/transactions/parse-text')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ text: 'lunch $50' });
+
+    expect(res.status).toBe(500);
+    process.env.ANTHROPIC_API_KEY = savedKey;
+  });
+});

--- a/src/routes/transactions.ts
+++ b/src/routes/transactions.ts
@@ -1,0 +1,203 @@
+import { Router, Response } from 'express';
+import { body, validationResult } from 'express-validator';
+import Anthropic from '@anthropic-ai/sdk';
+import { protect, AuthRequest } from '../middleware/auth';
+
+const router = Router();
+router.use(protect);
+
+// In-memory rate limiter: userId -> timestamps of requests in the last hour
+const parseTimestamps = new Map<string, number[]>();
+const RATE_LIMIT = 30;
+const RATE_WINDOW_MS = 60 * 60 * 1000;
+
+function isRateLimited(userId: string): boolean {
+  const now = Date.now();
+  const cutoff = now - RATE_WINDOW_MS;
+  const times = (parseTimestamps.get(userId) ?? []).filter((t) => t > cutoff);
+  if (times.length >= RATE_LIMIT) return true;
+  times.push(now);
+  parseTimestamps.set(userId, times);
+  return false;
+}
+
+const CATEGORIES = [
+  'Food',
+  'Transport',
+  'Shopping',
+  'Entertainment',
+  'Health',
+  'Utilities',
+  'Groceries',
+  'Travel',
+  'Education',
+  'Dining',
+  'Subscriptions',
+  'Housing',
+  'Insurance',
+  'Personal Care',
+  'Other',
+];
+
+const SUBCATEGORIES: Record<string, string[]> = {
+  Food: ['Fast Food', 'Restaurant', 'Cafe', 'Bakery', 'Street Food', 'Other'],
+  Transport: ['Bus', 'MTR', 'Taxi', 'Uber', 'Ferry', 'Parking', 'Fuel', 'Other'],
+  Shopping: ['Clothing', 'Electronics', 'Books', 'Home', 'Sports', 'Beauty', 'Other'],
+  Entertainment: ['Cinema', 'Concert', 'Sports', 'Games', 'Streaming', 'Other'],
+  Health: ['Pharmacy', 'Doctor', 'Gym', 'Dental', 'Vision', 'Other'],
+  Utilities: ['Electricity', 'Water', 'Gas', 'Internet', 'Phone', 'Other'],
+  Groceries: ['Supermarket', 'Wet Market', 'Convenience Store', 'Online', 'Other'],
+  Travel: ['Flights', 'Hotel', 'Tour', 'Visa', 'Other'],
+  Education: ['Tuition', 'Books', 'Course', 'Exam', 'Other'],
+  Dining: ['Lunch', 'Dinner', 'Breakfast', 'Brunch', 'Drinks', 'Other'],
+  Subscriptions: ['Streaming', 'Software', 'Membership', 'Other'],
+  Housing: ['Rent', 'Mortgage', 'Maintenance', 'Furniture', 'Other'],
+  Insurance: ['Life', 'Health', 'Car', 'Home', 'Other'],
+  'Personal Care': ['Haircut', 'Skincare', 'Spa', 'Other'],
+  Other: ['Other'],
+};
+
+const PARSE_PROMPT = `You are a financial transaction parser for a Hong Kong expense tracking app.
+Parse the user's natural language text (which may be in Cantonese, English, or a mix) and extract structured transaction data.
+
+Today's date is: {TODAY}
+
+Return ONLY a valid JSON object with exactly these fields:
+- merchant: string | null (merchant or vendor name, translated to English if in Chinese)
+- amount: number | null (numeric amount, null if not mentioned)
+- currency: string (3-letter ISO code; default HKD unless specified; common: HKD, USD, CNY, JPY)
+- category: string (must be one of: ${CATEGORIES.join(', ')})
+- subcategory: string | null (subcategory within the category, or null if unclear)
+- participants: string[] (other people mentioned as sharing the expense, e.g. ["Casey"]; empty array if none)
+- date: string | null (ISO 8601 YYYY-MM-DD; use today if "today"/"今日", infer from context, null if truly unknown)
+- notes: string | null (brief English description of what was purchased)
+- confidence: number (0.0–1.0; high if amount+merchant+date all found, lower if any are missing)
+- missing_fields: string[] (list of field names that could not be determined, e.g. ["amount", "date"])
+
+Rules:
+- Cantonese: 食 = eat/food, 買 = buy, 搭 = take (transport), 去 = go, 今日 = today, 聽日 = tomorrow, 尋日/噚日 = yesterday
+- Common HK merchants: 麥當勞 = McDonald's, 肯德基 = KFC, 大家樂 = Café de Coral, 大快活 = Fairwood, 美心 = Maxim's, 惠康 = Wellcome, 百佳 = ParknShop, 759阿信屋 = 759 Store, 莎莎 = Sa Sa, 屈臣氏 = Watsons
+- $ without currency prefix defaults to HKD in HK context
+- If multiple items, sum them or pick the total; note items in notes field
+- missing_fields should only list: merchant, amount, currency, date (do not list fields with defaults like participants)
+
+Return ONLY the JSON object, no explanation.`;
+
+interface ParsedTransaction {
+  merchant: string | null;
+  amount: number | null;
+  currency: string;
+  category: string;
+  subcategory: string | null;
+  participants: string[];
+  date: string | null;
+  notes: string | null;
+  confidence: number;
+  missing_fields: string[];
+}
+
+function sanitiseResult(raw: Record<string, unknown>): ParsedTransaction {
+  const merchant = typeof raw.merchant === 'string' ? raw.merchant : null;
+  const amount = typeof raw.amount === 'number' && raw.amount > 0 ? raw.amount : null;
+  const currency = typeof raw.currency === 'string' && raw.currency.length === 3 ? raw.currency.toUpperCase() : 'HKD';
+  const category = typeof raw.category === 'string' && CATEGORIES.includes(raw.category) ? raw.category : 'Other';
+  const subcategory = typeof raw.subcategory === 'string' ? raw.subcategory : null;
+  const participants = Array.isArray(raw.participants)
+    ? (raw.participants as unknown[]).filter((p): p is string => typeof p === 'string')
+    : [];
+  const date = typeof raw.date === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(raw.date) ? raw.date : null;
+  const notes = typeof raw.notes === 'string' ? raw.notes : null;
+  const confidence =
+    typeof raw.confidence === 'number' ? Math.min(1, Math.max(0, raw.confidence)) : 0.5;
+  const missing_fields = Array.isArray(raw.missing_fields)
+    ? (raw.missing_fields as unknown[]).filter((f): f is string => typeof f === 'string')
+    : [];
+
+  // Validate subcategory against known subcategories for this category
+  const validSubs = SUBCATEGORIES[category] ?? [];
+  const resolvedSubcategory =
+    subcategory && validSubs.includes(subcategory) ? subcategory : null;
+
+  return { merchant, amount, currency, category, subcategory: resolvedSubcategory, participants, date, notes, confidence, missing_fields };
+}
+
+const parseTextValidation = [
+  body('text')
+    .isString()
+    .withMessage('text must be a string')
+    .trim()
+    .notEmpty()
+    .withMessage('text is required')
+    .isLength({ max: 1000 })
+    .withMessage('text must not exceed 1000 characters'),
+  body('locale')
+    .optional()
+    .isString()
+    .withMessage('locale must be a string')
+    .isIn(['zh-HK', 'en', 'zh-CN'])
+    .withMessage('locale must be one of: zh-HK, en, zh-CN'),
+];
+
+// POST /api/transactions/parse-text
+router.post('/parse-text', parseTextValidation, async (req: AuthRequest, res: Response): Promise<void> => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    res.status(400).json({ error: errors.array()[0].msg });
+    return;
+  }
+
+  const userId = req.userId!;
+
+  if (isRateLimited(userId)) {
+    res.status(429).json({ error: 'Rate limit exceeded. Maximum 30 parses per hour.' });
+    return;
+  }
+
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    res.status(500).json({ error: 'Text parsing is not configured' });
+    return;
+  }
+
+  const { text } = req.body as { text: string; locale?: string };
+  const today = new Date().toISOString().split('T')[0];
+  const prompt = PARSE_PROMPT.replace('{TODAY}', today);
+
+  const client = new Anthropic({ apiKey });
+
+  let rawText: string;
+  try {
+    const message = await client.messages.create({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 512,
+      messages: [
+        {
+          role: 'user',
+          content: `${prompt}\n\nText to parse: "${text}"`,
+        },
+      ],
+    });
+
+    const block = message.content[0];
+    rawText = block.type === 'text' ? block.text : '';
+  } catch (err) {
+    console.error('Claude API error:', err);
+    res.status(422).json({ error: 'Could not parse transaction text' });
+    return;
+  }
+
+  let parsed: ParsedTransaction;
+  try {
+    const jsonMatch = rawText.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) throw new Error('No JSON found in response');
+    const raw = JSON.parse(jsonMatch[0]) as Record<string, unknown>;
+    parsed = sanitiseResult(raw);
+  } catch {
+    res.status(422).json({ error: 'Could not parse transaction text' });
+    return;
+  }
+
+  res.json(parsed);
+});
+
+export default router;


### PR DESCRIPTION
## What
New endpoint `POST /api/transactions/parse-text` that accepts natural language text (Cantonese, English, or mixed) and returns structured transaction data via Claude Haiku.

## Why
Closes #109

## Acceptance Criteria
- [x] Endpoint parses multilingual transaction descriptions (Cantonese, English, mixed)
- [x] Returns structured JSON: merchant, amount, currency, category, subcategory, participants, date, notes, confidence, missing_fields
- [x] Flags missing fields (especially amount) in `missing_fields` array
- [x] Handles edge cases: no merchant, ambiguous dates, null amount, unknown categories
- [x] Rate limited to 30 requests/hour per user (in-memory sliding window)
- [x] Input validation: text required, max 1000 chars, locale optional enum
- [x] Uses Claude Haiku (`claude-haiku-4-5-20251001`) via `@anthropic-ai/sdk`
- [x] JWT auth required
- [x] Graceful error handling — 422 on Claude failure, 500 if API key missing
- [x] 17 tests pass, zero TypeScript errors

## Test Plan
```
# With a valid JWT:
curl -X POST http://localhost:3001/api/transactions/parse-text \
  -H "Authorization: Bearer <token>" \
  -H "Content-Type: application/json" \
  -d '{"text": "我今日同Casey食咗麥當勞巨無霸餐 $65", "locale": "zh-HK"}'

# Expected:
{
  "merchant": "McDonald's",
  "amount": 65,
  "currency": "HKD",
  "category": "Food",
  "subcategory": "Fast Food",
  "participants": ["Casey"],
  "date": "2026-03-27",
  "notes": "Big Mac Meal",
  "confidence": 0.95,
  "missing_fields": []
}
```

cc @QA-agent for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)