### PR TITLE
feat: add change-password endpoint for email/password users

### DIFF
--- a/__tests__/users-password.test.ts
+++ b/__tests__/users-password.test.ts
@@ -1,0 +1,143 @@
+import request from 'supertest';
+import express from 'express';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import userRoutes from '../src/routes/users';
+import UserModel from '../src/models/User';
+
+let mongoServer: MongoMemoryServer;
+const JWT_SECRET = 'test-secret-key';
+let app: express.Application;
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  process.env.JWT_SECRET = JWT_SECRET;
+  await mongoose.connect(mongoServer.getUri());
+
+  app = express();
+  app.use(express.json());
+  app.use('/api/users', userRoutes);
+}, 30000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+afterEach(async () => {
+  await UserModel.deleteMany({});
+});
+
+const generateToken = (userId: string) => {
+  return jwt.sign({ userId }, JWT_SECRET);
+};
+
+describe('PATCH /api/users/password', () => {
+  it('changes password successfully with correct current password', async () => {
+    const user = await UserModel.create({ email: 'user@test.com', password: 'password123' });
+    const token = generateToken((user._id as mongoose.Types.ObjectId).toString());
+
+    const res = await request(app)
+      .patch('/api/users/password')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ currentPassword: 'password123', newPassword: 'newpass456' });
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Password updated');
+  });
+
+  it('allows login with new password after change', async () => {
+    const user = await UserModel.create({ email: 'user@test.com', password: 'password123' });
+    const token = generateToken((user._id as mongoose.Types.ObjectId).toString());
+
+    await request(app)
+      .patch('/api/users/password')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ currentPassword: 'password123', newPassword: 'newpass456' });
+
+    const updated = await UserModel.findById(user._id);
+    const matches = await updated!.comparePassword('newpass456');
+    expect(matches).toBe(true);
+  });
+
+  it('old password no longer works after change', async () => {
+    const user = await UserModel.create({ email: 'user@test.com', password: 'password123' });
+    const token = generateToken((user._id as mongoose.Types.ObjectId).toString());
+
+    await request(app)
+      .patch('/api/users/password')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ currentPassword: 'password123', newPassword: 'newpass456' });
+
+    const updated = await UserModel.findById(user._id);
+    const matches = await updated!.comparePassword('password123');
+    expect(matches).toBe(false);
+  });
+
+  it('rejects incorrect current password with 400', async () => {
+    const user = await UserModel.create({ email: 'user@test.com', password: 'password123' });
+    const token = generateToken((user._id as mongoose.Types.ObjectId).toString());
+
+    const res = await request(app)
+      .patch('/api/users/password')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ currentPassword: 'wrongpassword', newPassword: 'newpass456' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Current password is incorrect');
+  });
+
+  it('rejects new password shorter than 6 characters', async () => {
+    const user = await UserModel.create({ email: 'user@test.com', password: 'password123' });
+    const token = generateToken((user._id as mongoose.Types.ObjectId).toString());
+
+    const res = await request(app)
+      .patch('/api/users/password')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ currentPassword: 'password123', newPassword: 'short' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/6 characters/);
+  });
+
+  it('rejects missing currentPassword', async () => {
+    const user = await UserModel.create({ email: 'user@test.com', password: 'password123' });
+    const token = generateToken((user._id as mongoose.Types.ObjectId).toString());
+
+    const res = await request(app)
+      .patch('/api/users/password')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ newPassword: 'newpass456' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/currentPassword/);
+  });
+
+  it('rejects missing newPassword', async () => {
+    const user = await UserModel.create({ email: 'user@test.com', password: 'password123' });
+    const token = generateToken((user._id as mongoose.Types.ObjectId).toString());
+
+    const res = await request(app)
+      .patch('/api/users/password')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ currentPassword: 'password123' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for account with no password set (social login)', async () => {
+    const id = new mongoose.Types.ObjectId();
+    await UserModel.collection.insertOne({ _id: id, email: 'social@test.com', budgets: [] });
+    const token = generateToken(id.toString());
+
+    const res = await request(app)
+      .patch('/api/users/password')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ currentPassword: 'anything', newPassword: 'newpass456' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Password change not available for social login accounts');
+  });
+
+  it('rejects unauthenticated request with 401', async () => {
+    const res = await request(app)
+      .patch('/api/users/password')
+      .send({ currentPassword: 'password123', newPassword: 'newpass456' });
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -59,4 +59,54 @@ router.patch(
   }
 );
 
+// PATCH /api/users/password
+router.patch(
+  '/password',
+  [
+    body('currentPassword')
+      .notEmpty()
+      .withMessage('currentPassword is required'),
+    body('newPassword')
+      .isLength({ min: 6 })
+      .withMessage('newPassword must be at least 6 characters'),
+  ],
+  async (req: AuthRequest, res: Response) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({ error: errors.array()[0].msg });
+      return;
+    }
+
+    try {
+      const { currentPassword, newPassword } = req.body as {
+        currentPassword: string;
+        newPassword: string;
+      };
+
+      const user = await UserModel.findById(req.userId);
+      if (!user) {
+        res.status(404).json({ error: 'User not found' });
+        return;
+      }
+
+      if (!user.password) {
+        res.status(400).json({ error: 'Password change not available for social login accounts' });
+        return;
+      }
+
+      const isMatch = await user.comparePassword(currentPassword);
+      if (!isMatch) {
+        res.status(400).json({ error: 'Current password is incorrect' });
+        return;
+      }
+
+      user.password = newPassword;
+      await user.save();
+
+      res.json({ message: 'Password updated' });
+    } catch {
+      res.status(500).json({ error: 'Failed to update password' });
+    }
+  }
+);
 export default router;


### PR DESCRIPTION
## What
Add `PATCH /api/users/password` endpoint that lets authenticated email/password users change their password.

## Why
Closes #135

## Acceptance Criteria
- [x] `PATCH /api/users/password` endpoint exists and is protected by auth middleware
- [x] Request body requires `currentPassword` (string) and `newPassword` (string, min 6 chars)
- [x] Validates that `currentPassword` matches the user's existing password (using bcrypt compare)
- [x] Returns 400 if current password is wrong, with `{ "error": "Current password is incorrect" }`
- [x] Returns 400 if new password fails validation (too short), with descriptive error
- [x] Returns 400 if user is a social-auth-only account (no password set), with `{ "error": "Password change not available for social login accounts" }`
- [x] On success, hashes and saves the new password, returns 200 with `{ "message": "Password updated" }`
- [x] Does NOT invalidate existing JWT tokens (keep it simple)
- [x] Input validation uses `express-validator` consistent with other routes
- [x] `yarn build` passes

## Test Plan
- Run `npx jest __tests__/users-password.test.ts` -- 9 tests covering:
  - Successful password change
  - New password works after change
  - Old password no longer works after change
  - Incorrect current password rejected (400)
  - New password too short rejected (400)
  - Missing currentPassword rejected (400)
  - Missing newPassword rejected (400)
  - Social-auth account without password rejected (400)
  - Unauthenticated request rejected (401)

🤖 Generated with [Claude Code](https://claude.com/claude-code)