### PR TITLE
feat: automated daily MongoDB backup to R2

### DIFF
--- a/.github/workflows/daily-backup.yml
+++ b/.github/workflows/daily-backup.yml
@@ -1,0 +1,100 @@
+name: Daily MongoDB Backup
+
+on:
+  schedule:
+    # Run daily at 03:00 UTC (14:00 AEST)
+    - cron: "0 3 * * *"
+  workflow_dispatch: {}
+
+env:
+  BACKUP_RETENTION_DAYS: 30
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install MongoDB tools
+        run: |
+          wget -qO- https://www.mongodb.org/static/pgp/server-7.0.asc | sudo gpg --dearmor -o /usr/share/keyrings/mongodb-server-7.0.gpg
+          echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-7.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-7.0.list
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq mongodb-database-tools
+
+      - name: Run mongodump
+        env:
+          MONGODB_URI: ${{ secrets.MONGODB_URI }}
+        run: |
+          TIMESTAMP=$(date -u +"%Y-%m-%d_%H%M%S")
+          echo "TIMESTAMP=${TIMESTAMP}" >> $GITHUB_ENV
+          echo "BACKUP_FILE=money-flow-backup-${TIMESTAMP}.gz" >> $GITHUB_ENV
+
+          mongodump --uri="${MONGODB_URI}" --gzip --archive="money-flow-backup-${TIMESTAMP}.gz"
+
+          FILESIZE=$(stat -c%s "money-flow-backup-${TIMESTAMP}.gz")
+          echo "Backup size: $(numfmt --to=iec ${FILESIZE})"
+
+          if [ "${FILESIZE}" -lt 100 ]; then
+            echo "ERROR: Backup file suspiciously small (${FILESIZE} bytes). Aborting."
+            exit 1
+          fi
+
+      - name: Upload to Cloudflare R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+        run: |
+          # Install AWS CLI (R2 is S3-compatible)
+          sudo apt-get install -y -qq awscli
+
+          # Configure for R2
+          export AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}"
+          export AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}"
+
+          # Upload backup
+          aws s3 cp "${BACKUP_FILE}" \
+            "s3://${R2_BUCKET}/backups/${BACKUP_FILE}" \
+            --endpoint-url "${R2_ENDPOINT}"
+
+          echo "Uploaded ${BACKUP_FILE} to R2"
+
+      - name: Delete backups older than retention period
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+        run: |
+          export AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}"
+          export AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}"
+
+          CUTOFF_DATE=$(date -u -d "-${BACKUP_RETENTION_DAYS} days" +"%Y-%m-%d")
+          echo "Deleting backups older than ${CUTOFF_DATE}"
+
+          aws s3 ls "s3://${R2_BUCKET}/backups/" \
+            --endpoint-url "${R2_ENDPOINT}" | while read -r line; do
+            FILE_DATE=$(echo "$line" | awk '{print $1}')
+            FILE_NAME=$(echo "$line" | awk '{print $4}')
+            if [ -n "${FILE_NAME}" ] && [ "${FILE_DATE}" \< "${CUTOFF_DATE}" ]; then
+              echo "Deleting old backup: ${FILE_NAME}"
+              aws s3 rm "s3://${R2_BUCKET}/backups/${FILE_NAME}" \
+                --endpoint-url "${R2_ENDPOINT}"
+            fi
+          done
+
+      - name: Notify Telegram on success
+        if: success()
+        run: |
+          FILESIZE=$(stat -c%s "${BACKUP_FILE}")
+          SIZE_HR=$(numfmt --to=iec ${FILESIZE})
+          curl -sf -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+            -d chat_id="${{ secrets.TELEGRAM_CHAT_ID }}" \
+            -d text="DB backup complete: money-flow (${SIZE_HR}) -> R2 [${TIMESTAMP}]" || true
+
+      - name: Notify Telegram on failure
+        if: failure()
+        run: |
+          curl -sf -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+            -d chat_id="${{ secrets.TELEGRAM_CHAT_ID }}" \
+            -d text="DB backup FAILED: money-flow — check Actions log" || true

