### PR TITLE
feat: recurring expense auto-creation with scheduled job

### DIFF
--- a/__tests__/processRecurring-error.test.ts
+++ b/__tests__/processRecurring-error.test.ts
@@ -15,11 +15,11 @@ const mockedProcessRecurringExpenses = processRecurringExpenses as jest.MockedFu
 >;
 
 describe('processRecurringJob error handling', () => {
-  it('logs error when processRecurringExpenses throws', async () => {
+  it('logs error and re-throws when processRecurringExpenses throws', async () => {
     const errorSpy = jest.spyOn(console, 'error').mockImplementation();
     mockedProcessRecurringExpenses.mockRejectedValueOnce(new Error('job error'));
 
-    await processRecurringJob();
+    await expect(processRecurringJob()).rejects.toThrow('job error');
 
     expect(errorSpy).toHaveBeenCalledWith(
       '[RecurringJob] Error processing recurring expenses:',

--- a/__tests__/processRecurring.test.ts
+++ b/__tests__/processRecurring.test.ts
@@ -29,10 +29,12 @@ beforeEach(async () => {
 describe('processRecurringJob', () => {
   it('completes successfully with no recurring expenses', async () => {
     const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
-    await processRecurringJob();
+    const result = await processRecurringJob();
     expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining('[RecurringJob] Processed recurring expenses in')
+      expect.stringContaining('[RecurringJob] Processed')
     );
+    expect(result.processed).toBe(0);
+    expect(result.expensesCreated).toBe(0);
     consoleSpy.mockRestore();
   });
 

--- a/__tests__/recurring-auto-creation.test.ts
+++ b/__tests__/recurring-auto-creation.test.ts
@@ -1,0 +1,489 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+process.env.JOBS_API_KEY = 'test-jobs-key';
+
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import mongoose from 'mongoose';
+import request from 'supertest';
+import app from '../src/app';
+import RecurringExpenseModel from '../src/models/RecurringExpense';
+import ExpenseModel from '../src/models/Expense';
+import { processRecurringExpenses, calculateNextOccurrence } from '../src/utils/recurring';
+
+let mongoServer: MongoMemoryServer;
+const testUserId = new mongoose.Types.ObjectId().toString();
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  await mongoose.connect(mongoServer.getUri());
+}, 30000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+beforeEach(async () => {
+  await RecurringExpenseModel.deleteMany({});
+  await ExpenseModel.deleteMany({});
+});
+
+function daysAgo(n: number): Date {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function today(): Date {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function daysFromNow(n: number): Date {
+  const d = new Date();
+  d.setDate(d.getDate() + n);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+describe('Recurring Expense Auto-Creation', () => {
+  describe('Basic expense generation', () => {
+    it('creates an expense when a daily recurring is due', async () => {
+      await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Coffee',
+        amount: 5,
+        category: 'Food',
+        start_date: today(),
+        frequency: 'DAILY',
+      });
+
+      const result = await processRecurringExpenses();
+
+      expect(result.processed).toBe(1);
+      expect(result.expensesCreated).toBe(1);
+
+      const expenses = await ExpenseModel.find({ owner: testUserId });
+      expect(expenses).toHaveLength(1);
+      expect(expenses[0].amount).toBe(5);
+      expect(expenses[0].category).toBe('Food');
+    });
+
+    it('creates an expense for monthly recurring due today', async () => {
+      await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Netflix',
+        amount: 15.99,
+        category: 'Entertainment',
+        start_date: today(),
+        frequency: 'MONTHLY',
+      });
+
+      const result = await processRecurringExpenses();
+
+      expect(result.expensesCreated).toBe(1);
+      const expenses = await ExpenseModel.find({ owner: testUserId });
+      expect(expenses[0].amount).toBe(15.99);
+    });
+
+    it('does not create expenses for future start_date', async () => {
+      await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Future Sub',
+        amount: 10,
+        start_date: daysFromNow(30),
+        frequency: 'MONTHLY',
+      });
+
+      const result = await processRecurringExpenses();
+      expect(result.processed).toBe(0);
+      expect(result.expensesCreated).toBe(0);
+    });
+
+    it('does not create expenses for expired recurring', async () => {
+      await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Old Sub',
+        amount: 10,
+        start_date: daysAgo(60),
+        end_date: daysAgo(1),
+        frequency: 'MONTHLY',
+      });
+
+      const result = await processRecurringExpenses();
+      expect(result.expensesCreated).toBe(0);
+    });
+
+    it('does not create expenses for inactive recurring', async () => {
+      await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Paused Sub',
+        amount: 10,
+        start_date: today(),
+        frequency: 'MONTHLY',
+        active: false,
+      });
+
+      const result = await processRecurringExpenses();
+      expect(result.processed).toBe(0);
+      expect(result.expensesCreated).toBe(0);
+    });
+  });
+
+  describe('nextDueDate advancement', () => {
+    it('advances nextDueDate after processing a daily recurring', async () => {
+      const rec = await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Daily Coffee',
+        amount: 5,
+        start_date: today(),
+        frequency: 'DAILY',
+      });
+
+      await processRecurringExpenses();
+
+      const updated = await RecurringExpenseModel.findById(rec._id);
+      const expectedNext = calculateNextOccurrence(today(), 'DAILY');
+      expect(updated?.nextDueDate.toDateString()).toBe(expectedNext.toDateString());
+    });
+
+    it('advances nextDueDate for monthly frequency', async () => {
+      const startDate = today();
+      const rec = await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Monthly Sub',
+        amount: 20,
+        start_date: startDate,
+        frequency: 'MONTHLY',
+      });
+
+      await processRecurringExpenses();
+
+      const updated = await RecurringExpenseModel.findById(rec._id);
+      const expectedNext = calculateNextOccurrence(startDate, 'MONTHLY');
+      expect(updated?.nextDueDate.toDateString()).toBe(expectedNext.toDateString());
+    });
+
+    it('sets lastProcessedDate after processing', async () => {
+      const rec = await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Sub',
+        amount: 10,
+        start_date: today(),
+        frequency: 'WEEKLY',
+      });
+
+      await processRecurringExpenses();
+
+      const updated = await RecurringExpenseModel.findById(rec._id);
+      expect(updated?.lastProcessedDate).toBeDefined();
+    });
+
+    it('sets processedUntil to the date of the created expense', async () => {
+      const startDate = today();
+      const rec = await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Sub',
+        amount: 10,
+        start_date: startDate,
+        frequency: 'WEEKLY',
+      });
+
+      await processRecurringExpenses();
+
+      const updated = await RecurringExpenseModel.findById(rec._id);
+      expect(updated?.processedUntil?.toDateString()).toBe(startDate.toDateString());
+    });
+  });
+
+  describe('Back-creation of missed expenses', () => {
+    it('creates 3 back-dated daily expenses if server was down 3 days', async () => {
+      await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Daily Vitamin',
+        amount: 1,
+        start_date: daysAgo(3),
+        frequency: 'DAILY',
+      });
+
+      const result = await processRecurringExpenses();
+
+      // Should create expenses for 3 days ago, 2 days ago, 1 day ago, and today = 4
+      expect(result.expensesCreated).toBe(4);
+
+      const expenses = await ExpenseModel.find({ owner: testUserId }).sort({ date: 1 });
+      expect(expenses).toHaveLength(4);
+    });
+
+    it('creates back-dated weekly expenses for missed weeks', async () => {
+      // Started 3 weeks ago, never processed
+      await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Weekly Lesson',
+        amount: 50,
+        start_date: daysAgo(21),
+        frequency: 'WEEKLY',
+      });
+
+      const result = await processRecurringExpenses();
+
+      // 3 weeks ago, 2 weeks ago, 1 week ago, today = 4
+      expect(result.expensesCreated).toBe(4);
+    });
+
+    it('creates back-dated monthly expenses when processedUntil is behind', async () => {
+      // Recurring started 3 months ago, processedUntil set to 2 months ago
+      const threeMonthsAgo = new Date();
+      threeMonthsAgo.setMonth(threeMonthsAgo.getMonth() - 3);
+      threeMonthsAgo.setHours(0, 0, 0, 0);
+
+      const twoMonthsAgo = new Date();
+      twoMonthsAgo.setMonth(twoMonthsAgo.getMonth() - 2);
+      twoMonthsAgo.setHours(0, 0, 0, 0);
+
+      await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Monthly Insurance',
+        amount: 100,
+        start_date: threeMonthsAgo,
+        frequency: 'MONTHLY',
+        processedUntil: twoMonthsAgo,
+        nextDueDate: calculateNextOccurrence(twoMonthsAgo, 'MONTHLY'),
+      });
+
+      const result = await processRecurringExpenses();
+
+      // Should create expenses for 1 month ago and today = 2
+      expect(result.expensesCreated).toBe(2);
+    });
+  });
+
+  describe('Idempotency', () => {
+    it('does not create duplicate expenses on double run', async () => {
+      await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Netflix',
+        amount: 15.99,
+        start_date: today(),
+        frequency: 'MONTHLY',
+      });
+
+      // First run
+      const result1 = await processRecurringExpenses();
+      expect(result1.expensesCreated).toBe(1);
+
+      // Second run -- should create nothing
+      const result2 = await processRecurringExpenses();
+      expect(result2.expensesCreated).toBe(0);
+
+      // Only 1 expense total
+      const expenses = await ExpenseModel.find({ owner: testUserId });
+      expect(expenses).toHaveLength(1);
+    });
+
+    it('remains idempotent with back-created expenses', async () => {
+      await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Daily Vitamin',
+        amount: 1,
+        start_date: daysAgo(2),
+        frequency: 'DAILY',
+      });
+
+      // First run: creates 3 expenses (2 days ago, yesterday, today)
+      const result1 = await processRecurringExpenses();
+      expect(result1.expensesCreated).toBe(3);
+
+      // Second run: creates nothing
+      const result2 = await processRecurringExpenses();
+      expect(result2.expensesCreated).toBe(0);
+
+      const expenses = await ExpenseModel.find({ owner: testUserId });
+      expect(expenses).toHaveLength(3);
+    });
+  });
+
+  describe('calculateNextOccurrence', () => {
+    it('handles DAILY frequency', () => {
+      const d = new Date(2026, 3, 1); // April 1, 2026
+      const next = calculateNextOccurrence(d, 'DAILY');
+      expect(next.getDate()).toBe(2);
+    });
+
+    it('handles WEEKLY frequency', () => {
+      const d = new Date(2026, 3, 1);
+      const next = calculateNextOccurrence(d, 'WEEKLY');
+      expect(next.getDate()).toBe(8);
+    });
+
+    it('handles MONTHLY frequency with month-end capping', () => {
+      const d = new Date(2026, 0, 31); // Jan 31
+      const next = calculateNextOccurrence(d, 'MONTHLY');
+      expect(next.getMonth()).toBe(1); // February
+      expect(next.getDate()).toBe(28); // Feb 28 (2026 is not a leap year)
+    });
+
+    it('handles QUARTERLY frequency', () => {
+      const d = new Date(2026, 0, 15); // Jan 15
+      const next = calculateNextOccurrence(d, 'QUARTERLY');
+      expect(next.getMonth()).toBe(3); // April
+      expect(next.getDate()).toBe(15);
+    });
+
+    it('handles YEARLY frequency', () => {
+      const d = new Date(2026, 5, 15); // June 15, 2026
+      const next = calculateNextOccurrence(d, 'YEARLY');
+      expect(next.getFullYear()).toBe(2027);
+      expect(next.getMonth()).toBe(5);
+    });
+  });
+
+  describe('POST /api/recurring/process endpoint', () => {
+    it('returns 401 without API key', async () => {
+      const res = await request(app).post('/api/recurring/process');
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 401 with wrong API key', async () => {
+      const res = await request(app)
+        .post('/api/recurring/process')
+        .set('x-api-key', 'wrong-key');
+      expect(res.status).toBe(401);
+    });
+
+    it('processes recurring expenses with valid API key', async () => {
+      await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Test Sub',
+        amount: 10,
+        start_date: today(),
+        frequency: 'MONTHLY',
+      });
+
+      const res = await request(app)
+        .post('/api/recurring/process')
+        .set('x-api-key', 'test-jobs-key');
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.expensesCreated).toBe(1);
+      expect(res.body.processed).toBe(1);
+      expect(res.body.durationMs).toBeDefined();
+    });
+
+    it('returns empty result when no recurring expenses are due', async () => {
+      const res = await request(app)
+        .post('/api/recurring/process')
+        .set('x-api-key', 'test-jobs-key');
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.expensesCreated).toBe(0);
+    });
+  });
+
+  describe('Model fields', () => {
+    it('sets nextDueDate to start_date on creation', async () => {
+      const startDate = daysFromNow(5);
+      const rec = await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Future Sub',
+        amount: 10,
+        start_date: startDate,
+        frequency: 'MONTHLY',
+      });
+
+      expect(rec.nextDueDate.toDateString()).toBe(startDate.toDateString());
+    });
+
+    it('defaults active to true', async () => {
+      const rec = await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Sub',
+        amount: 10,
+        start_date: today(),
+        frequency: 'MONTHLY',
+      });
+
+      expect(rec.active).toBe(true);
+    });
+  });
+
+  describe('Processing result details', () => {
+    it('includes details for each processed recurring', async () => {
+      await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Sub A',
+        amount: 10,
+        start_date: today(),
+        frequency: 'MONTHLY',
+      });
+
+      await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Sub B',
+        amount: 20,
+        start_date: today(),
+        frequency: 'WEEKLY',
+      });
+
+      const result = await processRecurringExpenses();
+
+      expect(result.details).toHaveLength(2);
+      expect(result.details.map((d) => d.name).sort()).toEqual(['Sub A', 'Sub B']);
+      expect(result.errors).toBe(0);
+    });
+  });
+
+  describe('Expense content', () => {
+    it('includes description in generated expense when present', async () => {
+      await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Gym',
+        amount: 50,
+        description: 'Monthly membership',
+        start_date: today(),
+        frequency: 'MONTHLY',
+      });
+
+      await processRecurringExpenses();
+
+      const expenses = await ExpenseModel.find({ owner: testUserId });
+      expect(expenses[0].description).toBe('Gym - Monthly membership');
+    });
+
+    it('uses name only when no description', async () => {
+      await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Spotify',
+        amount: 9.99,
+        start_date: today(),
+        frequency: 'MONTHLY',
+      });
+
+      await processRecurringExpenses();
+
+      const expenses = await ExpenseModel.find({ owner: testUserId });
+      expect(expenses[0].description).toBe('Spotify');
+    });
+
+    it('sets correct date on back-dated expenses', async () => {
+      const startDate = daysAgo(2);
+      await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Daily',
+        amount: 1,
+        start_date: startDate,
+        frequency: 'DAILY',
+      });
+
+      await processRecurringExpenses();
+
+      const expenses = await ExpenseModel.find({ owner: testUserId }).sort({ date: 1 });
+      // First expense should be on start_date
+      expect(expenses[0].date?.toDateString()).toBe(startDate.toDateString());
+    });
+  });
+});

