### PR TITLE
perf: add compound index on owner+category+date

### DIFF
--- a/src/models/Expense.ts
+++ b/src/models/Expense.ts
@@ -82,6 +82,7 @@ const ExpenseSchema = new mongoose.Schema(
 
 ExpenseSchema.index({ owner: 1, date: -1 });
 ExpenseSchema.index({ owner: 1, _id: 1 });
+ExpenseSchema.index({ owner: 1, category: 1, date: -1 }); // budget + report queries filtered by category
 
 export { PAYMENT_METHODS, SUPPORTED_CURRENCIES };
 export type { SupportedCurrency };


### PR DESCRIPTION
## What
Add compound index `{ owner: 1, category: 1, date: -1 }` to the Expense model.

## Why
Closes #153

Budget calculations and report endpoints (`/api/insights/summary`, `/api/reports/monthly`) query expenses filtered by owner + category + date range. Without this index, MongoDB does a collection scan within the owner's documents. The new index enables an index scan for these queries.

## Acceptance Criteria
- [x] Add index `{ owner: 1, category: 1, date: -1 }` to `src/models/Expense.ts`
- [x] No duplicate of existing indexes (existing ones don't include category)
- [x] Build passes (`yarn build`)
- [x] Brief comment explaining what queries the index supports

## Test Plan
- `yarn build` passes
- After deploy, verify index creation in MongoDB Atlas under the Expenses collection indexes tab
- Run `/api/insights/summary` and `/api/reports/monthly` -- confirm no regression

Generated with [Claude Code](https://claude.com/claude-code)