--- a/BACKUP.md
+++ b/BACKUP.md
@@ -1,0 +1,150 @@
+# MongoDB Backup & Restore
+
+## Overview
+
+Daily automated backups of the Money Flow MongoDB database to Cloudflare R2 (S3-compatible object storage). Backups run via GitHub Actions on a cron schedule.
+
+## Architecture
+
+```
+MongoDB Atlas (M0) --> mongodump (GitHub Actions) --> gzip --> Cloudflare R2 bucket
+```
+
+- **Schedule**: Daily at 03:00 UTC (14:00 AEST)
+- **Retention**: 30 days (older backups auto-deleted)
+- **Storage**: Cloudflare R2 free tier (10GB storage, 1M Class B requests/month)
+- **Format**: gzip-compressed mongodump archive (all collections)
+- **Notifications**: Telegram on success/failure
+
+## Collections Backed Up
+
+All collections in the database are included:
+- users
+- expenses
+- accounts
+- friendships
+- alerts
+- networths
+- recurringexpenses
+- transactiontemplates
+- itemprices
+- weeklypulses
+
+## Required GitHub Secrets
+
+| Secret | Description |
+|---|---|
+| `MONGODB_URI` | Full MongoDB connection string (already set for CI) |
+| `R2_ACCESS_KEY_ID` | Cloudflare R2 API token key ID |
+| `R2_SECRET_ACCESS_KEY` | Cloudflare R2 API token secret |
+| `R2_ENDPOINT` | R2 endpoint URL, e.g. `https://<account-id>.r2.cloudflarestorage.com` |
+| `R2_BUCKET` | R2 bucket name, e.g. `money-flow-backups` |
+| `TELEGRAM_BOT_TOKEN` | Telegram bot token (already set) |
+| `TELEGRAM_CHAT_ID` | Telegram chat ID (already set) |
+
+## Setup: Cloudflare R2
+
+1. Go to Cloudflare Dashboard > R2 Object Storage
+2. Create a bucket named `money-flow-backups`
+3. Go to R2 > Manage R2 API Tokens > Create API Token
+4. Grant the token read/write access to the bucket
+5. Copy the Access Key ID, Secret Access Key, and the S3 endpoint URL
+6. Add all four R2 secrets to the GitHub repo: Settings > Secrets and variables > Actions
+
+## Manual Trigger
+
+To run a backup manually (e.g., before a migration):
+
+```bash
+gh workflow run daily-backup.yml --repo wkliwk/money-flow-backend
+```
+
+Or use the GitHub Actions UI: Actions > Daily MongoDB Backup > Run workflow.
+
+## Restore Procedure
+
+### Prerequisites
+
+- `mongorestore` installed locally (`brew install mongodb-database-tools` on macOS)
+- AWS CLI installed (`brew install awscli`)
+- R2 credentials configured
+
+### Step 1: Configure AWS CLI for R2
+
+```bash
+aws configure --profile r2
+# Access Key ID: <R2_ACCESS_KEY_ID>
+# Secret Access Key: <R2_SECRET_ACCESS_KEY>
+# Region: auto
+# Output format: json
+```
+
+### Step 2: List Available Backups
+
+```bash
+aws s3 ls s3://money-flow-backups/backups/ \
+  --endpoint-url https://<account-id>.r2.cloudflarestorage.com \
+  --profile r2
+```
+
+### Step 3: Download the Backup
+
+```bash
+aws s3 cp s3://money-flow-backups/backups/money-flow-backup-2026-04-04_030012.gz ./restore.gz \
+  --endpoint-url https://<account-id>.r2.cloudflarestorage.com \
+  --profile r2
+```
+
+### Step 4: Restore to MongoDB
+
+**Restore to production (full overwrite):**
+
+```bash
+mongorestore --uri="<MONGODB_URI>" --gzip --archive=restore.gz --drop
+```
+
+The `--drop` flag drops each collection before restoring. Omit it to merge.
+
+**Restore to a local MongoDB for inspection:**
+
+```bash
+mongorestore --host=localhost:27017 --gzip --archive=restore.gz --drop
+```
+
+**Restore a single collection:**
+
+```bash
+mongorestore --uri="<MONGODB_URI>" --gzip --archive=restore.gz \
+  --nsInclude="money-flow.expenses" --drop
+```
+
+### Step 5: Verify
+
+After restoring, check data integrity:
+
+```bash
+mongosh "<MONGODB_URI>" --eval "
+  db.getCollectionNames().forEach(c => {
+    print(c + ': ' + db[c].countDocuments() + ' documents');
+  });
+"
+```
+
+## Disaster Recovery Runbook
+
+1. Identify the issue (data corruption, accidental deletion, etc.)
+2. Determine which backup to restore from (list backups by date)
+3. If partial data loss: restore only the affected collection with `--nsInclude`
+4. If full data loss: restore the most recent backup with `--drop`
+5. Verify document counts match expectations
+6. Notify via Telegram that restore is complete
+7. Post incident report on the GitHub issue
+
+## Cost
+
+Cloudflare R2 free tier:
+- 10 GB storage (estimated backup size: ~5-50 MB/day = ~150 MB-1.5 GB for 30 days)
+- 1,000,000 Class B requests/month (we use ~60: 30 uploads + 30 deletes)
+- No egress fees
+
+This should remain well within free tier for the foreseeable future.


### PR DESCRIPTION
## Summary

- Adds daily MongoDB backup via GitHub Actions (cron at 03:00 UTC)
- Uses `mongodump` to create gzip-compressed archives of all collections
- Uploads to Cloudflare R2 (free tier: 10GB storage, no egress fees)
- Auto-deletes backups older than 30 days
- Sends Telegram notification on success/failure
- Includes `BACKUP.md` with full restore procedure and disaster recovery runbook

Closes #125

## Required Setup (before first run)

Add these GitHub secrets:
- `MONGODB_URI` — already set
- `R2_ACCESS_KEY_ID` — from Cloudflare R2 API token
- `R2_SECRET_ACCESS_KEY` — from Cloudflare R2 API token
- `R2_ENDPOINT` — e.g. `https://<account-id>.r2.cloudflarestorage.com`
- `R2_BUCKET` — e.g. `money-flow-backups`
- `TELEGRAM_BOT_TOKEN` — already set
- `TELEGRAM_CHAT_ID` — already set

## Test plan

- [ ] Create R2 bucket and API token in Cloudflare dashboard
- [ ] Add R2 secrets to GitHub repo settings
- [ ] Trigger workflow manually via `gh workflow run daily-backup.yml`
- [ ] Verify backup file appears in R2 bucket
- [ ] Download backup and run `mongorestore` to local MongoDB to verify integrity
- [ ] Verify Telegram notification received

Generated with [Claude Code](https://claude.com/claude-code)