### PR TITLE
feat: add Template model and CRUD routes for /api/templates

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -10,6 +10,7 @@ import budgetRoutes from './routes/budgets';
 import transactionRoutes from './routes/transactions';
 import recurringRoutes from './routes/recurring';
 import goalRoutes from './routes/goals';
+import templateRoutes from './routes/templates';
 
 dotenv.config();
 
@@ -33,6 +34,7 @@ app.use('/api/budgets', budgetRoutes);
 app.use('/api/transactions', transactionRoutes);
 app.use('/api/recurring', recurringRoutes);
 app.use('/api/goals', goalRoutes);
+app.use('/api/templates', templateRoutes);
 
 Sentry.setupExpressErrorHandler(app);
 

--- a/src/models/Template.ts
+++ b/src/models/Template.ts
@@ -1,0 +1,26 @@
+import mongoose, { Document } from 'mongoose';
+
+export interface ITemplate extends Document {
+  userId: string;
+  label: string;
+  item?: string;
+  description: string;
+  type: 'income' | 'expense';
+  category: string;
+  defaultAmount?: number;
+}
+
+const TemplateSchema = new mongoose.Schema(
+  {
+    userId: { type: String, required: true, index: true },
+    label: { type: String, required: true },
+    item: String,
+    description: { type: String, default: '' },
+    type: { type: String, enum: ['income', 'expense'], default: 'expense' },
+    category: { type: String, required: true },
+    defaultAmount: Number,
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model<ITemplate>('Template', TemplateSchema);

--- a/src/routes/templates.ts
+++ b/src/routes/templates.ts
@@ -1,0 +1,67 @@
+import { Router, Response } from 'express';
+import { body, validationResult } from 'express-validator';
+import Template from '../models/Template';
+import { protect, AuthRequest } from '../middleware/auth';
+
+const router = Router();
+
+router.use(protect);
+
+const validation = [
+  body('label').notEmpty().withMessage('label is required'),
+  body('category').notEmpty().withMessage('category is required'),
+  body('type').optional().isIn(['income', 'expense']),
+  body('defaultAmount').optional().isNumeric().withMessage('defaultAmount must be a number'),
+];
+
+// GET /api/templates
+router.get('/', async (req: AuthRequest, res: Response) => {
+  try {
+    const items = await Template.find({ userId: req.userId }).sort({ createdAt: -1 }).lean();
+    res.json(items.map((i) => ({ ...i, id: i._id })));
+  } catch {
+    res.status(500).json({ error: 'Failed to fetch templates' });
+  }
+});
+
+// POST /api/templates
+router.post('/', validation, async (req: AuthRequest, res: Response) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    res.status(400).json({ error: errors.array()[0].msg });
+    return;
+  }
+  try {
+    const { label, item, description, type, category, defaultAmount } = req.body;
+    const doc = await Template.create({
+      userId: req.userId,
+      label,
+      item,
+      description: description || '',
+      type: type || 'expense',
+      category,
+      defaultAmount: defaultAmount !== undefined ? parseFloat(defaultAmount) : undefined,
+    });
+    const obj = doc.toObject();
+    res.status(201).json({ ...obj, id: obj._id });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Failed to create template';
+    res.status(400).json({ error: message });
+  }
+});
+
+// DELETE /api/templates/:id
+router.delete('/:id', async (req: AuthRequest, res: Response) => {
+  try {
+    const doc = await Template.findOneAndDelete({ _id: req.params.id, userId: req.userId });
+    if (!doc) {
+      res.status(404).json({ error: 'Not found' });
+      return;
+    }
+    res.json({ message: 'Deleted' });
+  } catch {
+    res.status(500).json({ error: 'Failed to delete template' });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## What
Adds Mongoose Template model and Express CRUD routes for `/api/templates` (GET, POST, DELETE), following the same pattern as recurring expenses.

## Why
Required by money-flow-frontend#225 — sync transaction templates to backend API

## Acceptance Criteria
- [x] Template Mongoose model with userId, label, item, description, type, category, defaultAmount
- [x] GET /api/templates — returns user's templates sorted by createdAt desc
- [x] POST /api/templates — creates a template with label/category validation
- [x] DELETE /api/templates/:id — deletes owned template (404 if not found)
- [x] All routes protected by auth middleware
- [x] yarn build passes (zero TS errors)

## Test Plan
1. POST /api/templates with valid JWT and `{ label, category }` — returns 201
2. GET /api/templates — returns array
3. DELETE /api/templates/:id — returns `{ message: 'Deleted' }`