--- a/__tests__/recurring-coverage.test.ts
+++ b/__tests__/recurring-coverage.test.ts
@@ -67,11 +67,11 @@ describe('calculateNextOccurrence', () => {
     expect(next.getDate()).toBe(15);
   });
 
-  it('handles MONTHLY with Jan 31 (setMonth overflow to March)', () => {
+  it('handles MONTHLY with Jan 31 (caps to Feb 28)', () => {
     const date = new Date(2026, 0, 31); // Jan 31
     const next = calculateNextOccurrence(date, 'MONTHLY');
-    // setMonth(1) on Jan 31 overflows to Mar 3, then setDate(28) gives Mar 28
-    expect(next.getMonth()).toBe(2); // March (due to JS Date overflow)
+    // Jan 31 + 1 month = Feb 28 (capped to last day of Feb)
+    expect(next.getMonth()).toBe(1); // February
     expect(next.getDate()).toBe(28);
   });
 
@@ -82,11 +82,11 @@ describe('calculateNextOccurrence', () => {
     expect(next.getDate()).toBe(15);
   });
 
-  it('handles QUARTERLY with Jan 31 (setMonth overflow to May)', () => {
+  it('handles QUARTERLY with Jan 31 (caps to Apr 30)', () => {
     const date = new Date(2026, 0, 31); // Jan 31
     const next = calculateNextOccurrence(date, 'QUARTERLY');
-    // setMonth(3) on Jan 31 overflows to May 1, then setDate(30) gives May 30
-    expect(next.getMonth()).toBe(4); // May
+    // Jan 31 + 3 months = Apr 30 (capped to last day of April)
+    expect(next.getMonth()).toBe(3); // April
     expect(next.getDate()).toBe(30);
   });
 });
@@ -284,10 +284,9 @@ describe('processRecurringExpenses', () => {
 
     const expenses = await ExpenseModel.find({
       owner: testUserId,
-      description: 'Daily Coffee',
     });
-    // Should only have 1 since shouldGenerateTransaction checks lastGenerated
-    expect(expenses.length).toBeLessThanOrEqual(2);
+    // Should only have 1 -- processedUntil ensures idempotency
+    expect(expenses).toHaveLength(1);
   });
 
   it('handles per-item errors gracefully', async () => {
@@ -311,7 +310,7 @@ describe('processRecurringExpenses', () => {
     await processRecurringExpenses();
 
     expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Error processing recurring expense'),
+      expect.stringContaining('[RecurringProcessor] Error processing'),
       expect.any(Error)
     );
     errorSpy.mockRestore();

--- a/__tests__/recurring.test.ts
+++ b/__tests__/recurring.test.ts
@@ -223,7 +223,7 @@ describe('Recurring Expenses', () => {
     // Check if transaction was created
     const expenses = await ExpenseModel.find({ owner: testUserId });
     expect(expenses.length).toBeGreaterThan(0);
-    const transaction = expenses.find((e) => e.description === 'Daily Coffee');
+    const transaction = expenses.find((e) => e.description?.includes('Daily Coffee'));
     expect(transaction).toBeDefined();
     expect(transaction?.amount).toBe(5);
   });

--- a/src/jobs/processRecurring.ts
+++ b/src/jobs/processRecurring.ts
@@ -1,17 +1,23 @@
-import { processRecurringExpenses } from '../utils/recurring';
+import { processRecurringExpenses, ProcessingResult } from '../utils/recurring';
 
 /**
- * Background job to process recurring expenses and generate transactions
- * Should be called daily
+ * Background job to process recurring expenses and generate transactions.
+ * Returns the processing result for use by the manual trigger endpoint.
  */
-export async function processRecurringJob(): Promise<void> {
+export async function processRecurringJob(): Promise<ProcessingResult> {
   const start = Date.now();
   try {
-    await processRecurringExpenses();
+    const result = await processRecurringExpenses();
     const duration = Date.now() - start;
-    console.log(`[RecurringJob] Processed recurring expenses in ${duration}ms`);
+    console.log(
+      `[RecurringJob] Processed ${result.processed} recurring expense(s), ` +
+      `created ${result.expensesCreated} expense(s), ` +
+      `${result.errors} error(s) in ${duration}ms`
+    );
+    return result;
   } catch (error) {
     console.error('[RecurringJob] Error processing recurring expenses:', error);
+    throw error;
   }
 }
 

--- a/src/models/RecurringExpense.ts
+++ b/src/models/RecurringExpense.ts
@@ -11,6 +11,10 @@ export interface IRecurringExpense extends Document {
   end_date?: Date;
   frequency: RecurringFrequency;
   description?: string;
+  nextDueDate: Date;
+  lastProcessedDate?: Date;
+  processedUntil?: Date;
+  active: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -29,17 +33,25 @@ const RecurringExpenseSchema = new mongoose.Schema(
       required: true,
     },
     description: { type: String },
+    nextDueDate: { type: Date, index: true },
+    lastProcessedDate: { type: Date },
+    processedUntil: { type: Date },
+    active: { type: Boolean, default: true },
   },
   { timestamps: true }
 );
 
-// Validate that end_date (if set) is after start_date
+// Validate that end_date (if set) is after start_date, and set nextDueDate on creation
 RecurringExpenseSchema.pre('save', function (next) {
   if (this.end_date && this.start_date > this.end_date) {
     next(new Error('end_date must be after start_date'));
-  } else {
-    next();
+    return;
   }
+  // Set nextDueDate to start_date if not already set
+  if (!this.nextDueDate) {
+    this.nextDueDate = this.start_date;
+  }
+  next();
 });
 
 export const RecurringExpenseModel = mongoose.model<IRecurringExpense>(

--- a/src/routes/recurring.ts
+++ b/src/routes/recurring.ts
@@ -1,10 +1,35 @@
-import { Router, Response } from 'express';
+import { Router, Request, Response } from 'express';
 import { body, validationResult } from 'express-validator';
 import RecurringExpenseModel from '../models/RecurringExpense';
 import { protect, AuthRequest } from '../middleware/auth';
 import { validateRecurringData } from '../utils/recurring';
+import { processRecurringJob } from '../jobs/processRecurring';
 
 const router = Router();
+
+// POST /api/recurring/process - manually trigger recurring expense processing
+// Protected by JOBS_API_KEY header (same as other job endpoints)
+router.post('/process', async (req: Request, res: Response) => {
+  const apiKey = process.env.JOBS_API_KEY;
+  if (!apiKey) {
+    res.status(503).json({ error: 'Jobs API key not configured' });
+    return;
+  }
+  const provided = req.headers['x-api-key'];
+  if (!provided || provided !== apiKey) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  const start = Date.now();
+  try {
+    const result = await processRecurringJob();
+    res.json({ ok: true, durationMs: Date.now() - start, ...result });
+  } catch (error) {
+    console.error('[POST /api/recurring/process] Error:', error);
+    res.status(500).json({ error: 'Recurring processing job failed' });
+  }
+});
 
 router.use(protect);
 

--- a/src/utils/recurring.ts
+++ b/src/utils/recurring.ts
@@ -1,6 +1,18 @@
 import RecurringExpenseModel, { RecurringFrequency, IRecurringExpense } from '../models/RecurringExpense';
 import ExpenseModel from '../models/Expense';
 
+export interface ProcessingResult {
+  processed: number;
+  expensesCreated: number;
+  errors: number;
+  details: Array<{
+    recurringId: string;
+    name: string;
+    expensesCreated: number;
+    error?: string;
+  }>;
+}
+
 /**
  * Calculate the next occurrence date for a recurring expense based on frequency
  */
@@ -18,8 +30,9 @@ export function calculateNextOccurrence(date: Date, frequency: RecurringFrequenc
     case 'MONTHLY': {
       const year = next.getFullYear();
       const month = next.getMonth();
-      // Add one month and keep the same day, but cap at the last day of month
       const lastDayOfNextMonth = new Date(year, month + 2, 0).getDate();
+      // Set date to 1 first to avoid overflow when setting month
+      next.setDate(1);
       next.setMonth(month + 1);
       next.setDate(Math.min(originalDay, lastDayOfNextMonth));
       break;
@@ -27,8 +40,9 @@ export function calculateNextOccurrence(date: Date, frequency: RecurringFrequenc
     case 'QUARTERLY': {
       const year = next.getFullYear();
       const month = next.getMonth();
-      // Add 3 months and keep the same day, but cap at the last day of month
       const lastDayOfTargetMonth = new Date(year, month + 4, 0).getDate();
+      // Set date to 1 first to avoid overflow when setting month
+      next.setDate(1);
       next.setMonth(month + 3);
       next.setDate(Math.min(originalDay, lastDayOfTargetMonth));
       break;
@@ -42,95 +56,160 @@ export function calculateNextOccurrence(date: Date, frequency: RecurringFrequenc
 }
 
 /**
- * Check if a recurring expense should generate a transaction today
+ * Normalize a date to midnight UTC for consistent comparison
  */
-function shouldGenerateTransaction(
-  recurring: IRecurringExpense,
-  lastGenerated?: Date
-): boolean {
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-
-  const startDate = new Date(recurring.start_date);
-  startDate.setHours(0, 0, 0, 0);
-
-  // Not started yet
-  if (startDate > today) {
-    return false;
-  }
-
-  // Already expired
-  if (recurring.end_date) {
-    const endDate = new Date(recurring.end_date);
-    endDate.setHours(0, 0, 0, 0);
-    if (endDate < today) {
-      return false;
-    }
-  }
-
-  // If no last generated, check if start date is today or past
-  if (!lastGenerated) {
-    return startDate <= today;
-  }
-
-  // Check if next occurrence is today or past
-  const lastGenDate = new Date(lastGenerated);
-  lastGenDate.setHours(0, 0, 0, 0);
-  const nextOccurrence = calculateNextOccurrence(lastGenDate, recurring.frequency);
-  nextOccurrence.setHours(0, 0, 0, 0);
-
-  return nextOccurrence <= today;
+function toMidnight(date: Date): Date {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  return d;
 }
 
 /**
- * Process all recurring expenses and generate transactions for today
- * Called daily by the cron job
+ * Process a single recurring expense, creating all missed expenses up to today.
+ * Uses processedUntil to guarantee idempotency -- if the job runs twice,
+ * no duplicate expenses are created.
  */
-export async function processRecurringExpenses(): Promise<void> {
-  try {
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
+async function processSingleRecurring(
+  recurring: IRecurringExpense
+): Promise<{ expensesCreated: number }> {
+  const now = new Date();
+  const today = toMidnight(now);
+  let expensesCreated = 0;
 
-    const recurringExpenses = await RecurringExpenseModel.find({
-      start_date: { $lte: today },
-      $or: [{ end_date: { $exists: false } }, { end_date: { $gte: today } }],
+  // Determine the starting point for generating expenses.
+  // If processedUntil exists, we start from there (already processed up to that date).
+  // Otherwise, start from start_date (first occurrence).
+  let cursor: Date;
+  if (recurring.processedUntil) {
+    // processedUntil marks the last date we created an expense for,
+    // so advance to the next occurrence from there
+    cursor = calculateNextOccurrence(new Date(recurring.processedUntil), recurring.frequency);
+  } else {
+    // Never processed: first expense should be on start_date
+    cursor = toMidnight(new Date(recurring.start_date));
+  }
+
+  // Cap at end_date if set
+  const endDate = recurring.end_date ? toMidnight(new Date(recurring.end_date)) : null;
+
+  // Generate all missed expenses up to today
+  // Safety: cap at 365 iterations to prevent runaway loops
+  let iterations = 0;
+  const MAX_ITERATIONS = 365;
+
+  while (toMidnight(cursor) <= today && iterations < MAX_ITERATIONS) {
+    // Stop if past end_date
+    if (endDate && toMidnight(cursor) > endDate) {
+      break;
+    }
+
+    // Create the expense entry
+    await ExpenseModel.create({
+      owner: recurring.userId,
+      description: recurring.description
+        ? `${recurring.name} - ${recurring.description}`
+        : recurring.name,
+      amount: recurring.amount,
+      category: recurring.category || undefined,
+      type: 'expense',
+      date: new Date(cursor),
     });
 
-    for (const recurring of recurringExpenses) {
-      try {
-        // Find the most recent generated expense for this recurring item
-        const lastGenerated = await ExpenseModel.findOne(
-          {
-            owner: recurring.userId,
-            description: recurring.name,
-            category: recurring.category,
-            amount: recurring.amount,
-            type: 'expense',
-          },
-          { createdAt: 1 },
-          { sort: { createdAt: -1 } }
-        ).lean();
+    expensesCreated++;
 
-        // Check if we should generate a new transaction
-        if (shouldGenerateTransaction(recurring, lastGenerated?.createdAt as Date)) {
-          // Create the expense
-          await ExpenseModel.create({
-            owner: recurring.userId,
-            description: recurring.name,
-            amount: recurring.amount,
-            category: recurring.category,
-            type: 'expense',
-            date: today,
-            notes: `Auto-generated from recurring: ${recurring.name}`,
-          });
-        }
-      } catch (error) {
-        console.error(`Error processing recurring expense ${recurring._id}:`, error);
+    // Update processedUntil atomically to ensure idempotency
+    await RecurringExpenseModel.updateOne(
+      { _id: recurring._id },
+      {
+        $set: {
+          processedUntil: new Date(cursor),
+          lastProcessedDate: now,
+          nextDueDate: calculateNextOccurrence(new Date(cursor), recurring.frequency),
+        },
       }
-    }
-  } catch (error) {
-    console.error('Error processing recurring expenses:', error);
+    );
+
+    // Advance cursor
+    cursor = calculateNextOccurrence(new Date(cursor), recurring.frequency);
+    iterations++;
   }
+
+  return { expensesCreated };
+}
+
+/**
+ * Process all due recurring expenses.
+ * Idempotent: uses processedUntil to track what's been generated.
+ * Back-creates missed expenses if the server was down.
+ */
+export async function processRecurringExpenses(): Promise<ProcessingResult> {
+  const result: ProcessingResult = {
+    processed: 0,
+    expensesCreated: 0,
+    errors: 0,
+    details: [],
+  };
+
+  const today = toMidnight(new Date());
+
+  // Find all active recurring expenses that are due.
+  // A recurring expense is due if:
+  // 1. It has nextDueDate <= today, OR
+  // 2. It has no processedUntil and start_date <= today (legacy/new records)
+  const recurringExpenses = await RecurringExpenseModel.find({
+    active: { $ne: false },
+    start_date: { $lte: today },
+    $and: [
+      {
+        $or: [
+          { end_date: { $exists: false } },
+          { end_date: null },
+          { end_date: { $gte: today } },
+        ],
+      },
+      {
+        $or: [
+          { nextDueDate: { $lte: today } },
+          { nextDueDate: { $exists: false } },
+          { processedUntil: { $exists: false }, start_date: { $lte: today } },
+        ],
+      },
+    ],
+  });
+
+  for (const recurring of recurringExpenses) {
+    try {
+      const { expensesCreated } = await processSingleRecurring(recurring);
+      result.processed++;
+      result.expensesCreated += expensesCreated;
+      result.details.push({
+        recurringId: String(recurring._id),
+        name: recurring.name,
+        expensesCreated,
+      });
+
+      if (expensesCreated > 0) {
+        console.log(
+          `[RecurringProcessor] Created ${expensesCreated} expense(s) for "${recurring.name}" (${recurring._id})`
+        );
+      }
+    } catch (error) {
+      result.errors++;
+      const message = error instanceof Error ? error.message : String(error);
+      result.details.push({
+        recurringId: String(recurring._id),
+        name: recurring.name,
+        expensesCreated: 0,
+        error: message,
+      });
+      console.error(
+        `[RecurringProcessor] Error processing "${recurring.name}" (${recurring._id}):`,
+        error
+      );
+    }
+  }
+
+  return result;
 }
 
 /**


### PR DESCRIPTION
## What
Implements automatic creation of expense entries from recurring expense definitions. A scheduled job runs daily and a manual trigger endpoint is available for testing.

## Why
Closes #131

Users could define recurring expenses (e.g. Netflix $15.99/month) but had to manually add the expense each time. Now expenses are auto-created when due.

## Acceptance Criteria
- [x] Scheduled job runs daily to process due recurring expenses
- [x] Creates actual expense documents with correct amount, category, description, and date
- [x] `nextDueDate` advanced correctly for each frequency (daily, weekly, monthly, quarterly, yearly)
- [x] Back-creates all missed expenses if server was down (capped at 365 iterations for safety)
- [x] No duplicate expenses on repeated runs (idempotent via `processedUntil` field)
- [x] `POST /api/recurring/process` endpoint for manual triggering (API key protected)
- [x] Processing logged with details (which recurring processed, count, errors)
- [x] Non-blocking -- uses async processing within existing Express process

## Changes
- **Model**: Added `nextDueDate`, `lastProcessedDate`, `processedUntil`, `active` fields to RecurringExpense
- **Processing**: Rewrote `processRecurringExpenses()` to use `processedUntil` for idempotency and back-creation
- **Endpoint**: Added `POST /api/recurring/process` with API key auth (same pattern as other job endpoints)
- **Bug fix**: Fixed month-end overflow in `calculateNextOccurrence` (Jan 31 + 1 month now correctly gives Feb 28)
- **Tests**: 29 new tests for auto-creation, updated 4 existing test files

## Test Plan
1. Create a recurring expense with `start_date` set to today
2. Call `POST /api/recurring/process` with `x-api-key` header
3. Verify an expense document was created with correct fields
4. Call process again -- verify no duplicate expense
5. Create a recurring expense with `start_date` 3 days ago, process, verify 4 expenses created (3 back-dated + today)

All 458 tests pass (40 suites).