### PR TITLE
feat: bank statement scan + reconciliation endpoints (#78)

### DIFF
--- a/src/routes/import.ts
+++ b/src/routes/import.ts
@@ -1,6 +1,7 @@
 import { Router, Response } from 'express';
 import multer from 'multer';
 import { parse } from 'csv-parse/sync';
+import Anthropic from '@anthropic-ai/sdk';
 import ExpenseModel from '../models/Expense';
 import { protect, AuthRequest } from '../middleware/auth';
 
@@ -134,6 +135,248 @@ router.post('/expenses', upload.single('file'), async (req: AuthRequest, res: Re
   }
 
   res.json({ imported, skipped, errors });
+});
+
+// Statement scanning
+
+export interface StatementTxn {
+  date: string;        // YYYY-MM-DD
+  description: string;
+  amount: number;
+  type: 'income' | 'expense';
+}
+
+interface MatchedPair {
+  extracted: StatementTxn;
+  existingId: string;
+  existingDescription: string;
+}
+
+interface Discrepancy {
+  extracted: StatementTxn;
+  existingId: string;
+  existingDescription: string;
+  existingAmount: number;
+  reason: string;
+}
+
+const STATEMENT_MIME_TYPES = [
+  'application/pdf',
+  'image/jpeg',
+  'image/png',
+  'image/heic',
+  'image/heif',
+  'image/webp',
+];
+
+const statementUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 10 * 1024 * 1024 },
+  fileFilter: (_req, file, cb) => {
+    const ok = STATEMENT_MIME_TYPES.some((m) => file.mimetype === m) ||
+      file.originalname.match(/\.(pdf|jpg|jpeg|png|heic|heif|webp)$/i);
+    if (ok) cb(null, true);
+    else cb(new Error('Only PDF and image files are accepted'));
+  },
+});
+
+async function extractTransactionsFromFile(
+  buffer: Buffer,
+  mimeType: string
+): Promise<StatementTxn[]> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) throw new Error('ANTHROPIC_API_KEY not configured');
+
+  const client = new Anthropic({ apiKey });
+  const data = buffer.toString('base64');
+
+  const prompt = `You are extracting transactions from a bank or credit card statement.
+
+Return ONLY a valid JSON array. Each element must have these fields:
+- date: string in YYYY-MM-DD format
+- description: string (merchant or payee name, cleaned up)
+- amount: number (always positive)
+- type: "expense" for debits/withdrawals/purchases, "income" for credits/deposits
+
+Rules:
+- Ignore balance rows, total rows, fee rows labelled as "interest" or "minimum payment"
+- If a row has parentheses around the amount or is labelled as a debit, it is an expense
+- If a row is a credit, deposit, or refund, it is income
+- Do NOT include any text outside the JSON array
+- Do NOT include markdown code blocks
+
+Example output: [{"date":"2026-03-01","description":"Starbucks","amount":45.50,"type":"expense"},{"date":"2026-03-05","description":"Salary","amount":25000,"type":"income"}]`;
+
+  let contentBlock: Anthropic.MessageParam['content'];
+
+  if (mimeType === 'application/pdf') {
+    contentBlock = [
+      {
+        type: 'document' as const,
+        source: { type: 'base64' as const, media_type: 'application/pdf' as const, data },
+      },
+      { type: 'text' as const, text: prompt },
+    ];
+  } else {
+    const imageType = mimeType as 'image/jpeg' | 'image/png' | 'image/webp' | 'image/gif';
+    contentBlock = [
+      {
+        type: 'image' as const,
+        source: { type: 'base64' as const, media_type: imageType, data },
+      },
+      { type: 'text' as const, text: prompt },
+    ];
+  }
+
+  const message = await client.messages.create({
+    model: 'claude-sonnet-4-6',
+    max_tokens: 4096,
+    messages: [{ role: 'user', content: contentBlock }],
+  });
+
+  const block = message.content[0];
+  if (block.type !== 'text') throw new Error('Unexpected response from Claude');
+
+  const text = block.text.trim();
+  const jsonStart = text.indexOf('[');
+  const jsonEnd = text.lastIndexOf(']');
+  if (jsonStart === -1 || jsonEnd === -1) throw new Error('No JSON array found in response');
+
+  const parsed = JSON.parse(text.slice(jsonStart, jsonEnd + 1)) as unknown[];
+  const result: StatementTxn[] = [];
+  for (const item of parsed) {
+    if (typeof item !== 'object' || item === null) continue;
+    const t = item as Record<string, unknown>;
+    if (typeof t.date !== 'string' || typeof t.description !== 'string' || typeof t.amount !== 'number') continue;
+    result.push({
+      date: t.date,
+      description: t.description,
+      amount: Math.abs(t.amount),
+      type: t.type === 'income' ? 'income' : 'expense',
+    });
+  }
+  return result;
+}
+
+async function reconcile(
+  userId: string,
+  extracted: StatementTxn[]
+): Promise<{ matched: MatchedPair[]; missing: StatementTxn[]; discrepancies: Discrepancy[] }> {
+  if (extracted.length === 0) return { matched: [], missing: [], discrepancies: [] };
+
+  const dates = extracted.map((t) => new Date(t.date));
+  const minDate = new Date(Math.min(...dates.map((d) => d.getTime())));
+  const maxDate = new Date(Math.max(...dates.map((d) => d.getTime())));
+  // Expand range by 2 days for matching tolerance
+  minDate.setDate(minDate.getDate() - 2);
+  maxDate.setDate(maxDate.getDate() + 2);
+
+  const existing = await ExpenseModel.find({
+    owner: userId,
+    date: { $gte: minDate, $lte: maxDate },
+  }).lean();
+
+  const matched: MatchedPair[] = [];
+  const discrepancies: Discrepancy[] = [];
+  const missing: StatementTxn[] = [];
+  const usedExistingIds = new Set<string>();
+
+  for (const txn of extracted) {
+    const txnDate = new Date(txn.date);
+    const AMOUNT_TOLERANCE = 0.05;
+    const DATE_TOLERANCE_MS = 2 * 24 * 60 * 60 * 1000; // 2 days
+
+    // Look for exact match: same amount (±tolerance) and same date (±2 days)
+    const exactMatch = existing.find((e) => {
+      if (usedExistingIds.has(String(e._id))) return false;
+      if (e.type !== txn.type) return false;
+      const amountMatch = Math.abs(e.amount - txn.amount) <= AMOUNT_TOLERANCE;
+      const eDateMs = new Date(e.date ?? e.createdAt ?? 0).getTime();
+      const dateMatch = Math.abs(eDateMs - txnDate.getTime()) <= DATE_TOLERANCE_MS;
+      return amountMatch && dateMatch;
+    });
+
+    if (exactMatch) {
+      usedExistingIds.add(String(exactMatch._id));
+      matched.push({
+        extracted: txn,
+        existingId: String(exactMatch._id),
+        existingDescription: (exactMatch.item || exactMatch.description || '') as string,
+      });
+      continue;
+    }
+
+    // Look for same amount but date mismatch → discrepancy
+    const amountMatch = existing.find((e) => {
+      if (usedExistingIds.has(String(e._id))) return false;
+      if (e.type !== txn.type) return false;
+      return Math.abs(e.amount - txn.amount) <= AMOUNT_TOLERANCE;
+    });
+
+    if (amountMatch) {
+      usedExistingIds.add(String(amountMatch._id));
+      discrepancies.push({
+        extracted: txn,
+        existingId: String(amountMatch._id),
+        existingDescription: (amountMatch.item || amountMatch.description || '') as string,
+        existingAmount: amountMatch.amount,
+        reason: 'Date mismatch',
+      });
+      continue;
+    }
+
+    missing.push(txn);
+  }
+
+  return { matched, missing, discrepancies };
+}
+
+// POST /api/import/statement — scan + reconcile (no DB write)
+router.post('/statement', statementUpload.single('file'), async (req: AuthRequest, res: Response): Promise<void> => {
+  if (!req.file) {
+    res.status(400).json({ error: 'No file uploaded' });
+    return;
+  }
+
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    res.status(500).json({ error: 'Statement scanning is not configured' });
+    return;
+  }
+
+  try {
+    const extracted = await extractTransactionsFromFile(req.file.buffer, req.file.mimetype);
+    const { matched, missing, discrepancies } = await reconcile(req.userId!, extracted);
+    res.json({ extracted, matched, missing, discrepancies });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Scan failed';
+    res.status(500).json({ error: msg });
+  }
+});
+
+// POST /api/import/statement/apply — create missing transactions
+router.post('/statement/apply', async (req: AuthRequest, res: Response): Promise<void> => {
+  const transactions = req.body.transactions as StatementTxn[] | undefined;
+  if (!Array.isArray(transactions) || transactions.length === 0) {
+    res.status(400).json({ error: 'No transactions provided' });
+    return;
+  }
+
+  try {
+    const toInsert = transactions.map((t) => ({
+      owner: req.userId!,
+      date: new Date(t.date),
+      description: t.description,
+      amount: t.amount,
+      type: t.type,
+      category: 'Other',
+    }));
+
+    await ExpenseModel.insertMany(toInsert);
+    res.json({ imported: toInsert.length });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to import transactions' });
+  }
 });
 
 export default router;


### PR DESCRIPTION
## Summary
Adds two new endpoints to `POST /api/import/`:

- **`POST /api/import/statement`** — upload PDF or image of bank/CC statement; Claude Sonnet extracts all transactions as JSON; backend reconciles against existing expenses in the same date range. Returns `{extracted, matched, missing, discrepancies}`.
- **`POST /api/import/statement/apply`** — batch-create missing transactions confirmed by the user.

## Reconciliation logic
- **Matched**: same amount (±0.05) and same date (±2 days) as an existing expense → already logged
- **Discrepancy**: same amount but date mismatch → flagged for review
- **Missing**: no match → can be imported

## Test plan
- [ ] Upload a PDF bank statement → transactions extracted correctly
- [ ] Upload an image statement → works
- [ ] Missing transactions returned with correct amounts/dates
- [ ] `POST /apply` creates records, returns `{ imported: N }`
- [ ] `npx tsc --noEmit` — zero errors

Requires `ANTHROPIC_API_KEY` in Railway env (already set from receipt scanning).

Closes #78 (frontend in money-flow-frontend PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)