### PR TITLE
feat: recurring expenses CRUD API

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -8,6 +8,7 @@ import authRoutes from './routes/auth';
 import expenseRoutes from './routes/expenses';
 import budgetRoutes from './routes/budgets';
 import transactionRoutes from './routes/transactions';
+import recurringRoutes from './routes/recurring';
 
 dotenv.config();
 
@@ -29,6 +30,7 @@ app.use('/auth', authRoutes);
 app.use('/api/expenses', expenseRoutes);
 app.use('/api/budgets', budgetRoutes);
 app.use('/api/transactions', transactionRoutes);
+app.use('/api/recurring', recurringRoutes);
 
 Sentry.setupExpressErrorHandler(app);
 

--- a/src/models/RecurringExpense.ts
+++ b/src/models/RecurringExpense.ts
@@ -1,0 +1,32 @@
+import mongoose, { Document } from 'mongoose';
+
+export interface IRecurringExpense extends Document {
+  userId: string;
+  label: string;
+  item?: string;
+  description: string;
+  amount: number;
+  type: 'income' | 'expense';
+  category?: string;
+  participants?: string[];
+  frequency?: 'monthly' | 'weekly' | 'daily';
+  lastApplied?: string;
+}
+
+const RecurringExpenseSchema = new mongoose.Schema(
+  {
+    userId: { type: String, required: true, index: true },
+    label: { type: String, required: true },
+    item: String,
+    description: { type: String, required: true },
+    amount: { type: Number, required: true, min: 0.01 },
+    type: { type: String, enum: ['income', 'expense'], default: 'expense' },
+    category: String,
+    participants: { type: [String], default: [] },
+    frequency: { type: String, enum: ['monthly', 'weekly', 'daily'], default: 'monthly' },
+    lastApplied: String,
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model<IRecurringExpense>('RecurringExpense', RecurringExpenseSchema);

--- a/src/routes/recurring.ts
+++ b/src/routes/recurring.ts
@@ -1,0 +1,87 @@
+import { Router, Response } from 'express';
+import { body, validationResult } from 'express-validator';
+import RecurringExpense from '../models/RecurringExpense';
+import { protect, AuthRequest } from '../middleware/auth';
+
+const router = Router();
+
+router.use(protect);
+
+const validation = [
+  body('label').notEmpty().withMessage('label is required'),
+  body('description').notEmpty().withMessage('description is required'),
+  body('amount').isNumeric().withMessage('amount must be a number'),
+  body('type').optional().isIn(['income', 'expense']),
+  body('frequency').optional().isIn(['monthly', 'weekly', 'daily']),
+];
+
+// GET /api/recurring
+router.get('/', async (req: AuthRequest, res: Response) => {
+  try {
+    const items = await RecurringExpense.find({ userId: req.userId }).sort({ createdAt: -1 }).lean();
+    res.json(items.map((i) => ({ ...i, id: i._id })));
+  } catch {
+    res.status(500).json({ error: 'Failed to fetch recurring expenses' });
+  }
+});
+
+// POST /api/recurring
+router.post('/', validation, async (req: AuthRequest, res: Response) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    res.status(400).json({ error: errors.array()[0].msg });
+    return;
+  }
+  try {
+    const { label, item, description, amount, type, category, participants, frequency } = req.body;
+    const doc = await RecurringExpense.create({
+      userId: req.userId,
+      label,
+      item,
+      description,
+      amount: parseFloat(amount),
+      type: type || 'expense',
+      category,
+      participants: participants || [],
+      frequency: frequency || 'monthly',
+    });
+    const obj = doc.toObject();
+    res.status(201).json({ ...obj, id: obj._id });
+  } catch (err: any) {
+    res.status(400).json({ error: err.message || 'Failed to create recurring expense' });
+  }
+});
+
+// PUT /api/recurring/:id
+router.put('/:id', async (req: AuthRequest, res: Response) => {
+  try {
+    const doc = await RecurringExpense.findOneAndUpdate(
+      { _id: req.params.id, userId: req.userId },
+      { $set: req.body },
+      { new: true, lean: true }
+    );
+    if (!doc) {
+      res.status(404).json({ error: 'Not found' });
+      return;
+    }
+    res.json({ ...doc, id: doc._id });
+  } catch {
+    res.status(500).json({ error: 'Failed to update recurring expense' });
+  }
+});
+
+// DELETE /api/recurring/:id
+router.delete('/:id', async (req: AuthRequest, res: Response) => {
+  try {
+    const doc = await RecurringExpense.findOneAndDelete({ _id: req.params.id, userId: req.userId });
+    if (!doc) {
+      res.status(404).json({ error: 'Not found' });
+      return;
+    }
+    res.json({ message: 'Deleted' });
+  } catch {
+    res.status(500).json({ error: 'Failed to delete recurring expense' });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- New `RecurringExpense` Mongoose model matching frontend `RecurringItem` interface
- CRUD routes at `/api/recurring` (GET, POST, PUT, DELETE)
- All routes protected by JWT auth middleware
- Supports: label, item, description, amount, type, category, participants, frequency, lastApplied

Part of wkliwk/money-flow-frontend#224

## Test plan
- [ ] `GET /api/recurring` returns empty array for new user
- [ ] `POST /api/recurring` creates a recurring expense
- [ ] `PUT /api/recurring/:id` updates fields
- [ ] `DELETE /api/recurring/:id` removes the item
- [ ] Auth required on all endpoints (401 without token)

🤖 Generated with [Claude Code](https://claude.com/claude-code)