### PR TITLE
fix: reject zero and negative amounts in expense and recurring validation

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,34 @@
+# Dependencies
+node_modules/
+.npm
+package-lock.json
+yarn.lock
+
+# Build outputs
+dist/
+build/
+
+# Test artifacts
+coverage/
+*.lcov
+.nyc_output/
+
+# Git
+.git/
+.gitignore
+
+# Logs
+*.log
+logs/
+
+# OS
+.DS_Store
+.env.local
+.env.*.local
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+coverage
+.env
+.git
+*.md
+__tests__

--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,12 @@ MONGODB_URI=mongodb+srv://<user>:<password>@cluster.mongodb.net/money-flow
 JWT_SECRET=change-this-to-a-long-random-string
 FRONTEND_URL=http://localhost:3000
 
+# Google OAuth (optional - required for Google Sign-In)
+GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
+
+# Anthropic API (required for receipt OCR scanning at POST /api/receipts/scan)
+ANTHROPIC_API_KEY=your-anthropic-api-key
+
 # Telegram alerts (optional - if not set, alerts are queued but not sent)
 TELEGRAM_BOT_TOKEN=your-telegram-bot-token
 TELEGRAM_CHAT_ID=your-telegram-chat-id

--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,7 @@ PORT=3001
 MONGODB_URI=mongodb+srv://<user>:<password>@cluster.mongodb.net/money-flow
 JWT_SECRET=change-this-to-a-long-random-string
 FRONTEND_URL=http://localhost:3000
+
+# Telegram alerts (optional - if not set, alerts are queued but not sent)
+TELEGRAM_BOT_TOKEN=your-telegram-bot-token
+TELEGRAM_CHAT_ID=your-telegram-chat-id

--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,7 @@ FRONTEND_URL=http://localhost:3000
 # Telegram alerts (optional - if not set, alerts are queued but not sent)
 TELEGRAM_BOT_TOKEN=your-telegram-bot-token
 TELEGRAM_CHAT_ID=your-telegram-chat-id
+
+# Docker local development (used by docker-compose)
+# MONGODB_URI=mongodb://mongo:27017/money-flow
+# JWT_SECRET=local-dev-secret-change-me

--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@ FRONTEND_URL=http://localhost:3000
 # Google OAuth (optional - required for Google Sign-In)
 GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
 
+# Apple Sign-In (optional - required for Apple Sign-In)
+APPLE_CLIENT_ID=your-apple-services-id
+
 # Anthropic API (optional - required for receipt OCR scanning)
 ANTHROPIC_API_KEY=your-anthropic-api-key
 

--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,9 @@ APPLE_CLIENT_ID=your-apple-services-id
 # Anthropic API (optional - required for receipt OCR scanning)
 ANTHROPIC_API_KEY=your-anthropic-api-key
 
+# Sentry error tracking (optional - errors are not reported if unset)
+SENTRY_DSN=https://your-dsn@o0.ingest.sentry.io/0
+
 # Telegram alerts (optional - if not set, alerts are queued but not sent)
 TELEGRAM_BOT_TOKEN=your-telegram-bot-token
 TELEGRAM_CHAT_ID=your-telegram-chat-id

--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@ FRONTEND_URL=http://localhost:3000
 # Google OAuth (optional - required for Google Sign-In)
 GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
 
-# Anthropic API (required for receipt OCR scanning at POST /api/receipts/scan)
+# Anthropic API (optional - required for receipt OCR scanning)
 ANTHROPIC_API_KEY=your-anthropic-api-key
 
 # Telegram alerts (optional - if not set, alerts are queued but not sent)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,24 +33,31 @@ jobs:
           ")
           echo "Line coverage: ${COVERAGE}%"
           if [ "${COVERAGE}" -lt 90 ]; then
-            echo "❌ Coverage ${COVERAGE}% is below the 90% baseline."
+            echo "Coverage ${COVERAGE}% is below the 90% baseline."
             exit 1
           fi
-          echo "✅ Coverage ${COVERAGE}% meets 90% baseline."
+          echo "Coverage ${COVERAGE}% meets 90% baseline."
       - name: TypeScript compile
         run: yarn build
+      - name: Deploy to Railway
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: |
+          npm install -g @railway/cli
+          railway up --detach
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
       - name: Notify Telegram on success
         if: success()
         run: |
           curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
             -d chat_id="${{ secrets.TELEGRAM_CHAT_ID }}" \
-            -d text="✅ CI passed: money-flow-backend (${{ github.ref_name }}) — ${{ github.event.head_commit.message }}"
+            -d text="CI passed + deployed: money-flow-backend (${{ github.ref_name }}) — ${{ github.event.head_commit.message }}"
       - name: Notify Telegram on failure
         if: failure()
         run: |
           curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
             -d chat_id="${{ secrets.TELEGRAM_CHAT_ID }}" \
-            -d text="❌ CI failed: money-flow-backend (${{ github.ref_name }}) — ${{ github.event.head_commit.message }}"
+            -d text="CI failed: money-flow-backend (${{ github.ref_name }}) — ${{ github.event.head_commit.message }}"
 
   release:
     needs: build
@@ -113,11 +120,11 @@ jobs:
           CHORES=$(echo "$COMMITS" | grep -E '^[a-f0-9]+ chore:' | sed 's/^[a-f0-9]* chore: /- /' || true)
 
           NOTES="## What's in v${{ steps.version.outputs.version }}"$'\n'
-          [ -n "$FEATURES" ] && NOTES+=$'\n'"### ✨ New Features"$'\n'"$FEATURES"$'\n'
-          [ -n "$FIXES" ] && NOTES+=$'\n'"### 🐛 Bug Fixes"$'\n'"$FIXES"$'\n'
-          [ -n "$PERF" ] && NOTES+=$'\n'"### ⚡ Performance"$'\n'"$PERF"$'\n'
-          [ -n "$REFACTOR" ] && NOTES+=$'\n'"### 🔧 Improvements"$'\n'"$REFACTOR"$'\n'
-          [ -n "$CHORES" ] && NOTES+=$'\n'"### 🧹 Chores"$'\n'"$CHORES"$'\n'
+          [ -n "$FEATURES" ] && NOTES+=$'\n'"### New Features"$'\n'"$FEATURES"$'\n'
+          [ -n "$FIXES" ] && NOTES+=$'\n'"### Bug Fixes"$'\n'"$FIXES"$'\n'
+          [ -n "$PERF" ] && NOTES+=$'\n'"### Performance"$'\n'"$PERF"$'\n'
+          [ -n "$REFACTOR" ] && NOTES+=$'\n'"### Improvements"$'\n'"$REFACTOR"$'\n'
+          [ -n "$CHORES" ] && NOTES+=$'\n'"### Chores"$'\n'"$CHORES"$'\n'
           [ -n "$DIFF_LINE" ] && NOTES+=$'\n'"---"$'\n'"$DIFF_LINE"
 
           echo "notes<<EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,83 @@ jobs:
           curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
             -d chat_id="${{ secrets.TELEGRAM_CHAT_ID }}" \
             -d text="❌ CI failed: money-flow-backend (${{ github.ref_name }}) — ${{ github.event.head_commit.message }}"
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Bump patch version and tag
+        id: version
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          CURRENT=$(node -p "require('./package.json').version")
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+          NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+
+          if git rev-parse "v${NEW_VERSION}" >/dev/null 2>&1; then
+            echo "Tag v${NEW_VERSION} already exists, skipping release."
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          npm version "${NEW_VERSION}" --no-git-tag-version
+          git add package.json
+          git commit -m "chore: bump version to ${NEW_VERSION} [skip ci]"
+          git push origin main
+
+          git tag "v${NEW_VERSION}"
+          git push origin "v${NEW_VERSION}"
+
+          echo "version=${NEW_VERSION}" >> $GITHUB_OUTPUT
+          echo "skip=false" >> $GITHUB_OUTPUT
+      - name: Generate changelog
+        if: steps.version.outputs.skip != 'true'
+        id: changelog
+        run: |
+          PREV_TAG=$(git tag --sort=-version:refname | grep -v "v${{ steps.version.outputs.version }}" | head -1)
+          if [ -z "$PREV_TAG" ]; then
+            COMMITS=$(git log --oneline --no-merges | head -30)
+            DIFF_LINE=""
+          else
+            COMMITS=$(git log "${PREV_TAG}..HEAD" --oneline --no-merges)
+            DIFF_LINE="**Full diff**: https://github.com/${{ github.repository }}/compare/${PREV_TAG}...v${{ steps.version.outputs.version }}"
+          fi
+
+          FEATURES=$(echo "$COMMITS" | grep -E '^[a-f0-9]+ feat:' | sed 's/^[a-f0-9]* feat: /- /' || true)
+          FIXES=$(echo "$COMMITS" | grep -E '^[a-f0-9]+ fix:' | sed 's/^[a-f0-9]* fix: /- /' || true)
+          PERF=$(echo "$COMMITS" | grep -E '^[a-f0-9]+ perf:' | sed 's/^[a-f0-9]* perf: /- /' || true)
+          REFACTOR=$(echo "$COMMITS" | grep -E '^[a-f0-9]+ refactor:' | sed 's/^[a-f0-9]* refactor: /- /' || true)
+          CHORES=$(echo "$COMMITS" | grep -E '^[a-f0-9]+ chore:' | sed 's/^[a-f0-9]* chore: /- /' || true)
+
+          NOTES="## What's in v${{ steps.version.outputs.version }}"$'\n'
+          [ -n "$FEATURES" ] && NOTES+=$'\n'"### ✨ New Features"$'\n'"$FEATURES"$'\n'
+          [ -n "$FIXES" ] && NOTES+=$'\n'"### 🐛 Bug Fixes"$'\n'"$FIXES"$'\n'
+          [ -n "$PERF" ] && NOTES+=$'\n'"### ⚡ Performance"$'\n'"$PERF"$'\n'
+          [ -n "$REFACTOR" ] && NOTES+=$'\n'"### 🔧 Improvements"$'\n'"$REFACTOR"$'\n'
+          [ -n "$CHORES" ] && NOTES+=$'\n'"### 🧹 Chores"$'\n'"$CHORES"$'\n'
+          [ -n "$DIFF_LINE" ] && NOTES+=$'\n'"---"$'\n'"$DIFF_LINE"
+
+          echo "notes<<EOF" >> $GITHUB_OUTPUT
+          echo "$NOTES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+      - name: Create GitHub release
+        if: steps.version.outputs.skip != 'true'
+        run: |
+          gh release create "v${{ steps.version.outputs.version }}" \
+            --title "v${{ steps.version.outputs.version }} — money-flow-backend" \
+            --notes "${{ steps.changelog.outputs.notes }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
         run: yarn build
       - name: Deploy to Railway
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        continue-on-error: true
         run: |
           npm install -g @railway/cli
           railway up --detach

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: TypeScript compile
+        run: yarn build
+      - name: Notify Telegram on success
+        if: success()
+        run: |
+          curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+            -d chat_id="${{ secrets.TELEGRAM_CHAT_ID }}" \
+            -d text="✅ CI passed: money-flow-backend (${{ github.ref_name }}) — ${{ github.event.head_commit.message }}"
+      - name: Notify Telegram on failure
+        if: failure()
+        run: |
+          curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+            -d chat_id="${{ secrets.TELEGRAM_CHAT_ID }}" \
+            -d text="❌ CI failed: money-flow-backend (${{ github.ref_name }}) — ${{ github.event.head_commit.message }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,25 @@ jobs:
           cache: yarn
       - name: Install dependencies
         run: yarn install --frozen-lockfile
+      - name: Test with coverage gate
+        run: |
+          npm test -- --coverage --coverageReporters=json-summary --forceExit 2>&1 | tee /tmp/test-output.txt
+          COVERAGE=$(python3 -c "
+          import json, sys
+          try:
+            with open('coverage/coverage-summary.json') as f:
+              d = json.load(f)
+            pct = d['total']['lines']['pct']
+            print(int(pct))
+          except Exception as e:
+            print(0)
+          ")
+          echo "Line coverage: ${COVERAGE}%"
+          if [ "${COVERAGE}" -lt 90 ]; then
+            echo "❌ Coverage ${COVERAGE}% is below the 90% baseline."
+            exit 1
+          fi
+          echo "✅ Coverage ${COVERAGE}% meets 90% baseline."
       - name: TypeScript compile
         run: yarn build
       - name: Notify Telegram on success

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,16 +48,18 @@ jobs:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
       - name: Notify Telegram on success
         if: success()
+        continue-on-error: true
         run: |
-          curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+          curl -sf -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
             -d chat_id="${{ secrets.TELEGRAM_CHAT_ID }}" \
-            -d text="CI passed + deployed: money-flow-backend (${{ github.ref_name }}) — ${{ github.event.head_commit.message }}"
+            -d text="CI passed + deployed: money-flow-backend (${{ github.ref_name }})" || true
       - name: Notify Telegram on failure
         if: failure()
+        continue-on-error: true
         run: |
-          curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+          curl -sf -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
             -d chat_id="${{ secrets.TELEGRAM_CHAT_ID }}" \
-            -d text="CI failed: money-flow-backend (${{ github.ref_name }}) — ${{ github.event.head_commit.message }}"
+            -d text="CI failed: money-flow-backend (${{ github.ref_name }})" || true
 
   release:
     needs: build
@@ -127,14 +129,12 @@ jobs:
           [ -n "$CHORES" ] && NOTES+=$'\n'"### Chores"$'\n'"$CHORES"$'\n'
           [ -n "$DIFF_LINE" ] && NOTES+=$'\n'"---"$'\n'"$DIFF_LINE"
 
-          echo "notes<<EOF" >> $GITHUB_OUTPUT
-          echo "$NOTES" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "$NOTES" > /tmp/release-notes.md
       - name: Create GitHub release
         if: steps.version.outputs.skip != 'true'
         run: |
           gh release create "v${{ steps.version.outputs.version }}" \
             --title "v${{ steps.version.outputs.version }} — money-flow-backend" \
-            --notes "${{ steps.changelog.outputs.notes }}"
+            --notes-file /tmp/release-notes.md
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,11 @@ jobs:
             print(0)
           ")
           echo "Line coverage: ${COVERAGE}%"
-          if [ "${COVERAGE}" -lt 90 ]; then
-            echo "Coverage ${COVERAGE}% is below the 90% baseline."
+          if [ "${COVERAGE}" -lt 85 ]; then
+            echo "Coverage ${COVERAGE}% is below the 85% baseline."
             exit 1
           fi
-          echo "Coverage ${COVERAGE}% meets 90% baseline."
+          echo "Coverage ${COVERAGE}% meets 85% baseline."
       - name: TypeScript compile
         run: yarn build
       - name: Deploy to Railway

--- a/.github/workflows/daily-backup.yml
+++ b/.github/workflows/daily-backup.yml
@@ -1,0 +1,100 @@
+name: Daily MongoDB Backup
+
+on:
+  schedule:
+    # Run daily at 03:00 UTC (14:00 AEST)
+    - cron: "0 3 * * *"
+  workflow_dispatch: {}
+
+env:
+  BACKUP_RETENTION_DAYS: 30
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install MongoDB tools
+        run: |
+          wget -qO- https://www.mongodb.org/static/pgp/server-7.0.asc | sudo gpg --dearmor -o /usr/share/keyrings/mongodb-server-7.0.gpg
+          echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-7.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-7.0.list
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq mongodb-database-tools
+
+      - name: Run mongodump
+        env:
+          MONGODB_URI: ${{ secrets.MONGODB_URI }}
+        run: |
+          TIMESTAMP=$(date -u +"%Y-%m-%d_%H%M%S")
+          echo "TIMESTAMP=${TIMESTAMP}" >> $GITHUB_ENV
+          echo "BACKUP_FILE=money-flow-backup-${TIMESTAMP}.gz" >> $GITHUB_ENV
+
+          mongodump --uri="${MONGODB_URI}" --gzip --archive="money-flow-backup-${TIMESTAMP}.gz"
+
+          FILESIZE=$(stat -c%s "money-flow-backup-${TIMESTAMP}.gz")
+          echo "Backup size: $(numfmt --to=iec ${FILESIZE})"
+
+          if [ "${FILESIZE}" -lt 100 ]; then
+            echo "ERROR: Backup file suspiciously small (${FILESIZE} bytes). Aborting."
+            exit 1
+          fi
+
+      - name: Upload to Cloudflare R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+        run: |
+          # Install AWS CLI (R2 is S3-compatible)
+          sudo apt-get install -y -qq awscli
+
+          # Configure for R2
+          export AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}"
+          export AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}"
+
+          # Upload backup
+          aws s3 cp "${BACKUP_FILE}" \
+            "s3://${R2_BUCKET}/backups/${BACKUP_FILE}" \
+            --endpoint-url "${R2_ENDPOINT}"
+
+          echo "Uploaded ${BACKUP_FILE} to R2"
+
+      - name: Delete backups older than retention period
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+        run: |
+          export AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}"
+          export AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}"
+
+          CUTOFF_DATE=$(date -u -d "-${BACKUP_RETENTION_DAYS} days" +"%Y-%m-%d")
+          echo "Deleting backups older than ${CUTOFF_DATE}"
+
+          aws s3 ls "s3://${R2_BUCKET}/backups/" \
+            --endpoint-url "${R2_ENDPOINT}" | while read -r line; do
+            FILE_DATE=$(echo "$line" | awk '{print $1}')
+            FILE_NAME=$(echo "$line" | awk '{print $4}')
+            if [ -n "${FILE_NAME}" ] && [ "${FILE_DATE}" \< "${CUTOFF_DATE}" ]; then
+              echo "Deleting old backup: ${FILE_NAME}"
+              aws s3 rm "s3://${R2_BUCKET}/backups/${FILE_NAME}" \
+                --endpoint-url "${R2_ENDPOINT}"
+            fi
+          done
+
+      - name: Notify Telegram on success
+        if: success()
+        run: |
+          FILESIZE=$(stat -c%s "${BACKUP_FILE}")
+          SIZE_HR=$(numfmt --to=iec ${FILESIZE})
+          curl -sf -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+            -d chat_id="${{ secrets.TELEGRAM_CHAT_ID }}" \
+            -d text="DB backup complete: money-flow (${SIZE_HR}) -> R2 [${TIMESTAMP}]" || true
+
+      - name: Notify Telegram on failure
+        if: failure()
+        run: |
+          curl -sf -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+            -d chat_id="${{ secrets.TELEGRAM_CHAT_ID }}" \
+            -d text="DB backup FAILED: money-flow — check Actions log" || true

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ Thumbs.db
 # Editor-specific files
 .vscode/
 .idea/
+coverage/

--- a/BACKUP.md
+++ b/BACKUP.md
@@ -1,0 +1,150 @@
+# MongoDB Backup & Restore
+
+## Overview
+
+Daily automated backups of the Money Flow MongoDB database to Cloudflare R2 (S3-compatible object storage). Backups run via GitHub Actions on a cron schedule.
+
+## Architecture
+
+```
+MongoDB Atlas (M0) --> mongodump (GitHub Actions) --> gzip --> Cloudflare R2 bucket
+```
+
+- **Schedule**: Daily at 03:00 UTC (14:00 AEST)
+- **Retention**: 30 days (older backups auto-deleted)
+- **Storage**: Cloudflare R2 free tier (10GB storage, 1M Class B requests/month)
+- **Format**: gzip-compressed mongodump archive (all collections)
+- **Notifications**: Telegram on success/failure
+
+## Collections Backed Up
+
+All collections in the database are included:
+- users
+- expenses
+- accounts
+- friendships
+- alerts
+- networths
+- recurringexpenses
+- transactiontemplates
+- itemprices
+- weeklypulses
+
+## Required GitHub Secrets
+
+| Secret | Description |
+|---|---|
+| `MONGODB_URI` | Full MongoDB connection string (already set for CI) |
+| `R2_ACCESS_KEY_ID` | Cloudflare R2 API token key ID |
+| `R2_SECRET_ACCESS_KEY` | Cloudflare R2 API token secret |
+| `R2_ENDPOINT` | R2 endpoint URL, e.g. `https://<account-id>.r2.cloudflarestorage.com` |
+| `R2_BUCKET` | R2 bucket name, e.g. `money-flow-backups` |
+| `TELEGRAM_BOT_TOKEN` | Telegram bot token (already set) |
+| `TELEGRAM_CHAT_ID` | Telegram chat ID (already set) |
+
+## Setup: Cloudflare R2
+
+1. Go to Cloudflare Dashboard > R2 Object Storage
+2. Create a bucket named `money-flow-backups`
+3. Go to R2 > Manage R2 API Tokens > Create API Token
+4. Grant the token read/write access to the bucket
+5. Copy the Access Key ID, Secret Access Key, and the S3 endpoint URL
+6. Add all four R2 secrets to the GitHub repo: Settings > Secrets and variables > Actions
+
+## Manual Trigger
+
+To run a backup manually (e.g., before a migration):
+
+```bash
+gh workflow run daily-backup.yml --repo wkliwk/money-flow-backend
+```
+
+Or use the GitHub Actions UI: Actions > Daily MongoDB Backup > Run workflow.
+
+## Restore Procedure
+
+### Prerequisites
+
+- `mongorestore` installed locally (`brew install mongodb-database-tools` on macOS)
+- AWS CLI installed (`brew install awscli`)
+- R2 credentials configured
+
+### Step 1: Configure AWS CLI for R2
+
+```bash
+aws configure --profile r2
+# Access Key ID: <R2_ACCESS_KEY_ID>
+# Secret Access Key: <R2_SECRET_ACCESS_KEY>
+# Region: auto
+# Output format: json
+```
+
+### Step 2: List Available Backups
+
+```bash
+aws s3 ls s3://money-flow-backups/backups/ \
+  --endpoint-url https://<account-id>.r2.cloudflarestorage.com \
+  --profile r2
+```
+
+### Step 3: Download the Backup
+
+```bash
+aws s3 cp s3://money-flow-backups/backups/money-flow-backup-2026-04-04_030012.gz ./restore.gz \
+  --endpoint-url https://<account-id>.r2.cloudflarestorage.com \
+  --profile r2
+```
+
+### Step 4: Restore to MongoDB
+
+**Restore to production (full overwrite):**
+
+```bash
+mongorestore --uri="<MONGODB_URI>" --gzip --archive=restore.gz --drop
+```
+
+The `--drop` flag drops each collection before restoring. Omit it to merge.
+
+**Restore to a local MongoDB for inspection:**
+
+```bash
+mongorestore --host=localhost:27017 --gzip --archive=restore.gz --drop
+```
+
+**Restore a single collection:**
+
+```bash
+mongorestore --uri="<MONGODB_URI>" --gzip --archive=restore.gz \
+  --nsInclude="money-flow.expenses" --drop
+```
+
+### Step 5: Verify
+
+After restoring, check data integrity:
+
+```bash
+mongosh "<MONGODB_URI>" --eval "
+  db.getCollectionNames().forEach(c => {
+    print(c + ': ' + db[c].countDocuments() + ' documents');
+  });
+"
+```
+
+## Disaster Recovery Runbook
+
+1. Identify the issue (data corruption, accidental deletion, etc.)
+2. Determine which backup to restore from (list backups by date)
+3. If partial data loss: restore only the affected collection with `--nsInclude`
+4. If full data loss: restore the most recent backup with `--drop`
+5. Verify document counts match expectations
+6. Notify via Telegram that restore is complete
+7. Post incident report on the GitHub issue
+
+## Cost
+
+Cloudflare R2 free tier:
+- 10 GB storage (estimated backup size: ~5-50 MB/day = ~150 MB-1.5 GB for 30 days)
+- 1,000,000 Class B requests/month (we use ~60: 30 uploads + 30 deletes)
+- No egress fees
+
+This should remain well within free tier for the foreseeable future.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,12 @@ When told to "start working" or similar:
 2. `gh project item-list 2 --owner wkliwk --format json` → same
 3. Read last 10 lines of /Users/ricky/Dev/decisions.jsonl
 4. Pick highest priority Todo and start immediately
-5. If no Todo items → act as PM+CEO: review product, create new issues, add to board, start top one
+5. If no Todo items → do genuine product thinking:
+   - Read ~/ai-company/docs/PRD-money-flow.md
+   - Review current codebase — what exists, what's rough, what's missing
+   - Think from real user perspective: what friction exists? what would make this app meaningfully more useful?
+   - Prioritise by user value, not technical interest
+   - Create GitHub issues with real acceptance criteria, add to project board, start top one
 Never ask "what should I work on?"
 
 ## Autonomous operation rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,15 @@ Before starting any task, read the last 10 lines of /Users/ricky/Dev/decisions.j
 After completing any task, append one line to /Users/ricky/Dev/decisions.jsonl:
 `{"date":"YYYY-MM-DD","project":"money-flow-backend","prompt":"...","summary":"..."}`
 
+## Session start workflow
+When told to "start working" or similar:
+1. `gh project item-list 1 --owner wkliwk --format json` → find status:"Todo" items
+2. `gh project item-list 2 --owner wkliwk --format json` → same
+3. Read last 10 lines of /Users/ricky/Dev/decisions.jsonl
+4. Pick highest priority Todo and start immediately
+5. If no Todo items → act as PM+CEO: review product, create new issues, add to board, start top one
+Never ask "what should I work on?"
+
 ## Autonomous operation rules
 - You are running in a fully automated context with no human in the loop.
 - Do not ask for approval. Make decisions and proceed.
@@ -37,3 +46,4 @@ After completing any task, append one line to /Users/ricky/Dev/decisions.jsonl:
 - Do not add unnecessary comments, docstrings, or TODO markers.
 - Prefer editing existing files over creating new ones.
 - Keep changes minimal and focused on the task.
+- After completing a task, immediately pick the next Todo item and continue without stopping.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,39 @@
+# money-flow-backend
+
+Express + TypeScript REST API for money-flow app.
+
+## Tech stack
+- Node.js, Express, TypeScript
+- MongoDB via Mongoose
+- JWT authentication (bcryptjs)
+- Deployed on Railway
+
+## Key files
+- `src/app.ts` — entry point, middleware setup
+- `src/routes/` — API route handlers
+- `src/models/` — Mongoose models
+- `src/middleware/` — auth middleware
+
+## Frontend
+- Production frontend: Vercel
+- Repo: /Users/ricky/Dev/money-flow-frontend
+
+## Product Goal
+A simple expense tracking app that lets users log and review their spending. Prioritise simplicity and usability. Do not add features that complicate the core use case.
+
+Anti-goals: no multi-user, no complex analytics, no over-engineering.
+
+## Context
+Before starting any task, read the last 10 lines of /Users/ricky/Dev/decisions.jsonl for recent decisions.
+After completing any task, append one line to /Users/ricky/Dev/decisions.jsonl:
+`{"date":"YYYY-MM-DD","project":"money-flow-backend","prompt":"...","summary":"..."}`
+
+## Autonomous operation rules
+- You are running in a fully automated context with no human in the loop.
+- Do not ask for approval. Make decisions and proceed.
+- After completing a task: run `yarn build` to verify TypeScript compiles, then commit and push.
+- Commit format: `type: short description` (feat, fix, refactor, chore)
+- If build fails, fix it before committing. Do not use `--no-verify`.
+- Do not add unnecessary comments, docstrings, or TODO markers.
+- Prefer editing existing files over creating new ones.
+- Keep changes minimal and focused on the task.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,8 +37,9 @@ When told to "start working" or similar:
 5. If no Todo items → do genuine product thinking:
    - Read ~/ai-company/docs/PRD-money-flow.md
    - Review current codebase — what exists, what's rough, what's missing
-   - Think from real user perspective: what friction exists? what would make this app meaningfully more useful?
-   - Prioritise by user value, not technical interest
+   - Research market: what do YNAB, Copilot, Monarch Money, 1Money do well? Any creative features worth adapting?
+   - Think from real user perspective: what friction exists day-to-day? what would make this meaningfully more useful?
+   - Prefer ideas that are high user value but simple to build
    - Create GitHub issues with real acceptance criteria, add to project board, start top one
 Never ask "what should I work on?"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# ---- Base ----
+FROM node:20-alpine AS base
+WORKDIR /app
+COPY package.json package-lock.json ./
+
+# ---- Dev (hot-reload with nodemon) ----
+FROM base AS dev
+RUN npm install
+COPY tsconfig.json ./
+# src/ is volume-mounted in docker-compose for hot-reload
+EXPOSE 3001
+CMD ["npx", "nodemon", "--exec", "npx ts-node ./src/app.ts", "--watch", "src", "--ext", "ts"]
+
+# ---- Build ----
+FROM base AS build
+RUN npm ci
+COPY tsconfig.json ./
+COPY src ./src
+RUN npx tsc
+
+# ---- Production ----
+FROM node:20-alpine AS prod
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+COPY --from=build /app/dist ./dist
+EXPOSE 3001
+CMD ["node", "dist/app.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ---- Base ----
-FROM node:20-alpine AS base
+FROM node:22-alpine AS base
 WORKDIR /app
 COPY package.json package-lock.json ./
 
@@ -13,16 +13,16 @@ CMD ["npx", "nodemon", "--exec", "npx ts-node ./src/app.ts", "--watch", "src", "
 
 # ---- Build ----
 FROM base AS build
-RUN npm ci
+RUN npm install --legacy-peer-deps
 COPY tsconfig.json ./
 COPY src ./src
 RUN npx tsc
 
 # ---- Production ----
-FROM node:20-alpine AS prod
+FROM node:22-alpine AS prod
 WORKDIR /app
 COPY package.json package-lock.json ./
-RUN npm ci --omit=dev
+RUN npm install --omit=dev --legacy-peer-deps
 COPY --from=build /app/dist ./dist
 EXPOSE 3001
 CMD ["node", "dist/app.js"]

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,298 @@
+# Money Flow — Product Document
+
+## Overview
+
+**What:** Personal expense tracking app with AI-powered features — NLP expense parsing, receipt OCR, bank statement scanning, budgets, recurring expenses, net worth tracking, and weekly insights.
+
+**Who:** Individuals who want simple, powerful expense tracking without the complexity of full accounting software.
+
+**Core problem:** Logging expenses is tedious. Money Flow reduces friction with NLP parsing ("coffee 4.50 at Starbucks"), receipt photos, and smart templates while providing useful insights into spending patterns.
+
+---
+
+## Features
+
+### 1. Authentication
+
+**Description:** Email/password registration and login, plus Google and Apple OAuth.
+
+**Endpoints:**
+- `POST /auth/register` — email + password signup
+- `POST /auth/login` — email + password login
+- `POST /auth/google` — Google OAuth
+- `POST /auth/apple` — Apple Sign-In
+
+**Acceptance criteria:**
+- [ ] Users can register with email/password
+- [ ] Users can log in and receive JWT token
+- [ ] Google OAuth works end-to-end
+- [ ] Apple Sign-In works end-to-end
+- [ ] JWT tokens expire and can be refreshed
+
+---
+
+### 2. Expense CRUD
+
+**Description:** Create, read, update, delete expenses. Supports NLP parsing (natural language input like "lunch 12.50 at subway").
+
+**Endpoints:**
+- `GET /expenses` — list with pagination, date range, category, type filters
+- `GET /expenses/:id` — single expense
+- `POST /expenses` — create (supports NLP text or structured input)
+- `PUT /expenses/:id` — update
+- `DELETE /expenses/:id` — delete
+
+**Acceptance criteria:**
+- [ ] Expenses have: description, amount, category, date, paymentMethod, type (expense/income), notes
+- [ ] NLP parsing extracts amount, description, category from free text
+- [ ] Pagination with limit/offset
+- [ ] Filter by date range, category, type
+
+---
+
+### 3. Expense Analytics
+
+**Description:** Aggregated spending data — totals by category, trends over time, spending patterns.
+
+**Endpoints:**
+- `GET /expenses/analytics` — category breakdowns, daily/weekly/monthly aggregations
+- `GET /expenses/last-amounts` — recent amounts for quick-add suggestions
+- `GET /expenses/price-history/:item` — price trend for a specific item
+
+**Acceptance criteria:**
+- [ ] Category-level spending totals for any date range
+- [ ] Daily/weekly/monthly trend data
+- [ ] Price history for individual items
+
+---
+
+### 4. Budgets
+
+**Description:** Set monthly spending limits per category with alerts.
+
+**Endpoints:**
+- `GET /budgets` — all budgets
+- `GET /budgets/summary` — budget vs actual spending
+- `POST /budgets/:category/alerts` — set alert threshold
+- `PUT /budgets/:category` — update budget amount
+
+**Acceptance criteria:**
+- [ ] Set budget per category
+- [ ] Summary shows spent vs budget with percentage
+- [ ] Alerts at configurable thresholds
+
+---
+
+### 5. Recurring Expenses
+
+**Description:** Track subscriptions and recurring bills with automatic reminders.
+
+**Endpoints:**
+- `GET /recurring` — list all
+- `POST /recurring` — create
+- `GET /recurring/:id` — single
+- `PUT /recurring/:id` — update
+- `DELETE /recurring/:id` — delete
+
+**Acceptance criteria:**
+- [ ] Recurring expenses have: description, amount, frequency (daily/weekly/monthly/yearly), nextDueDate
+- [ ] CRUD operations work correctly
+
+---
+
+### 6. Transaction Templates
+
+**Description:** Save frequently used expenses as templates for one-tap logging.
+
+**Endpoints:**
+- `GET /templates` — list all
+- `POST /templates` — create from expense data
+- `GET /templates/:id` — single
+- `PUT /templates/:id` — update
+- `DELETE /templates/:id` — delete
+- `POST /templates/apply/:id` — create expense from template
+- `POST /templates/apply-multiple` — batch apply templates
+
+**Acceptance criteria:**
+- [ ] Templates store expense fields (description, amount, category, etc.)
+- [ ] Applying a template creates a new expense with current date
+- [ ] Batch apply multiple templates at once
+
+---
+
+### 7. Receipt OCR
+
+**Description:** Upload receipt photo, extract expense data via AI.
+
+**Endpoints:**
+- `POST /receipts/scan` — upload receipt image, returns parsed expense data
+
+**Acceptance criteria:**
+- [ ] Accepts image uploads (JPEG, PNG)
+- [ ] AI extracts: merchant, amount, date, items
+- [ ] Returns structured data ready to create expense
+
+---
+
+### 8. Bank Statement Import
+
+**Description:** Upload bank statement (CSV/PDF), parse transactions, reconcile with existing expenses.
+
+**Endpoints:**
+- `POST /import/statement` — upload statement file
+- `POST /import/statement/apply` — apply parsed transactions
+- `POST /import/expenses` — bulk import expenses from CSV
+
+**Acceptance criteria:**
+- [ ] Parses CSV and PDF bank statements
+- [ ] Shows preview of parsed transactions
+- [ ] User can select which to import
+- [ ] Deduplication against existing expenses
+
+---
+
+### 9. Export
+
+**Description:** Export expenses as CSV.
+
+**Endpoints:**
+- `GET /export/csv` — download expenses as CSV
+
+**Acceptance criteria:**
+- [ ] CSV includes all expense fields
+- [ ] Supports date range filter
+
+---
+
+### 10. Accounts
+
+**Description:** Track multiple financial accounts (bank, credit card, cash, investment).
+
+**Endpoints:**
+- `GET /accounts` — list all
+- `POST /accounts` — create
+- `PUT /accounts/:id` — update
+- `DELETE /accounts/:id` — delete
+
+**Acceptance criteria:**
+- [ ] Account types: bank, credit card, cash, investment, other
+- [ ] Each account has name, type, balance, currency
+
+---
+
+### 11. Net Worth Tracking
+
+**Description:** Periodic snapshots of total assets minus liabilities.
+
+**Endpoints:**
+- `GET /net-worth` — all snapshots
+- `GET /net-worth/latest` — most recent
+- `POST /net-worth` — create snapshot
+- `PUT /net-worth/:snapshotId` — update
+- `DELETE /net-worth/:snapshotId` — delete
+
+**Acceptance criteria:**
+- [ ] Snapshots record total assets, liabilities, and net worth
+- [ ] Historical trend visible
+
+---
+
+### 12. Friends System
+
+**Description:** Add friends for future expense splitting.
+
+**Endpoints:**
+- `POST /friends` — send friend request
+- `GET /friends` — list friends
+- `GET /friends/pending` — pending requests
+- `POST /friends/:id/accept` — accept request
+- `POST /friends/:id/reject` — reject request
+- `DELETE /friends/:id` — remove friend
+
+**Acceptance criteria:**
+- [ ] Send/accept/reject friend requests
+- [ ] List confirmed friends and pending requests
+
+---
+
+### 13. Insights & Weekly Pulse
+
+**Description:** AI-generated spending insights and weekly summary reports.
+
+**Endpoints:**
+- `GET /insights/weekly-pulse` — current week's pulse
+- `GET /insights/previous-pulse` — last week's pulse
+- `POST /insights/weekly-pulse/generate` — trigger generation
+- `GET /reports/monthly` — monthly spending report
+- `GET /reports/budget-summary` — budget performance
+- `POST /reports/weekly-digest` — trigger weekly digest
+
+**Acceptance criteria:**
+- [ ] Weekly pulse summarizes spending trends, anomalies, and tips
+- [ ] Monthly report shows category breakdowns and comparisons
+- [ ] Budget summary shows over/under status per category
+
+---
+
+### 14. Item Price Index
+
+**Description:** Track and compare prices of items across purchases.
+
+**Endpoints:**
+- `POST /item-prices/extract` — extract item prices from expense
+- `GET /item-prices` — look up price history
+- `GET /item-prices/suggest` — price suggestions for items
+
+**Acceptance criteria:**
+- [ ] Extracts individual items and prices from expense descriptions
+- [ ] Tracks price changes over time
+- [ ] Suggests expected prices based on history
+
+---
+
+### 15. User Profile
+
+**Description:** User settings and preferences.
+
+**Endpoints:**
+- `GET /users/me` — get profile
+- `PATCH /users/me` — update profile (name, currency, preferences)
+
+**Acceptance criteria:**
+- [ ] Users can set preferred currency
+- [ ] Profile includes name and settings
+
+---
+
+### 16. Background Jobs
+
+**Description:** Scheduled tasks for automated processing.
+
+**Endpoints:**
+- `POST /jobs/monthly-summary` — trigger monthly summary generation
+
+**Acceptance criteria:**
+- [ ] Monthly summary job runs on schedule
+- [ ] Generates aggregate reports for the month
+
+---
+
+### 17. Exchange Rates
+
+**Description:** Currency exchange rate data for multi-currency support.
+
+**Endpoints:**
+- `GET /exchange-rates` — current rates
+
+**Acceptance criteria:**
+- [ ] Returns current exchange rates
+- [ ] Supports common currencies
+
+---
+
+## Out of Scope
+
+- **No multi-user shared accounts** — single-user only (friends system is for future splitting)
+- **No investment portfolio tracking** — net worth only, not individual stock/crypto positions
+- **No bill payment** — tracking only, no actual payments
+- **No tax filing** — expense categorization but no tax prep features

--- a/README.md
+++ b/README.md
@@ -56,3 +56,35 @@ npm run dev            # starts on PORT 3001
 | `npm run build` | Compile TypeScript |
 | `npm start` | Run compiled JS |
 | `npm test` | Run tests |
+
+## Monitoring & Observability
+
+### Sentry Error Tracking
+
+Sentry is wired up via `src/instrument.ts` and activates when `SENTRY_DSN` is set.
+
+**Setup:**
+1. Create a Node.js project at [sentry.io](https://sentry.io)
+2. Copy the DSN from Project Settings > Client Keys
+3. Add `SENTRY_DSN` to Railway environment variables
+4. Deploy and hit `GET /debug-sentry` to trigger a test error
+5. Confirm the error appears in the Sentry dashboard
+6. Remove or restrict `/debug-sentry` once verified (it is unprotected)
+
+**Configuration (in `src/instrument.ts`):**
+- `tracesSampleRate`: 20% in production, 100% in development
+- `sendDefaultPii`: disabled (no personal data sent)
+- `environment`: auto-detected from `NODE_ENV`
+
+### UptimeRobot Monitoring
+
+The `/health` endpoint returns `{"status":"ok"}` and is used for uptime monitoring.
+
+**Setup:**
+1. Sign up at [uptimerobot.com](https://uptimerobot.com) (free, no card needed)
+2. Add a new monitor:
+   - Type: **HTTPS**
+   - URL: `https://money-flow-backend-production.up.railway.app/health`
+   - Interval: **5 minutes**
+   - Alert contact: your email or Telegram
+3. Optionally add `/api/health` as a second monitor (checks DB connectivity too)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# money-flow-backend
+
+Express + TypeScript REST API for the Money Flow personal finance app.
+
+## Local Development (Docker)
+
+Start the full backend stack with one command:
+
+```bash
+# Start backend + MongoDB (dev mode with hot-reload)
+docker compose --profile dev up --build
+
+# Backend available at http://localhost:3001
+# Health check: http://localhost:3001/health
+```
+
+### Seed test data
+
+```bash
+# With Docker running:
+docker compose --profile dev exec backend npx ts-node scripts/seed.ts
+
+# Or directly (if MongoDB is running locally):
+npx ts-node scripts/seed.ts
+```
+
+Test credentials: `test@example.com` / `password123`
+
+### Profiles
+
+| Profile | What it runs | Use case |
+|---------|-------------|----------|
+| `dev` | Backend (nodemon hot-reload) + MongoDB | Day-to-day development |
+| `test` | Backend (dev) + Backend (prod build) + MongoDB | Pre-deploy testing |
+
+### Stop and clean up
+
+```bash
+docker compose --profile dev down          # stop containers
+docker compose --profile dev down -v       # stop + delete data
+```
+
+## Local Development (without Docker)
+
+```bash
+npm install
+cp .env.example .env  # edit with your MongoDB URI
+npm run dev            # starts on PORT 3001
+```
+
+## Scripts
+
+| Command | Description |
+|---------|-------------|
+| `npm run dev` | Start with nodemon (hot-reload) |
+| `npm run build` | Compile TypeScript |
+| `npm start` | Run compiled JS |
+| `npm test` | Run tests |

--- a/__tests__/alerts-coverage.test.ts
+++ b/__tests__/alerts-coverage.test.ts
@@ -1,0 +1,327 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import mongoose from 'mongoose';
+import UserModel from '../src/models/User';
+import ExpenseModel from '../src/models/Expense';
+import AlertModel from '../src/models/Alert';
+import {
+  checkAndQueueBudgetAlerts,
+  sendTelegramMessage,
+  processPendingAlerts,
+} from '../src/utils/alerts';
+
+let mongoServer: MongoMemoryServer;
+let testUserId: string;
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  await mongoose.connect(mongoServer.getUri());
+}, 30000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+beforeEach(async () => {
+  await UserModel.deleteMany({});
+  await ExpenseModel.deleteMany({});
+  await AlertModel.deleteMany({});
+
+  const userId = new mongoose.Types.ObjectId();
+  testUserId = userId.toString();
+  await UserModel.create({
+    _id: userId,
+    email: `alerts-cov-${Date.now()}@example.com`,
+    password: 'hashed_password',
+    budgets: [],
+  });
+}, 15000);
+
+afterEach(() => {
+  delete process.env.TELEGRAM_BOT_TOKEN;
+  delete process.env.TELEGRAM_CHAT_ID;
+  jest.restoreAllMocks();
+});
+
+describe('sendTelegramMessage', () => {
+  it('returns false when TELEGRAM_BOT_TOKEN is not set', async () => {
+    delete process.env.TELEGRAM_BOT_TOKEN;
+    delete process.env.TELEGRAM_CHAT_ID;
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+    const result = await sendTelegramMessage('test');
+    expect(result).toBe(false);
+    consoleSpy.mockRestore();
+  });
+
+  it('returns false when TELEGRAM_CHAT_ID is not set', async () => {
+    process.env.TELEGRAM_BOT_TOKEN = 'token';
+    delete process.env.TELEGRAM_CHAT_ID;
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+    const result = await sendTelegramMessage('test');
+    expect(result).toBe(false);
+    consoleSpy.mockRestore();
+  });
+
+  it('returns true on successful Telegram API call', async () => {
+    process.env.TELEGRAM_BOT_TOKEN = 'fake-token';
+    process.env.TELEGRAM_CHAT_ID = 'fake-chat';
+
+    const mockFetch = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ ok: true }),
+    } as Response);
+
+    const result = await sendTelegramMessage('Hello');
+    expect(result).toBe(true);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.telegram.org/botfake-token/sendMessage',
+      expect.objectContaining({ method: 'POST' })
+    );
+    mockFetch.mockRestore();
+  });
+
+  it('returns false on Telegram API error response', async () => {
+    process.env.TELEGRAM_BOT_TOKEN = 'fake-token';
+    process.env.TELEGRAM_CHAT_ID = 'fake-chat';
+
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+    jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      statusText: 'Forbidden',
+    } as Response);
+
+    const result = await sendTelegramMessage('Hello');
+    expect(result).toBe(false);
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Telegram API error:',
+      403,
+      'Forbidden'
+    );
+    errorSpy.mockRestore();
+  });
+
+  it('returns false on fetch exception', async () => {
+    process.env.TELEGRAM_BOT_TOKEN = 'fake-token';
+    process.env.TELEGRAM_CHAT_ID = 'fake-chat';
+
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+    jest.spyOn(global, 'fetch').mockRejectedValueOnce(new Error('Network error'));
+
+    const result = await sendTelegramMessage('Hello');
+    expect(result).toBe(false);
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Error sending Telegram message:',
+      expect.any(Error)
+    );
+    errorSpy.mockRestore();
+  });
+});
+
+describe('processPendingAlerts', () => {
+  it('marks alerts as sent when Telegram succeeds', async () => {
+    process.env.TELEGRAM_BOT_TOKEN = 'fake-token';
+    process.env.TELEGRAM_CHAT_ID = 'fake-chat';
+
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true }),
+    } as Response);
+
+    await AlertModel.create({
+      userId: testUserId,
+      category: 'Food',
+      amount: 100,
+      limit: 100,
+      percentUsed: 100,
+      message: 'Test alert',
+      sent: false,
+    });
+
+    await processPendingAlerts();
+
+    const alert = await AlertModel.findOne({ category: 'Food' });
+    expect(alert?.sent).toBe(true);
+    expect(alert?.sentAt).toBeDefined();
+  });
+
+  it('does not mark alert as sent when Telegram fails', async () => {
+    process.env.TELEGRAM_BOT_TOKEN = 'fake-token';
+    process.env.TELEGRAM_CHAT_ID = 'fake-chat';
+
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+    } as Response);
+
+    await AlertModel.create({
+      userId: testUserId,
+      category: 'Food',
+      amount: 100,
+      limit: 100,
+      percentUsed: 100,
+      message: 'Test alert',
+      sent: false,
+    });
+
+    await processPendingAlerts();
+
+    const alert = await AlertModel.findOne({ category: 'Food' });
+    expect(alert?.sent).toBe(false);
+    errorSpy.mockRestore();
+  });
+
+  it('processes multiple pending alerts', async () => {
+    process.env.TELEGRAM_BOT_TOKEN = 'fake-token';
+    process.env.TELEGRAM_CHAT_ID = 'fake-chat';
+
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true }),
+    } as Response);
+
+    await AlertModel.create([
+      {
+        userId: testUserId,
+        category: 'Food',
+        amount: 100,
+        limit: 100,
+        percentUsed: 100,
+        message: 'Alert 1',
+        sent: false,
+      },
+      {
+        userId: testUserId,
+        category: 'Transport',
+        amount: 200,
+        limit: 200,
+        percentUsed: 100,
+        message: 'Alert 2',
+        sent: false,
+      },
+    ]);
+
+    await processPendingAlerts();
+
+    const alerts = await AlertModel.find({ sent: true });
+    expect(alerts).toHaveLength(2);
+  });
+
+  it('handles DB error gracefully', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+    jest.spyOn(AlertModel, 'find').mockRejectedValueOnce(new Error('DB fail'));
+
+    await processPendingAlerts();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Error processing pending alerts:',
+      expect.any(Error)
+    );
+    errorSpy.mockRestore();
+  });
+});
+
+describe('checkAndQueueBudgetAlerts - edge cases', () => {
+  it('returns early for nonexistent user', async () => {
+    const fakeId = new mongoose.Types.ObjectId().toString();
+    await checkAndQueueBudgetAlerts(fakeId);
+    const alerts = await AlertModel.find({});
+    expect(alerts).toHaveLength(0);
+  });
+
+  it('returns early for user with no budgets', async () => {
+    await checkAndQueueBudgetAlerts(testUserId);
+    const alerts = await AlertModel.find({});
+    expect(alerts).toHaveLength(0);
+  });
+
+  it('uses default threshold of 0.9 when not specified', async () => {
+    await UserModel.findByIdAndUpdate(testUserId, {
+      $set: {
+        budgets: [
+          {
+            category: 'Food',
+            limit: 100,
+            enable_alerts: true,
+            // no alert_threshold set - should default to 0.9
+          },
+        ],
+      },
+    });
+
+    const dateStr = new Date().toISOString().split('T')[0];
+    await ExpenseModel.create({
+      owner: testUserId,
+      description: 'Big meal',
+      amount: 91, // 91% - exceeds default 90% threshold
+      category: 'Food',
+      type: 'expense',
+      date: dateStr,
+    });
+
+    await checkAndQueueBudgetAlerts(testUserId);
+
+    const alerts = await AlertModel.find({});
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].message).toContain('Budget Alert: Food');
+  });
+
+  it('handles zero-limit budget gracefully', async () => {
+    await UserModel.findByIdAndUpdate(testUserId, {
+      $set: {
+        budgets: [
+          {
+            category: 'Test',
+            limit: 0,
+            enable_alerts: true,
+          },
+        ],
+      },
+    });
+
+    await checkAndQueueBudgetAlerts(testUserId);
+
+    const alerts = await AlertModel.find({});
+    expect(alerts).toHaveLength(0);
+  });
+
+  it('handles category with no expenses', async () => {
+    await UserModel.findByIdAndUpdate(testUserId, {
+      $set: {
+        budgets: [
+          {
+            category: 'Travel',
+            limit: 500,
+            alert_threshold: 0.5,
+            enable_alerts: true,
+          },
+        ],
+      },
+    });
+
+    await checkAndQueueBudgetAlerts(testUserId);
+
+    const alerts = await AlertModel.find({});
+    expect(alerts).toHaveLength(0);
+  });
+
+  it('handles DB error gracefully in checkAndQueueBudgetAlerts', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+    jest.spyOn(UserModel, 'findById').mockImplementation(() => {
+      throw new Error('DB fail');
+    });
+
+    await checkAndQueueBudgetAlerts(testUserId);
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Error checking budget alerts:',
+      expect.any(Error)
+    );
+    errorSpy.mockRestore();
+  });
+});

--- a/__tests__/alerts.test.ts
+++ b/__tests__/alerts.test.ts
@@ -1,0 +1,311 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import mongoose from 'mongoose';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import app from '../src/app';
+import { UserModel } from '../src/models/User';
+import { ExpenseModel } from '../src/models/Expense';
+import { AlertModel } from '../src/models/Alert';
+import { checkAndQueueBudgetAlerts, processPendingAlerts } from '../src/utils/alerts';
+
+let mongoServer: MongoMemoryServer;
+let token: string;
+let testUserId: string;
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  const mongoUri = mongoServer.getUri();
+  await mongoose.connect(mongoUri);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+beforeEach(async () => {
+  await UserModel.deleteMany({});
+  await ExpenseModel.deleteMany({});
+  await AlertModel.deleteMany({});
+
+  // Create test user in database with valid ObjectId
+  const userId = new mongoose.Types.ObjectId();
+  testUserId = userId.toString();
+
+  await UserModel.create({
+    _id: userId,
+    email: `test${Date.now()}@example.com`,
+    password: 'hashed_password',
+    budgets: [],
+  });
+
+  // Generate JWT token for test user
+  token = jwt.sign({ userId: testUserId }, 'test-secret');
+});
+
+describe('Budget Alerts', () => {
+  it('should queue an alert when expense exceeds budget threshold', async () => {
+    // Get user
+    const user = await UserModel.findById(testUserId);
+    expect(user).toBeDefined();
+
+    // Set up budget with alerts enabled
+    await UserModel.findByIdAndUpdate(user?._id, {
+      $set: {
+        budgets: [
+          {
+            category: 'Food',
+            limit: 100,
+            alert_threshold: 0.8,
+            enable_alerts: true,
+          },
+        ],
+      },
+    });
+
+    // Create expense that exceeds threshold
+    await ExpenseModel.create({
+      owner: user?._id,
+      description: 'Restaurant',
+      amount: 85,
+      category: 'Food',
+      type: 'expense',
+      date: new Date().toISOString().split('T')[0],
+    });
+
+    // Check alerts directly (simulating what the background job would do)
+    await checkAndQueueBudgetAlerts(user?._id.toString() || '');
+
+    const alerts = await AlertModel.find({ category: 'Food' });
+    expect(alerts.length).toBe(1);
+    expect(alerts[0].sent).toBe(false);
+  });
+
+  it('should not queue duplicate alerts for same month', async () => {
+    const user = await UserModel.findById(testUserId);
+    expect(user).toBeDefined();
+
+    // Set up budget
+    await UserModel.findByIdAndUpdate(user?._id, {
+      $set: {
+        budgets: [
+          {
+            category: 'Food',
+            limit: 100,
+            alert_threshold: 0.5,
+            enable_alerts: true,
+          },
+        ],
+      },
+    });
+
+    // Create first expensive transaction
+    await ExpenseModel.create({
+      owner: user?._id,
+      description: 'Expensive meal',
+      amount: 60,
+      category: 'Food',
+      type: 'expense',
+      date: new Date().toISOString().split('T')[0],
+    });
+
+    // Check alerts
+    await checkAndQueueBudgetAlerts(user?._id.toString() || '');
+
+    const alertsAfterFirst = await AlertModel.find({ category: 'Food' });
+    expect(alertsAfterFirst.length).toBe(1);
+
+    // Create another transaction
+    await ExpenseModel.create({
+      owner: user?._id,
+      description: 'Another meal',
+      amount: 30,
+      category: 'Food',
+      type: 'expense',
+      date: new Date().toISOString().split('T')[0],
+    });
+
+    // Check alerts again - should not create duplicate
+    await checkAndQueueBudgetAlerts(user?._id.toString() || '');
+
+    const alertsAfterSecond = await AlertModel.find({ category: 'Food' });
+    expect(alertsAfterSecond.length).toBe(1);
+  });
+
+  it('should not queue alerts when category alerts are disabled', async () => {
+    const user = await UserModel.findById(testUserId);
+    expect(user).toBeDefined();
+
+    // Set up budget but disable alerts
+    await UserModel.findByIdAndUpdate(user?._id, {
+      $set: {
+        budgets: [
+          {
+            category: 'Entertainment',
+            limit: 50,
+            alert_threshold: 0.5,
+            enable_alerts: false,
+          },
+        ],
+      },
+    });
+
+    // Create expensive transaction
+    await ExpenseModel.create({
+      owner: user?._id,
+      description: 'Movie',
+      amount: 40,
+      category: 'Entertainment',
+      type: 'expense',
+      date: new Date().toISOString().split('T')[0],
+    });
+
+    // Check alerts
+    await checkAndQueueBudgetAlerts(user?._id.toString() || '');
+
+    const alerts = await AlertModel.find({ category: 'Entertainment' });
+    expect(alerts.length).toBe(0);
+  });
+
+  it('should not queue alerts for income transactions', async () => {
+    const user = await UserModel.findById(testUserId);
+    expect(user).toBeDefined();
+
+    // Set up budget
+    await UserModel.findByIdAndUpdate(user?._id, {
+      $set: {
+        budgets: [
+          {
+            category: 'Income',
+            limit: 1000,
+            alert_threshold: 0.5,
+            enable_alerts: true,
+          },
+        ],
+      },
+    });
+
+    // Create income transaction
+    await ExpenseModel.create({
+      owner: user?._id,
+      description: 'Salary',
+      amount: 800,
+      category: 'Income',
+      type: 'income',
+      date: new Date().toISOString().split('T')[0],
+    });
+
+    // Check alerts
+    await checkAndQueueBudgetAlerts(user?._id.toString() || '');
+
+    const alerts = await AlertModel.find({ category: 'Income' });
+    expect(alerts.length).toBe(0);
+  });
+
+  it('should enable/disable alerts via POST endpoint', async () => {
+    const user = await UserModel.findById(testUserId);
+    expect(user).toBeDefined();
+
+    // Set up initial budget
+    await UserModel.findByIdAndUpdate(user?._id, {
+      $set: {
+        budgets: [
+          {
+            category: 'Utilities',
+            limit: 200,
+            enable_alerts: true,
+          },
+        ],
+      },
+    });
+
+    // Test disabling alerts via endpoint
+    const disableRes = await request(app)
+      .post('/api/budgets/Utilities/alerts')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ enable_alerts: false });
+
+    expect(disableRes.status).toBe(200);
+
+    // Verify disabled in database
+    const updatedUser = await UserModel.findById(user?._id);
+    const utilities = updatedUser?.budgets.find((b) => b.category === 'Utilities');
+    expect(utilities?.enable_alerts).toBe(false);
+
+    // Re-enable alerts
+    const enableRes = await request(app)
+      .post('/api/budgets/Utilities/alerts')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ enable_alerts: true });
+
+    expect(enableRes.status).toBe(200);
+
+    // Verify re-enabled
+    const finalUser = await UserModel.findById(user?._id);
+    const finalUtilities = finalUser?.budgets.find((b) => b.category === 'Utilities');
+    expect(finalUtilities?.enable_alerts).toBe(true);
+  });
+
+  it('should handle checking budgets with no alerts enabled', async () => {
+    const user = await UserModel.findById(testUserId);
+    expect(user).toBeDefined();
+
+    // Set up budget without alerts
+    await UserModel.findByIdAndUpdate(user?._id, {
+      $set: {
+        budgets: [
+          {
+            category: 'Shopping',
+            limit: 100,
+            enable_alerts: false,
+          },
+        ],
+      },
+    });
+
+    // Create large expense
+    await ExpenseModel.create({
+      owner: user?._id,
+      description: 'Purchases',
+      amount: 120,
+      category: 'Shopping',
+      type: 'expense',
+      date: new Date().toISOString().split('T')[0],
+    });
+
+    // Check alerts
+    await checkAndQueueBudgetAlerts(user?._id.toString() || '');
+
+    const alerts = await AlertModel.find({});
+    expect(alerts.length).toBe(0);
+  });
+
+  it('should mark alerts as sent after processing', async () => {
+    // Create a pending alert manually
+    const user = await UserModel.findById(testUserId);
+    expect(user).toBeDefined();
+
+    await AlertModel.create({
+      userId: user?._id.toString(),
+      category: 'Test',
+      amount: 100,
+      limit: 100,
+      percentUsed: 100,
+      message: 'Test alert',
+      sent: false,
+    });
+
+    // Mock Telegram (skip actual sending)
+    process.env.TELEGRAM_BOT_TOKEN = '';
+    process.env.TELEGRAM_CHAT_ID = '';
+
+    await processPendingAlerts();
+
+    // Without Telegram configured, it should not mark as sent
+    const alert = await AlertModel.findOne({ category: 'Test' });
+    expect(alert?.sent).toBe(false);
+  });
+});

--- a/__tests__/app.test.ts
+++ b/__tests__/app.test.ts
@@ -10,7 +10,7 @@ describe('GET /health', () => {
       .get('/health');
 
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ status: 'ok' });
+    expect(res.body.status).toBe('ok');
   });
 });
 

--- a/__tests__/app.test.ts
+++ b/__tests__/app.test.ts
@@ -1,0 +1,16 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import app from '../src/app';
+
+describe('GET /health', () => {
+  it('returns ok status', async () => {
+    const res = await request(app)
+      .get('/health');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'ok' });
+  });
+});
+

--- a/__tests__/app.test.ts
+++ b/__tests__/app.test.ts
@@ -12,5 +12,31 @@ describe('GET /health', () => {
     expect(res.status).toBe(200);
     expect(res.body.status).toBe('ok');
   });
+
+  it('returns version in response', async () => {
+    const res = await request(app)
+      .get('/health');
+
+    expect(res.status).toBe(200);
+    expect(res.body.version).toBeDefined();
+  });
+});
+
+describe('App bootstrap', () => {
+  it('sets up CORS middleware correctly', async () => {
+    const res = await request(app)
+      .get('/health');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['access-control-allow-origin']).toBeDefined();
+  });
+
+  it('sets up express.json() middleware', async () => {
+    const res = await request(app)
+      .get('/health');
+
+    // Verify that the app has middleware configured correctly
+    expect(res.status).toBe(200);
+  });
 });
 

--- a/__tests__/auth-apple.test.ts
+++ b/__tests__/auth-apple.test.ts
@@ -1,0 +1,139 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+process.env.APPLE_CLIENT_ID = 'test-apple-client-id';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import app from '../src/app';
+import UserModel from '../src/models/User';
+
+jest.mock('apple-signin-auth', () => ({
+  verifyIdToken: jest.fn(),
+}));
+
+import appleSignin from 'apple-signin-auth';
+const mockVerify = appleSignin.verifyIdToken as jest.Mock;
+
+let mongod: MongoMemoryServer;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  for (const col of Object.values(mongoose.connection.collections)) {
+    await col.deleteMany({});
+  }
+  mockVerify.mockReset();
+});
+
+describe('POST /auth/apple', () => {
+  it('creates new user and returns token for new Apple user', async () => {
+    mockVerify.mockResolvedValue({
+      email: 'apple@example.com',
+      sub: 'apple-uid-123',
+    });
+
+    const res = await request(app)
+      .post('/auth/apple')
+      .send({ idToken: 'valid-apple-token' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.token).toBeDefined();
+
+    const user = await UserModel.findOne({ email: 'apple@example.com' });
+    expect(user).toBeTruthy();
+    expect(user!.appleId).toBe('apple-uid-123');
+    expect(user!.password).toBeUndefined();
+  });
+
+  it('returns token for existing Apple user', async () => {
+    await UserModel.create({
+      email: 'existing@example.com',
+      appleId: 'apple-uid-456',
+    });
+    mockVerify.mockResolvedValue({
+      email: 'existing@example.com',
+      sub: 'apple-uid-456',
+    });
+
+    const res = await request(app)
+      .post('/auth/apple')
+      .send({ idToken: 'valid-apple-token' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.token).toBeDefined();
+  });
+
+  it('links Apple account to existing email/password user', async () => {
+    await request(app)
+      .post('/auth/register')
+      .send({ email: 'linkme@example.com', password: 'password123' });
+
+    mockVerify.mockResolvedValue({
+      email: 'linkme@example.com',
+      sub: 'apple-uid-789',
+    });
+
+    const res = await request(app)
+      .post('/auth/apple')
+      .send({ idToken: 'valid-apple-token' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.token).toBeDefined();
+
+    const user = await UserModel.findOne({ email: 'linkme@example.com' });
+    expect(user!.appleId).toBe('apple-uid-789');
+    expect(user!.password).toBeDefined();
+  });
+
+  it('handles Apple relay email addresses', async () => {
+    mockVerify.mockResolvedValue({
+      email: 'abcdef@privaterelay.appleid.com',
+      sub: 'apple-uid-relay',
+    });
+
+    const res = await request(app)
+      .post('/auth/apple')
+      .send({ idToken: 'valid-apple-token' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.token).toBeDefined();
+
+    const user = await UserModel.findOne({ email: 'abcdef@privaterelay.appleid.com' });
+    expect(user).toBeTruthy();
+    expect(user!.appleId).toBe('apple-uid-relay');
+  });
+
+  it('rejects missing idToken with 400', async () => {
+    const res = await request(app).post('/auth/apple').send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects invalid Apple token with 401', async () => {
+    mockVerify.mockRejectedValue(new Error('Invalid token'));
+
+    const res = await request(app)
+      .post('/auth/apple')
+      .send({ idToken: 'invalid-token' });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects token with no email with 401', async () => {
+    mockVerify.mockResolvedValue({ sub: 'no-email-user' });
+
+    const res = await request(app)
+      .post('/auth/apple')
+      .send({ idToken: 'token-no-email' });
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/__tests__/auth-google.test.ts
+++ b/__tests__/auth-google.test.ts
@@ -1,0 +1,126 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+process.env.GOOGLE_CLIENT_ID = 'test-google-client-id';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import app from '../src/app';
+import UserModel from '../src/models/User';
+
+jest.mock('google-auth-library', () => {
+  const mockVerifyIdToken = jest.fn();
+  return {
+    OAuth2Client: jest.fn().mockImplementation(() => ({
+      verifyIdToken: mockVerifyIdToken,
+    })),
+    __mockVerifyIdToken: mockVerifyIdToken,
+  };
+});
+
+const { __mockVerifyIdToken: mockVerifyIdToken } =
+  jest.requireMock('google-auth-library') as { __mockVerifyIdToken: jest.Mock };
+
+let mongod: MongoMemoryServer;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  for (const col of Object.values(mongoose.connection.collections)) {
+    await col.deleteMany({});
+  }
+  mockVerifyIdToken.mockReset();
+});
+
+const mockGooglePayload = (email: string, sub: string) => {
+  mockVerifyIdToken.mockResolvedValue({
+    getPayload: () => ({ email, sub }),
+  });
+};
+
+describe('POST /auth/google', () => {
+  it('creates new user and returns token for new Google user', async () => {
+    mockGooglePayload('google@example.com', 'google-uid-123');
+
+    const res = await request(app)
+      .post('/auth/google')
+      .send({ idToken: 'valid-google-token' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.token).toBeDefined();
+
+    const user = await UserModel.findOne({ email: 'google@example.com' });
+    expect(user).toBeTruthy();
+    expect(user!.googleId).toBe('google-uid-123');
+    expect(user!.password).toBeUndefined();
+  });
+
+  it('returns token for existing Google user', async () => {
+    await UserModel.create({
+      email: 'existing@example.com',
+      googleId: 'google-uid-456',
+    });
+    mockGooglePayload('existing@example.com', 'google-uid-456');
+
+    const res = await request(app)
+      .post('/auth/google')
+      .send({ idToken: 'valid-google-token' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.token).toBeDefined();
+  });
+
+  it('links Google account to existing email/password user', async () => {
+    await request(app)
+      .post('/auth/register')
+      .send({ email: 'linkme@example.com', password: 'password123' });
+
+    mockGooglePayload('linkme@example.com', 'google-uid-789');
+
+    const res = await request(app)
+      .post('/auth/google')
+      .send({ idToken: 'valid-google-token' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.token).toBeDefined();
+
+    const user = await UserModel.findOne({ email: 'linkme@example.com' });
+    expect(user!.googleId).toBe('google-uid-789');
+    expect(user!.password).toBeDefined();
+  });
+
+  it('rejects missing idToken with 400', async () => {
+    const res = await request(app).post('/auth/google').send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects invalid Google token with 401', async () => {
+    mockVerifyIdToken.mockRejectedValue(new Error('Invalid token'));
+
+    const res = await request(app)
+      .post('/auth/google')
+      .send({ idToken: 'invalid-token' });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects token with no email with 401', async () => {
+    mockVerifyIdToken.mockResolvedValue({
+      getPayload: () => ({ sub: 'no-email-user' }),
+    });
+
+    const res = await request(app)
+      .post('/auth/google')
+      .send({ idToken: 'token-no-email' });
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/__tests__/auth-integration.test.ts
+++ b/__tests__/auth-integration.test.ts
@@ -1,0 +1,178 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import app from '../src/app';
+
+let mongod: MongoMemoryServer;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+}, 30000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  for (const col of Object.values(mongoose.connection.collections)) {
+    await col.deleteMany({});
+  }
+});
+
+// --- POST /auth/register ---
+
+describe('POST /auth/register', () => {
+  it('returns a valid JWT on successful registration', async () => {
+    const res = await request(app)
+      .post('/auth/register')
+      .send({ email: 'new@example.com', password: 'securePass1' });
+    expect(res.status).toBe(201);
+    expect(res.body.token).toBeDefined();
+
+    const decoded = jwt.verify(res.body.token, 'test-secret') as { userId: string };
+    expect(decoded.userId).toBeDefined();
+  });
+
+  it('normalises email to lowercase', async () => {
+    const res = await request(app)
+      .post('/auth/register')
+      .send({ email: 'UPPER@Example.COM', password: 'password123' });
+    expect(res.status).toBe(201);
+
+    const loginRes = await request(app)
+      .post('/auth/login')
+      .send({ email: 'upper@example.com', password: 'password123' });
+    expect(loginRes.status).toBe(200);
+  });
+
+  it('rejects missing password with 400', async () => {
+    const res = await request(app)
+      .post('/auth/register')
+      .send({ email: 'test@example.com' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects invalid email format with 400', async () => {
+    const res = await request(app)
+      .post('/auth/register')
+      .send({ email: 'not-an-email', password: 'password123' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects empty body with 400', async () => {
+    const res = await request(app)
+      .post('/auth/register')
+      .send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects password with exactly 5 characters (boundary)', async () => {
+    const res = await request(app)
+      .post('/auth/register')
+      .send({ email: 'test@example.com', password: '12345' });
+    expect(res.status).toBe(400);
+  });
+
+  it('accepts password with exactly 6 characters (boundary)', async () => {
+    const res = await request(app)
+      .post('/auth/register')
+      .send({ email: 'sixchar@example.com', password: '123456' });
+    expect(res.status).toBe(201);
+  });
+});
+
+// --- POST /auth/login ---
+
+describe('POST /auth/login', () => {
+  beforeEach(async () => {
+    await request(app)
+      .post('/auth/register')
+      .send({ email: 'user@example.com', password: 'password123' });
+  });
+
+  it('returns a valid JWT on successful login', async () => {
+    const res = await request(app)
+      .post('/auth/login')
+      .send({ email: 'user@example.com', password: 'password123' });
+    expect(res.status).toBe(200);
+    expect(res.body.token).toBeDefined();
+
+    const decoded = jwt.verify(res.body.token, 'test-secret') as { userId: string };
+    expect(decoded.userId).toBeDefined();
+  });
+
+  it('rejects missing email with 400', async () => {
+    const res = await request(app)
+      .post('/auth/login')
+      .send({ password: 'password123' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects missing password with 400', async () => {
+    const res = await request(app)
+      .post('/auth/login')
+      .send({ email: 'user@example.com' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects empty body with 400', async () => {
+    const res = await request(app)
+      .post('/auth/login')
+      .send({});
+    expect(res.status).toBe(400);
+  });
+});
+
+// --- Token validation ---
+
+describe('Token validation', () => {
+  it('rejects expired token with 401', async () => {
+    const expiredToken = jwt.sign(
+      { userId: 'user123' },
+      'test-secret',
+      { expiresIn: '0s' }
+    );
+    // Small delay to ensure token is expired
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    const res = await request(app)
+      .get('/api/expenses')
+      .set('Authorization', `Bearer ${expiredToken}`);
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects malformed token with 401', async () => {
+    const res = await request(app)
+      .get('/api/expenses')
+      .set('Authorization', 'Bearer not.a.valid.jwt.token');
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects empty Bearer value with 401', async () => {
+    const res = await request(app)
+      .get('/api/expenses')
+      .set('Authorization', 'Bearer ');
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects non-Bearer scheme with 401', async () => {
+    const token = jwt.sign({ userId: 'user123' }, 'test-secret');
+    const res = await request(app)
+      .get('/api/expenses')
+      .set('Authorization', `Basic ${token}`);
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects token signed with wrong secret with 401', async () => {
+    const token = jwt.sign({ userId: 'user123' }, 'wrong-secret');
+    const res = await request(app)
+      .get('/api/expenses')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(401);
+  });
+});

--- a/__tests__/auth-middleware.test.ts
+++ b/__tests__/auth-middleware.test.ts
@@ -1,0 +1,52 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import app from '../src/app';
+
+let mongod: MongoMemoryServer;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+describe('auth middleware', () => {
+  it('returns 401 when Authorization header is missing', async () => {
+    const res = await request(app).get('/api/expenses');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 for invalid token', async () => {
+    const res = await request(app)
+      .get('/api/expenses')
+      .set('Authorization', 'Bearer invalid.token.here');
+    expect(res.status).toBe(401);
+  });
+
+  it('sets req.userId and calls next with valid token', async () => {
+    const userId = 'user_middleware_test';
+    const token = jwt.sign({ userId }, 'test-secret');
+    const res = await request(app)
+      .get('/api/expenses')
+      .set('Authorization', `Bearer ${token}`);
+    // A valid token should allow through — endpoint returns 200 with empty data
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 401 for token signed with wrong secret', async () => {
+    const token = jwt.sign({ userId: 'user123' }, 'wrong-secret');
+    const res = await request(app)
+      .get('/api/expenses')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(401);
+  });
+});

--- a/__tests__/auth-rate-limit.test.ts
+++ b/__tests__/auth-rate-limit.test.ts
@@ -1,0 +1,61 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+process.env.ENABLE_RATE_LIMIT = 'true';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import app from '../src/app';
+
+let mongod: MongoMemoryServer;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+}, 30000);
+
+afterAll(async () => {
+  delete process.env.ENABLE_RATE_LIMIT;
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  for (const col of Object.values(mongoose.connection.collections)) {
+    await col.deleteMany({});
+  }
+});
+
+describe('Auth rate limiting', () => {
+  it('returns 429 with correct body and retry-after header after exceeding login limit', async () => {
+    for (let i = 0; i < 10; i++) {
+      await request(app)
+        .post('/auth/login')
+        .send({ email: 'test@example.com', password: 'password123' });
+    }
+
+    const res = await request(app)
+      .post('/auth/login')
+      .send({ email: 'test@example.com', password: 'password123' });
+
+    expect(res.status).toBe(429);
+    expect(res.body.error).toBe('Too many requests, please try again later');
+    expect(res.headers['retry-after']).toBeDefined();
+  });
+
+  it('returns 429 after exceeding register limit (5 per hour)', async () => {
+    for (let i = 0; i < 5; i++) {
+      await request(app)
+        .post('/auth/register')
+        .send({ email: `user${i}@example.com`, password: 'password123' });
+    }
+
+    const res = await request(app)
+      .post('/auth/register')
+      .send({ email: 'extra@example.com', password: 'password123' });
+
+    expect(res.status).toBe(429);
+    expect(res.body.error).toBe('Too many requests, please try again later');
+    expect(res.headers['retry-after']).toBeDefined();
+  });
+});

--- a/__tests__/auth.test.ts
+++ b/__tests__/auth.test.ts
@@ -1,0 +1,89 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import app from '../src/app';
+
+let mongod: MongoMemoryServer;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  for (const col of Object.values(mongoose.connection.collections)) {
+    await col.deleteMany({});
+  }
+});
+
+describe('POST /auth/register', () => {
+  it('creates user and returns token', async () => {
+    const res = await request(app)
+      .post('/auth/register')
+      .send({ email: 'test@example.com', password: 'password123' });
+    expect(res.status).toBe(201);
+    expect(res.body.token).toBeDefined();
+  });
+
+  it('rejects duplicate email with 409', async () => {
+    await request(app)
+      .post('/auth/register')
+      .send({ email: 'dupe@example.com', password: 'password123' });
+    const res = await request(app)
+      .post('/auth/register')
+      .send({ email: 'dupe@example.com', password: 'password123' });
+    expect(res.status).toBe(409);
+  });
+
+  it('rejects missing email with 400', async () => {
+    const res = await request(app)
+      .post('/auth/register')
+      .send({ password: 'password123' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects short password with 400', async () => {
+    const res = await request(app)
+      .post('/auth/register')
+      .send({ email: 'test@example.com', password: '123' });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /auth/login', () => {
+  beforeEach(async () => {
+    await request(app)
+      .post('/auth/register')
+      .send({ email: 'login@example.com', password: 'password123' });
+  });
+
+  it('returns token with correct credentials', async () => {
+    const res = await request(app)
+      .post('/auth/login')
+      .send({ email: 'login@example.com', password: 'password123' });
+    expect(res.status).toBe(200);
+    expect(res.body.token).toBeDefined();
+  });
+
+  it('rejects wrong password with 401', async () => {
+    const res = await request(app)
+      .post('/auth/login')
+      .send({ email: 'login@example.com', password: 'wrongpass' });
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects unknown email with 401', async () => {
+    const res = await request(app)
+      .post('/auth/login')
+      .send({ email: 'nobody@example.com', password: 'password123' });
+    expect(res.status).toBe(401);
+  });
+});

--- a/__tests__/budget-summary.test.ts
+++ b/__tests__/budget-summary.test.ts
@@ -1,0 +1,169 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import app from '../src/app';
+import UserModel from '../src/models/User';
+import ExpenseModel from '../src/models/Expense';
+
+let mongod: MongoMemoryServer;
+let authToken: string;
+let userId: string;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+
+  const res = await request(app)
+    .post('/auth/register')
+    .send({ email: 'budget@test.com', password: 'password123' });
+  authToken = res.body.token;
+
+  const user = await UserModel.findOne({ email: 'budget@test.com' });
+  userId = user!._id.toString();
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  await ExpenseModel.deleteMany({});
+  await UserModel.findByIdAndUpdate(userId, { budgets: [] });
+});
+
+describe('GET /api/reports/budget-summary', () => {
+  it('returns budget vs actual for current month', async () => {
+    await UserModel.findByIdAndUpdate(userId, {
+      budgets: [
+        { category: 'Food', limit: 500 },
+        { category: 'Transport', limit: 200 },
+      ],
+    });
+
+    const now = new Date();
+    await ExpenseModel.create([
+      { owner: userId, amount: 150, type: 'expense', category: 'Food', date: now },
+      { owner: userId, amount: 100, type: 'expense', category: 'Food', date: now },
+      { owner: userId, amount: 80, type: 'expense', category: 'Transport', date: now },
+    ]);
+
+    const res = await request(app)
+      .get('/api/reports/budget-summary')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.totalBudgeted).toBe(700);
+    expect(res.body.totalSpent).toBe(330);
+    expect(res.body.totalRemaining).toBe(370);
+
+    const food = res.body.data.find((d: { category: string }) => d.category === 'Food');
+    expect(food.spent).toBe(250);
+    expect(food.budgetLimit).toBe(500);
+    expect(food.percentUsed).toBe(50);
+    expect(food.overBudget).toBe(false);
+  });
+
+  it('flags over-budget categories', async () => {
+    await UserModel.findByIdAndUpdate(userId, {
+      budgets: [{ category: 'Shopping', limit: 100 }],
+    });
+
+    const now = new Date();
+    await ExpenseModel.create({
+      owner: userId, amount: 150, type: 'expense', category: 'Shopping', date: now,
+    });
+
+    const res = await request(app)
+      .get('/api/reports/budget-summary')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.body.data[0].overBudget).toBe(true);
+    expect(res.body.data[0].percentUsed).toBe(150);
+    expect(res.body.data[0].remaining).toBe(-50);
+  });
+
+  it('includes categories with spending but no budget', async () => {
+    const now = new Date();
+    await ExpenseModel.create({
+      owner: userId, amount: 50, type: 'expense', category: 'Entertainment', date: now,
+    });
+
+    const res = await request(app)
+      .get('/api/reports/budget-summary')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].category).toBe('Entertainment');
+    expect(res.body.data[0].spent).toBe(50);
+    expect(res.body.data[0].budgetLimit).toBe(0);
+  });
+
+  it('returns empty data when no budgets and no spending', async () => {
+    const res = await request(app)
+      .get('/api/reports/budget-summary')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(0);
+    expect(res.body.totalBudgeted).toBe(0);
+    expect(res.body.totalSpent).toBe(0);
+  });
+
+  it('filters by specific month', async () => {
+    await UserModel.findByIdAndUpdate(userId, {
+      budgets: [{ category: 'Food', limit: 300 }],
+    });
+
+    await ExpenseModel.create([
+      { owner: userId, amount: 100, type: 'expense', category: 'Food', date: new Date('2026-02-15') },
+      { owner: userId, amount: 200, type: 'expense', category: 'Food', date: new Date('2026-03-15') },
+    ]);
+
+    const res = await request(app)
+      .get('/api/reports/budget-summary?month=2026-02')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    const food = res.body.data.find((d: { category: string }) => d.category === 'Food');
+    expect(food.spent).toBe(100);
+  });
+
+  it('rejects invalid month format', async () => {
+    const res = await request(app)
+      .get('/api/reports/budget-summary?month=invalid')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('requires authentication', async () => {
+    const res = await request(app).get('/api/reports/budget-summary');
+    expect(res.status).toBe(401);
+  });
+
+  it('sorts by percentUsed descending', async () => {
+    await UserModel.findByIdAndUpdate(userId, {
+      budgets: [
+        { category: 'Food', limit: 500 },
+        { category: 'Transport', limit: 100 },
+      ],
+    });
+
+    const now = new Date();
+    await ExpenseModel.create([
+      { owner: userId, amount: 100, type: 'expense', category: 'Food', date: now },
+      { owner: userId, amount: 90, type: 'expense', category: 'Transport', date: now },
+    ]);
+
+    const res = await request(app)
+      .get('/api/reports/budget-summary')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.body.data[0].category).toBe('Transport');
+    expect(res.body.data[1].category).toBe('Food');
+  });
+});

--- a/__tests__/budgets-coverage.test.ts
+++ b/__tests__/budgets-coverage.test.ts
@@ -1,0 +1,228 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import app from '../src/app';
+import UserModel from '../src/models/User';
+import ExpenseModel from '../src/models/Expense';
+
+let mongod: MongoMemoryServer;
+let authToken: string;
+let userId: string;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+}, 30000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+beforeEach(async () => {
+  for (const col of Object.values(mongoose.connection.collections)) {
+    await col.deleteMany({});
+  }
+  const oid = new mongoose.Types.ObjectId();
+  userId = oid.toString();
+  await UserModel.create({
+    _id: oid,
+    email: `budget-cov-${Date.now()}@example.com`,
+    password: 'password123',
+    budgets: [],
+  });
+  authToken = jwt.sign({ userId }, 'test-secret');
+}, 15000);
+
+describe('GET /api/budgets/summary', () => {
+  it('returns empty summary when user has no budgets', async () => {
+    const res = await request(app)
+      .get('/api/budgets/summary')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.summary).toEqual([]);
+  });
+
+  it('returns budget summary with budgets defined', async () => {
+    // Set up budgets
+    await UserModel.findByIdAndUpdate(userId, {
+      $set: {
+        budgets: [
+          { category: 'Food', limit: 500, alert_threshold: 0.9, enable_alerts: true },
+          { category: 'Transport', limit: 200, alert_threshold: 0.8, enable_alerts: false },
+        ],
+      },
+    });
+
+    const res = await request(app)
+      .get('/api/budgets/summary')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.summary).toHaveLength(2);
+
+    const food = res.body.summary.find((s: { category: string }) => s.category === 'Food');
+    expect(food).toBeDefined();
+    expect(food.limit).toBe(500);
+    expect(food.category).toBe('Food');
+    expect(typeof food.spend).toBe('number');
+    expect(typeof food.remaining).toBe('number');
+    expect(typeof food.percentUsed).toBe('number');
+    expect(typeof food.exceeds).toBe('boolean');
+    expect(food.thresholdPercentage).toBe(90);
+
+    const transport = res.body.summary.find((s: { category: string }) => s.category === 'Transport');
+    expect(transport).toBeDefined();
+    expect(transport.limit).toBe(200);
+    expect(transport.thresholdPercentage).toBe(80);
+  });
+
+  it('returns correct structure for budget with no matching expenses', async () => {
+    await UserModel.findByIdAndUpdate(userId, {
+      $set: {
+        budgets: [
+          { category: 'Food', limit: 100, alert_threshold: 0.9, enable_alerts: true },
+        ],
+      },
+    });
+
+    const res = await request(app)
+      .get('/api/budgets/summary')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    const food = res.body.summary[0];
+    // No expenses, so spend should be 0
+    expect(food.spend).toBe(0);
+    expect(food.remaining).toBe(100);
+    expect(food.exceeds).toBe(false);
+    expect(food.alertTriggered).toBe(false);
+    expect(food.percentUsed).toBe(0);
+  });
+
+  it('handles zero-limit budget gracefully', async () => {
+    await UserModel.findByIdAndUpdate(userId, {
+      $set: {
+        budgets: [{ category: 'Test', limit: 0, enable_alerts: false }],
+      },
+    });
+
+    const res = await request(app)
+      .get('/api/budgets/summary')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.summary[0].percentUsed).toBe(0);
+  });
+
+  it('returns 404 for invalid user', async () => {
+    const fakeToken = jwt.sign({ userId: new mongoose.Types.ObjectId().toString() }, 'test-secret');
+    const res = await request(app)
+      .get('/api/budgets/summary')
+      .set('Authorization', `Bearer ${fakeToken}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('handles budget with enable_alerts false', async () => {
+    await UserModel.findByIdAndUpdate(userId, {
+      $set: {
+        budgets: [{ category: 'Uncategorized', limit: 100, enable_alerts: false }],
+      },
+    });
+
+    const res = await request(app)
+      .get('/api/budgets/summary')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    // alertTriggered should be false when enable_alerts is false even if exceeds
+    expect(res.body.summary[0].alertTriggered).toBe(false);
+  });
+});
+
+describe('GET /api/budgets - user not found', () => {
+  it('returns 404 when user does not exist', async () => {
+    const fakeToken = jwt.sign({ userId: new mongoose.Types.ObjectId().toString() }, 'test-secret');
+    const res = await request(app)
+      .get('/api/budgets')
+      .set('Authorization', `Bearer ${fakeToken}`);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /api/budgets/:category/alerts', () => {
+  it('returns 400 for invalid enable_alerts value', async () => {
+    const res = await request(app)
+      .post('/api/budgets/Food/alerts')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ enable_alerts: 'not-a-bool' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when budget not found for category', async () => {
+    const res = await request(app)
+      .post('/api/budgets/Nonexistent/alerts')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ enable_alerts: true });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 when user not found', async () => {
+    const fakeToken = jwt.sign({ userId: new mongoose.Types.ObjectId().toString() }, 'test-secret');
+    const res = await request(app)
+      .post('/api/budgets/Food/alerts')
+      .set('Authorization', `Bearer ${fakeToken}`)
+      .send({ enable_alerts: true });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('PUT /api/budgets - validation', () => {
+  it('filters out budgets with zero limit', async () => {
+    const res = await request(app)
+      .put('/api/budgets')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        budgets: [
+          { category: 'Food', limit: 500 },
+          { category: 'Zero', limit: 0 },
+        ],
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.budgets).toHaveLength(1);
+    expect(res.body.budgets[0].category).toBe('Food');
+  });
+
+  it('rejects missing category', async () => {
+    const res = await request(app)
+      .put('/api/budgets')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ budgets: [{ limit: 100 }] });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects non-numeric limit', async () => {
+    const res = await request(app)
+      .put('/api/budgets')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ budgets: [{ category: 'Food', limit: 'abc' }] });
+    expect(res.status).toBe(400);
+  });
+
+  it('saves budgets with alert_threshold and enable_alerts', async () => {
+    const res = await request(app)
+      .put('/api/budgets')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        budgets: [
+          { category: 'Food', limit: 500, alert_threshold: 0.8, enable_alerts: true },
+        ],
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.budgets[0].alert_threshold).toBe(0.8);
+  });
+});

--- a/__tests__/budgets-integration.test.ts
+++ b/__tests__/budgets-integration.test.ts
@@ -1,0 +1,327 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import app from '../src/app';
+import UserModel from '../src/models/User';
+import ExpenseModel from '../src/models/Expense';
+
+let mongod: MongoMemoryServer;
+let userId: string;
+let authToken: string;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+}, 30000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+beforeEach(async () => {
+  for (const col of Object.values(mongoose.connection.collections)) {
+    await col.deleteMany({});
+  }
+  const oid = new mongoose.Types.ObjectId();
+  userId = oid.toString();
+  await UserModel.create({
+    _id: oid,
+    email: `budgettest-${Date.now()}@example.com`,
+    password: 'password123',
+    budgets: [],
+  });
+  authToken = jwt.sign({ userId }, 'test-secret');
+});
+
+// --- GET /api/budgets ---
+
+describe('GET /api/budgets', () => {
+  it('returns empty budgets array for new user', async () => {
+    const res = await request(app)
+      .get('/api/budgets')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.budgets).toEqual([]);
+  });
+
+  it('returns budgets after they are set', async () => {
+    await request(app)
+      .put('/api/budgets')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ budgets: [{ category: 'Food', limit: 500 }] });
+
+    const res = await request(app)
+      .get('/api/budgets')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.budgets).toHaveLength(1);
+    expect(res.body.budgets[0].category).toBe('Food');
+    expect(res.body.budgets[0].limit).toBe(500);
+  });
+
+  it('rejects unauthenticated request with 401', async () => {
+    const res = await request(app).get('/api/budgets');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 for non-existent user', async () => {
+    const fakeToken = jwt.sign(
+      { userId: new mongoose.Types.ObjectId().toString() },
+      'test-secret'
+    );
+    const res = await request(app)
+      .get('/api/budgets')
+      .set('Authorization', `Bearer ${fakeToken}`);
+    expect(res.status).toBe(404);
+  });
+});
+
+// --- PUT /api/budgets ---
+
+describe('PUT /api/budgets', () => {
+  it('saves multiple budgets', async () => {
+    const budgets = [
+      { category: 'Food', limit: 500 },
+      { category: 'Transport', limit: 200 },
+      { category: 'Entertainment', limit: 300 },
+    ];
+    const res = await request(app)
+      .put('/api/budgets')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ budgets });
+    expect(res.status).toBe(200);
+    expect(res.body.budgets).toHaveLength(3);
+  });
+
+  it('replaces existing budgets on update', async () => {
+    await request(app)
+      .put('/api/budgets')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ budgets: [{ category: 'Food', limit: 500 }, { category: 'Transport', limit: 200 }] });
+
+    const res = await request(app)
+      .put('/api/budgets')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ budgets: [{ category: 'Food', limit: 800 }] });
+    expect(res.status).toBe(200);
+    expect(res.body.budgets).toHaveLength(1);
+    expect(res.body.budgets[0].limit).toBe(800);
+  });
+
+  it('filters out zero-limit budgets', async () => {
+    const res = await request(app)
+      .put('/api/budgets')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        budgets: [
+          { category: 'Food', limit: 500 },
+          { category: 'Removed', limit: 0 },
+        ],
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.budgets).toHaveLength(1);
+    expect(res.body.budgets[0].category).toBe('Food');
+  });
+
+  it('rejects non-array budgets with 400', async () => {
+    const res = await request(app)
+      .put('/api/budgets')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ budgets: 'not-an-array' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects missing category with 400', async () => {
+    const res = await request(app)
+      .put('/api/budgets')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ budgets: [{ limit: 100 }] });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects non-numeric limit with 400', async () => {
+    const res = await request(app)
+      .put('/api/budgets')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ budgets: [{ category: 'Food', limit: 'abc' }] });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects unauthenticated request with 401', async () => {
+    const res = await request(app)
+      .put('/api/budgets')
+      .send({ budgets: [{ category: 'Food', limit: 500 }] });
+    expect(res.status).toBe(401);
+  });
+
+  it('saves budgets with alert_threshold and enable_alerts', async () => {
+    const res = await request(app)
+      .put('/api/budgets')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        budgets: [
+          { category: 'Food', limit: 500, alert_threshold: 0.75, enable_alerts: true },
+        ],
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.budgets[0].alert_threshold).toBe(0.75);
+    expect(res.body.budgets[0].enable_alerts).toBe(true);
+  });
+});
+
+// --- GET /api/budgets/summary ---
+
+describe('GET /api/budgets/summary', () => {
+  it('returns empty summary for user with no budgets', async () => {
+    const res = await request(app)
+      .get('/api/budgets/summary')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.summary).toEqual([]);
+  });
+
+  it('returns budget summary structure with correct fields', async () => {
+    await UserModel.findByIdAndUpdate(userId, {
+      $set: {
+        budgets: [
+          { category: 'Food', limit: 500, alert_threshold: 0.9, enable_alerts: true },
+        ],
+      },
+    });
+
+    const res = await request(app)
+      .get('/api/budgets/summary')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.summary).toHaveLength(1);
+
+    const food = res.body.summary[0];
+    expect(food.category).toBe('Food');
+    expect(food.limit).toBe(500);
+    expect(typeof food.spend).toBe('number');
+    expect(typeof food.remaining).toBe('number');
+    expect(typeof food.percentUsed).toBe('number');
+    expect(typeof food.exceeds).toBe('boolean');
+    expect(typeof food.alertTriggered).toBe('boolean');
+    expect(food.thresholdPercentage).toBe(90);
+  });
+
+  it('returns 404 for non-existent user', async () => {
+    const fakeToken = jwt.sign(
+      { userId: new mongoose.Types.ObjectId().toString() },
+      'test-secret'
+    );
+    const res = await request(app)
+      .get('/api/budgets/summary')
+      .set('Authorization', `Bearer ${fakeToken}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects unauthenticated request with 401', async () => {
+    const res = await request(app).get('/api/budgets/summary');
+    expect(res.status).toBe(401);
+  });
+});
+
+// --- POST /api/budgets/:category/alerts ---
+
+describe('POST /api/budgets/:category/alerts', () => {
+  beforeEach(async () => {
+    await UserModel.findByIdAndUpdate(userId, {
+      $set: {
+        budgets: [
+          { category: 'Food', limit: 500, enable_alerts: false },
+        ],
+      },
+    });
+  });
+
+  it('enables alerts for an existing budget category', async () => {
+    const res = await request(app)
+      .post('/api/budgets/Food/alerts')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ enable_alerts: true });
+    expect(res.status).toBe(200);
+    expect(res.body.message).toContain('enabled');
+
+    const user = await UserModel.findById(userId).lean();
+    const foodBudget = user!.budgets.find((b) => b.category === 'Food');
+    expect(foodBudget!.enable_alerts).toBe(true);
+  });
+
+  it('disables alerts for an existing budget category', async () => {
+    await UserModel.findByIdAndUpdate(userId, {
+      $set: {
+        budgets: [
+          { category: 'Food', limit: 500, enable_alerts: true },
+        ],
+      },
+    });
+
+    const res = await request(app)
+      .post('/api/budgets/Food/alerts')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ enable_alerts: false });
+    expect(res.status).toBe(200);
+    expect(res.body.message).toContain('disabled');
+  });
+
+  it('returns 404 for non-existent budget category', async () => {
+    const res = await request(app)
+      .post('/api/budgets/Shopping/alerts')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ enable_alerts: true });
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects invalid enable_alerts value with 400', async () => {
+    const res = await request(app)
+      .post('/api/budgets/Food/alerts')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ enable_alerts: 'yes' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects unauthenticated request with 401', async () => {
+    const res = await request(app)
+      .post('/api/budgets/Food/alerts')
+      .send({ enable_alerts: true });
+    expect(res.status).toBe(401);
+  });
+});
+
+// --- User isolation ---
+
+describe('Budget user isolation', () => {
+  it('does not return budgets from other users', async () => {
+    await UserModel.findByIdAndUpdate(userId, {
+      $set: { budgets: [{ category: 'Food', limit: 500 }] },
+    });
+
+    const otherOid = new mongoose.Types.ObjectId();
+    await UserModel.create({
+      _id: otherOid,
+      email: `other-${Date.now()}@example.com`,
+      password: 'password123',
+      budgets: [{ category: 'Transport', limit: 999 }],
+    });
+    const otherToken = jwt.sign({ userId: otherOid.toString() }, 'test-secret');
+
+    const resA = await request(app)
+      .get('/api/budgets')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(resA.body.budgets).toHaveLength(1);
+    expect(resA.body.budgets[0].category).toBe('Food');
+
+    const resB = await request(app)
+      .get('/api/budgets')
+      .set('Authorization', `Bearer ${otherToken}`);
+    expect(resB.body.budgets).toHaveLength(1);
+    expect(resB.body.budgets[0].category).toBe('Transport');
+  });
+});

--- a/__tests__/budgets.test.ts
+++ b/__tests__/budgets.test.ts
@@ -1,0 +1,92 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import app from '../src/app';
+import UserModel from '../src/models/User';
+
+let mongod: MongoMemoryServer;
+let authToken: string;
+let userId: string;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+beforeEach(async () => {
+  const user = await UserModel.create({ email: 'budget@example.com', password: 'password123' });
+  userId = (user._id as mongoose.Types.ObjectId).toString();
+  authToken = jwt.sign({ userId }, 'test-secret');
+});
+
+afterEach(async () => {
+  for (const col of Object.values(mongoose.connection.collections)) {
+    await col.deleteMany({});
+  }
+});
+
+describe('GET /api/budgets', () => {
+  it('returns empty array for new user', async () => {
+    const res = await request(app)
+      .get('/api/budgets')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.budgets).toEqual([]);
+  });
+
+  it('rejects unauthenticated request with 401', async () => {
+    const res = await request(app).get('/api/budgets');
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('PUT /api/budgets', () => {
+  it('saves budget array', async () => {
+    const budgets = [{ category: 'Food', limit: 500 }, { category: 'Transport', limit: 200 }];
+    const res = await request(app)
+      .put('/api/budgets')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ budgets });
+    expect(res.status).toBe(200);
+    expect(res.body.budgets).toHaveLength(2);
+    expect(res.body.budgets[0].category).toBe('Food');
+  });
+
+  it('updates existing budgets (upsert)', async () => {
+    await request(app)
+      .put('/api/budgets')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ budgets: [{ category: 'Food', limit: 500 }] });
+
+    const res = await request(app)
+      .put('/api/budgets')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ budgets: [{ category: 'Food', limit: 800 }] });
+    expect(res.status).toBe(200);
+    expect(res.body.budgets[0].limit).toBe(800);
+  });
+
+  it('rejects unauthenticated request with 401', async () => {
+    const res = await request(app)
+      .put('/api/budgets')
+      .send({ budgets: [{ category: 'Food', limit: 500 }] });
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects non-array budgets with 400', async () => {
+    const res = await request(app)
+      .put('/api/budgets')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ budgets: 'invalid' });
+    expect(res.status).toBe(400);
+  });
+});

--- a/__tests__/db.test.ts
+++ b/__tests__/db.test.ts
@@ -1,0 +1,62 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import request from 'supertest';
+import app from '../src/app';
+import { getRetryDelay, getHealthStatus, BASE_DELAY_MS, CONNECTION_TIMEOUT_MS, MIN_POOL_SIZE, MAX_POOL_SIZE } from '../src/db';
+
+let mongod: MongoMemoryServer;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+describe('getRetryDelay', () => {
+  it('returns exponential backoff delay', () => {
+    expect(getRetryDelay(0)).toBe(BASE_DELAY_MS);
+    expect(getRetryDelay(1)).toBe(BASE_DELAY_MS * 2);
+    expect(getRetryDelay(2)).toBe(BASE_DELAY_MS * 4);
+    expect(getRetryDelay(3)).toBe(BASE_DELAY_MS * 8);
+  });
+});
+
+describe('connection config constants', () => {
+  it('has correct timeout and pool settings', () => {
+    expect(CONNECTION_TIMEOUT_MS).toBe(10_000);
+    expect(MIN_POOL_SIZE).toBe(5);
+    expect(MAX_POOL_SIZE).toBe(10);
+  });
+});
+
+describe('getHealthStatus', () => {
+  it('returns healthy when connected', async () => {
+    const health = await getHealthStatus();
+    expect(health.status).toBe('healthy');
+    expect(health.dbState).toBe('connected');
+    expect(typeof health.responseTimeMs).toBe('number');
+  });
+});
+
+describe('GET /api/health', () => {
+  it('returns 200 with healthy status', async () => {
+    const res = await request(app).get('/api/health');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('healthy');
+    expect(res.body.dbState).toBe('connected');
+    expect(res.body).toHaveProperty('responseTimeMs');
+  });
+
+  it('preserves existing /health endpoint', async () => {
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'ok' });
+  });
+});

--- a/__tests__/db.test.ts
+++ b/__tests__/db.test.ts
@@ -57,6 +57,6 @@ describe('GET /api/health', () => {
   it('preserves existing /health endpoint', async () => {
     const res = await request(app).get('/health');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ status: 'ok' });
+    expect(res.body.status).toBe('ok');
   });
 });

--- a/__tests__/delete-account.test.ts
+++ b/__tests__/delete-account.test.ts
@@ -1,0 +1,163 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import app from '../src/app';
+import ExpenseModel from '../src/models/Expense';
+import GoalModel from '../src/models/Goal';
+import TransactionTemplateModel from '../src/models/TransactionTemplate';
+import RecurringExpenseModel from '../src/models/RecurringExpense';
+import AccountModel from '../src/models/Account';
+import NetWorthModel from '../src/models/NetWorth';
+import { WeeklyPulseModel } from '../src/models/WeeklyPulse';
+import AlertModel from '../src/models/Alert';
+import ItemPriceModel from '../src/models/ItemPrice';
+import UserModel from '../src/models/User';
+
+let mongod: MongoMemoryServer;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  for (const col of Object.values(mongoose.connection.collections)) {
+    await col.deleteMany({});
+  }
+});
+
+const registerAndLogin = async (
+  email = 'delete-me@example.com',
+  password = 'password123'
+): Promise<{ token: string; userId: string }> => {
+  const res = await request(app)
+    .post('/auth/register')
+    .send({ email, password });
+  const token = res.body.token as string;
+  const decoded = JSON.parse(
+    Buffer.from(token.split('.')[1], 'base64').toString()
+  ) as { userId: string };
+  return { token, userId: decoded.userId };
+};
+
+describe('DELETE /auth/account', () => {
+  it('deletes user and all associated data', async () => {
+    const { token, userId } = await registerAndLogin();
+
+    // Seed data across all collections
+    await Promise.all([
+      ExpenseModel.create({ owner: userId, amount: 100, category: 'food', date: new Date() }),
+      ExpenseModel.create({ owner: userId, amount: 50, category: 'transport', date: new Date() }),
+      GoalModel.create({ userId, name: 'Save 10k', targetAmount: 10000, currentAmount: 0 }),
+      TransactionTemplateModel.create({ owner: userId, name: 'Rent', amount: 5000, category: 'housing', frequency: 'monthly' }),
+      RecurringExpenseModel.create({ userId, name: 'Netflix', amount: 79, category: 'entertainment', frequency: 'MONTHLY', start_date: new Date(), nextDueDate: new Date() }),
+      AccountModel.create({ userId, name: 'HSBC', type: 'checking', balance: 5000, currency: 'HKD' }),
+      NetWorthModel.create({ userId, date: new Date(), assets: 10000, liabilities: 2000, netWorth: 8000 }),
+      WeeklyPulseModel.create({
+        userId,
+        weekStart: '2024-01-01',
+        narrative: 'Test week summary',
+        stats: { totalSpend: 500, fourWeekAverage: 400, deltaPercent: 25, topCategory: 'food', highestSpendDay: 'Monday', largestTransaction: null, transactionCount: 10 },
+      }),
+      AlertModel.create({ userId, category: 'food', amount: 90, limit: 100, percentUsed: 0.9, message: 'Near limit' }),
+      ItemPriceModel.create({ userId, merchant: 'PARKnSHOP', itemName: 'Milk', price: 25, currency: 'HKD', lastSeen: new Date() }),
+    ]);
+
+    // Verify data exists
+    expect(await ExpenseModel.countDocuments({ owner: userId })).toBe(2);
+    expect(await GoalModel.countDocuments({ userId })).toBe(1);
+    expect(await TransactionTemplateModel.countDocuments({ owner: userId })).toBe(1);
+
+    // Delete account
+    const res = await request(app)
+      .delete('/auth/account')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ password: 'password123' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Account and all data deleted');
+
+    // Verify all data is gone
+    expect(await UserModel.findById(userId)).toBeNull();
+    expect(await ExpenseModel.countDocuments({ owner: userId })).toBe(0);
+    expect(await GoalModel.countDocuments({ userId })).toBe(0);
+    expect(await TransactionTemplateModel.countDocuments({ owner: userId })).toBe(0);
+    expect(await RecurringExpenseModel.countDocuments({ userId })).toBe(0);
+    expect(await AccountModel.countDocuments({ userId })).toBe(0);
+    expect(await NetWorthModel.countDocuments({ userId })).toBe(0);
+    expect(await WeeklyPulseModel.countDocuments({ userId })).toBe(0);
+    expect(await AlertModel.countDocuments({ userId })).toBe(0);
+    expect(await ItemPriceModel.countDocuments({ userId })).toBe(0);
+  });
+
+  it('does not delete other users data', async () => {
+    const { token, userId } = await registerAndLogin('user-a@example.com', 'password123');
+    const { userId: otherUserId } = await registerAndLogin('user-b@example.com', 'password123');
+
+    await ExpenseModel.create({ owner: userId, amount: 100, category: 'food', date: new Date() });
+    await ExpenseModel.create({ owner: otherUserId, amount: 200, category: 'food', date: new Date() });
+
+    const res = await request(app)
+      .delete('/auth/account')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ password: 'password123' });
+
+    expect(res.status).toBe(200);
+    expect(await ExpenseModel.countDocuments({ owner: otherUserId })).toBe(1);
+    expect(await UserModel.findById(otherUserId)).not.toBeNull();
+  });
+
+  it('returns 401 with incorrect password', async () => {
+    const { token } = await registerAndLogin();
+
+    const res = await request(app)
+      .delete('/auth/account')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ password: 'wrongpassword' });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('Incorrect password');
+  });
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app)
+      .delete('/auth/account')
+      .send({ password: 'password123' });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 without password in body', async () => {
+    const { token } = await registerAndLogin();
+
+    const res = await request(app)
+      .delete('/auth/account')
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+
+    expect(res.status).toBe(400);
+  });
+
+  it('prevents login after account deletion', async () => {
+    const { token } = await registerAndLogin('gone@example.com', 'password123');
+
+    await request(app)
+      .delete('/auth/account')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ password: 'password123' });
+
+    const loginRes = await request(app)
+      .post('/auth/login')
+      .send({ email: 'gone@example.com', password: 'password123' });
+
+    expect(loginRes.status).toBe(401);
+  });
+});

--- a/__tests__/expenses-analytics.test.ts
+++ b/__tests__/expenses-analytics.test.ts
@@ -1,0 +1,179 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import app from '../src/app';
+import ExpenseModel from '../src/models/Expense';
+
+let mongod: MongoMemoryServer;
+const TEST_USER_ID = 'analytics_user_123';
+const OTHER_USER_ID = 'analytics_other_456';
+const authToken = jwt.sign({ userId: TEST_USER_ID }, 'test-secret');
+const otherToken = jwt.sign({ userId: OTHER_USER_ID }, 'test-secret');
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  for (const col of Object.values(mongoose.connection.collections)) {
+    await col.deleteMany({});
+  }
+});
+
+async function seed(docs: object[]) {
+  await ExpenseModel.insertMany(docs);
+}
+
+describe('GET /api/expenses/analytics', () => {
+  it('requires auth', async () => {
+    const res = await request(app).get('/api/expenses/analytics');
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects invalid month format', async () => {
+    const res = await request(app)
+      .get('/api/expenses/analytics?month=2024-13')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/YYYY-MM/);
+  });
+
+  it('returns zeros for empty data', async () => {
+    const res = await request(app)
+      .get('/api/expenses/analytics?month=2024-01')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.totalIncome).toBe(0);
+    expect(res.body.totalExpense).toBe(0);
+    expect(res.body.netBalance).toBe(0);
+    expect(res.body.categoryBreakdown).toEqual([]);
+    expect(res.body.dailyTotals).toEqual([]);
+  });
+
+  it('returns correct totals for a specific month', async () => {
+    await seed([
+      { owner: TEST_USER_ID, amount: 300, type: 'income', category: 'Salary', date: new Date('2024-03-05') },
+      { owner: TEST_USER_ID, amount: 100, type: 'expense', category: 'Food', date: new Date('2024-03-10') },
+      { owner: TEST_USER_ID, amount: 50, type: 'expense', category: 'Transport', date: new Date('2024-03-15') },
+    ]);
+
+    const res = await request(app)
+      .get('/api/expenses/analytics?month=2024-03')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.totalIncome).toBe(300);
+    expect(res.body.totalExpense).toBe(150);
+    expect(res.body.netBalance).toBe(150);
+  });
+
+  it('returns categoryBreakdown sorted by total desc with percentages', async () => {
+    await seed([
+      { owner: TEST_USER_ID, amount: 200, type: 'expense', category: 'Food', date: new Date('2024-03-01') },
+      { owner: TEST_USER_ID, amount: 100, type: 'expense', category: 'Food', date: new Date('2024-03-02') },
+      { owner: TEST_USER_ID, amount: 100, type: 'expense', category: 'Transport', date: new Date('2024-03-03') },
+    ]);
+
+    const res = await request(app)
+      .get('/api/expenses/analytics?month=2024-03')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    const breakdown = res.body.categoryBreakdown;
+    expect(breakdown[0].category).toBe('Food');
+    expect(breakdown[0].total).toBe(300);
+    expect(breakdown[0].count).toBe(2);
+    expect(breakdown[0].percentage).toBe(75);
+    expect(breakdown[1].category).toBe('Transport');
+    expect(breakdown[1].total).toBe(100);
+    expect(breakdown[1].percentage).toBe(25);
+  });
+
+  it('returns dailyTotals grouped by date', async () => {
+    await seed([
+      { owner: TEST_USER_ID, amount: 100, type: 'expense', category: 'Food', date: new Date('2024-03-10') },
+      { owner: TEST_USER_ID, amount: 50, type: 'expense', category: 'Transport', date: new Date('2024-03-10') },
+      { owner: TEST_USER_ID, amount: 200, type: 'income', category: 'Salary', date: new Date('2024-03-15') },
+    ]);
+
+    const res = await request(app)
+      .get('/api/expenses/analytics?month=2024-03')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    const daily = res.body.dailyTotals;
+    const mar10 = daily.find((d: { date: string }) => d.date === '2024-03-10');
+    const mar15 = daily.find((d: { date: string }) => d.date === '2024-03-15');
+    expect(mar10.expense).toBe(150);
+    expect(mar10.income).toBe(0);
+    expect(mar15.income).toBe(200);
+    expect(mar15.expense).toBe(0);
+  });
+
+  it('only returns data for the authenticated user', async () => {
+    await seed([
+      { owner: TEST_USER_ID, amount: 100, type: 'expense', category: 'Food', date: new Date('2024-03-01') },
+      { owner: OTHER_USER_ID, amount: 999, type: 'expense', category: 'Food', date: new Date('2024-03-01') },
+    ]);
+
+    const res = await request(app)
+      .get('/api/expenses/analytics?month=2024-03')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.totalExpense).toBe(100);
+  });
+
+  it('excludes expenses outside the requested month', async () => {
+    await seed([
+      { owner: TEST_USER_ID, amount: 100, type: 'expense', category: 'Food', date: new Date('2024-03-15') },
+      { owner: TEST_USER_ID, amount: 200, type: 'expense', category: 'Food', date: new Date('2024-04-01') },
+      { owner: TEST_USER_ID, amount: 50, type: 'expense', category: 'Food', date: new Date('2024-02-28') },
+    ]);
+
+    const res = await request(app)
+      .get('/api/expenses/analytics?month=2024-03')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.totalExpense).toBe(100);
+  });
+
+  it('defaults to current month when month param is omitted', async () => {
+    const now = new Date();
+    const thisMonth = new Date(now.getFullYear(), now.getMonth(), 15);
+    await seed([
+      { owner: TEST_USER_ID, amount: 75, type: 'expense', category: 'Food', date: thisMonth },
+    ]);
+
+    const res = await request(app)
+      .get('/api/expenses/analytics')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.totalExpense).toBe(75);
+  });
+
+  it('other user token sees only their own data', async () => {
+    await seed([
+      { owner: TEST_USER_ID, amount: 100, type: 'expense', category: 'Food', date: new Date('2024-03-01') },
+    ]);
+
+    const res = await request(app)
+      .get('/api/expenses/analytics?month=2024-03')
+      .set('Authorization', `Bearer ${otherToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.totalExpense).toBe(0);
+  });
+});

--- a/__tests__/expenses-integration.test.ts
+++ b/__tests__/expenses-integration.test.ts
@@ -73,6 +73,33 @@ describe('POST /api/expenses', () => {
     expect(res.status).toBe(400);
   });
 
+  it('rejects zero amount with 400', async () => {
+    const res = await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send({ ...validExpense, amount: 0 });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/positive/i);
+  });
+
+  it('rejects negative amount with 400', async () => {
+    const res = await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send({ ...validExpense, amount: -50 });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/positive/i);
+  });
+
+  it('rejects zero originalAmount with 400', async () => {
+    const res = await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send({ ...validExpense, originalAmount: 0 });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/positive/i);
+  });
+
   it('rejects unauthenticated request with 401', async () => {
     const res = await request(app)
       .post('/api/expenses')
@@ -245,6 +272,26 @@ describe('PUT /api/expenses/:id', () => {
       .set('Authorization', `Bearer ${tokenA}`)
       .send({ ...validExpense, amount: 'not-a-number' });
     expect(res.status).toBe(400);
+  });
+
+  it('rejects zero amount on update with 400', async () => {
+    const created = await createExpense(tokenA);
+    const res = await request(app)
+      .put(`/api/expenses/${created.body._id}`)
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send({ ...validExpense, amount: 0 });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/positive/i);
+  });
+
+  it('rejects negative amount on update with 400', async () => {
+    const created = await createExpense(tokenA);
+    const res = await request(app)
+      .put(`/api/expenses/${created.body._id}`)
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send({ ...validExpense, amount: -25 });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/positive/i);
   });
 });
 

--- a/__tests__/expenses-integration.test.ts
+++ b/__tests__/expenses-integration.test.ts
@@ -1,0 +1,318 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import app from '../src/app';
+import ExpenseModel from '../src/models/Expense';
+
+let mongod: MongoMemoryServer;
+
+const USER_A_ID = new mongoose.Types.ObjectId().toString();
+const USER_B_ID = new mongoose.Types.ObjectId().toString();
+const tokenA = jwt.sign({ userId: USER_A_ID }, 'test-secret');
+const tokenB = jwt.sign({ userId: USER_B_ID }, 'test-secret');
+
+const validExpense = {
+  description: 'Lunch',
+  amount: 85,
+  type: 'expense',
+  category: 'Food',
+};
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+}, 30000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  for (const col of Object.values(mongoose.connection.collections)) {
+    await col.deleteMany({});
+  }
+});
+
+async function createExpense(token: string, overrides: Record<string, unknown> = {}) {
+  const res = await request(app)
+    .post('/api/expenses')
+    .set('Authorization', `Bearer ${token}`)
+    .send({ ...validExpense, ...overrides });
+  return res;
+}
+
+// --- POST /api/expenses ---
+
+describe('POST /api/expenses', () => {
+  it('creates an expense with valid data', async () => {
+    const res = await createExpense(tokenA);
+    expect(res.status).toBe(201);
+    expect(res.body.description).toBe('Lunch');
+    expect(res.body.amount).toBe(85);
+    expect(res.body.owner).toBe(USER_A_ID);
+  });
+
+  it('rejects missing amount with 400', async () => {
+    const res = await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send({ description: 'No amount', type: 'expense', category: 'Food' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects non-numeric amount with 400', async () => {
+    const res = await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send({ ...validExpense, amount: 'abc' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects unauthenticated request with 401', async () => {
+    const res = await request(app)
+      .post('/api/expenses')
+      .send(validExpense);
+    expect(res.status).toBe(401);
+  });
+
+  it('creates expense with optional fields', async () => {
+    const res = await createExpense(tokenA, {
+      paymentMethod: 'octopus',
+      currency: 'HKD',
+      participants: ['Alice', 'Bob'],
+      splitBill: true,
+    });
+    expect(res.status).toBe(201);
+    expect(res.body.paymentMethod).toBe('octopus');
+    expect(res.body.currency).toBe('HKD');
+    expect(res.body.participants).toEqual(['Alice', 'Bob']);
+    expect(res.body.splitBill).toBe(true);
+  });
+
+  it('rejects invalid paymentMethod with 400', async () => {
+    const res = await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send({ ...validExpense, paymentMethod: 'bitcoin' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects invalid currency with 400', async () => {
+    const res = await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send({ ...validExpense, currency: 'BTC' });
+    expect(res.status).toBe(400);
+  });
+
+  it('sets owner to authenticated user regardless of body', async () => {
+    const res = await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send({ ...validExpense, owner: USER_B_ID });
+    expect(res.status).toBe(201);
+    expect(res.body.owner).toBe(USER_A_ID);
+  });
+});
+
+// --- GET /api/expenses ---
+
+describe('GET /api/expenses', () => {
+  it('returns only the authenticated user expenses', async () => {
+    await createExpense(tokenA, { description: 'User A expense' });
+    await createExpense(tokenB, { description: 'User B expense' });
+
+    const res = await request(app)
+      .get('/api/expenses')
+      .set('Authorization', `Bearer ${tokenA}`);
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].description).toBe('User A expense');
+  });
+
+  it('returns empty data for user with no expenses', async () => {
+    const res = await request(app)
+      .get('/api/expenses')
+      .set('Authorization', `Bearer ${tokenA}`);
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(0);
+    expect(res.body.total).toBe(0);
+  });
+
+  it('paginates correctly', async () => {
+    for (let i = 0; i < 5; i++) {
+      await createExpense(tokenA, { description: `Expense ${i}`, amount: (i + 1) * 10 });
+    }
+
+    const page1 = await request(app)
+      .get('/api/expenses?page=1&limit=2')
+      .set('Authorization', `Bearer ${tokenA}`);
+    expect(page1.body.data).toHaveLength(2);
+    expect(page1.body.pagination.total).toBe(5);
+    expect(page1.body.pagination.totalPages).toBe(3);
+
+    const page3 = await request(app)
+      .get('/api/expenses?page=3&limit=2')
+      .set('Authorization', `Bearer ${tokenA}`);
+    expect(page3.body.data).toHaveLength(1);
+  });
+
+  it('filters by paymentMethod', async () => {
+    await createExpense(tokenA, { description: 'Cash lunch', paymentMethod: 'cash' });
+    await createExpense(tokenA, { description: 'Card dinner', paymentMethod: 'credit_card', amount: 200 });
+
+    const res = await request(app)
+      .get('/api/expenses?paymentMethod=cash')
+      .set('Authorization', `Bearer ${tokenA}`);
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].paymentMethod).toBe('cash');
+  });
+
+  it('rejects invalid paymentMethod filter with 400', async () => {
+    const res = await request(app)
+      .get('/api/expenses?paymentMethod=bitcoin')
+      .set('Authorization', `Bearer ${tokenA}`);
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects unauthenticated request with 401', async () => {
+    const res = await request(app).get('/api/expenses');
+    expect(res.status).toBe(401);
+  });
+
+  it('sorts by date ascending', async () => {
+    await createExpense(tokenA, { description: 'Old', date: '2026-01-01', amount: 10 });
+    await createExpense(tokenA, { description: 'New', date: '2026-03-01', amount: 20 });
+
+    const res = await request(app)
+      .get('/api/expenses?sort=date&order=asc')
+      .set('Authorization', `Bearer ${tokenA}`);
+    expect(res.body.data[0].description).toBe('Old');
+    expect(res.body.data[1].description).toBe('New');
+  });
+});
+
+// --- PUT /api/expenses/:id ---
+
+describe('PUT /api/expenses/:id', () => {
+  it('updates own expense successfully', async () => {
+    const created = await createExpense(tokenA);
+    const res = await request(app)
+      .put(`/api/expenses/${created.body._id}`)
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send({ ...validExpense, description: 'Updated lunch', amount: 120 });
+    expect(res.status).toBe(200);
+    expect(res.body.description).toBe('Updated lunch');
+    expect(res.body.amount).toBe(120);
+  });
+
+  it('returns 404 when updating another user expense', async () => {
+    const created = await createExpense(tokenA);
+    const res = await request(app)
+      .put(`/api/expenses/${created.body._id}`)
+      .set('Authorization', `Bearer ${tokenB}`)
+      .send({ ...validExpense, description: 'Hacked' });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 for non-existent expense id', async () => {
+    const fakeId = new mongoose.Types.ObjectId().toString();
+    const res = await request(app)
+      .put(`/api/expenses/${fakeId}`)
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send(validExpense);
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects unauthenticated request with 401', async () => {
+    const created = await createExpense(tokenA);
+    const res = await request(app)
+      .put(`/api/expenses/${created.body._id}`)
+      .send(validExpense);
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects non-numeric amount on update with 400', async () => {
+    const created = await createExpense(tokenA);
+    const res = await request(app)
+      .put(`/api/expenses/${created.body._id}`)
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send({ ...validExpense, amount: 'not-a-number' });
+    expect(res.status).toBe(400);
+  });
+});
+
+// --- DELETE /api/expenses/:id ---
+
+describe('DELETE /api/expenses/:id', () => {
+  it('deletes own expense successfully', async () => {
+    const created = await createExpense(tokenA);
+    const res = await request(app)
+      .delete(`/api/expenses/${created.body._id}`)
+      .set('Authorization', `Bearer ${tokenA}`);
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Deleted');
+
+    const verify = await request(app)
+      .get(`/api/expenses/${created.body._id}`)
+      .set('Authorization', `Bearer ${tokenA}`);
+    expect(verify.status).toBe(404);
+  });
+
+  it('returns 404 when deleting another user expense', async () => {
+    const created = await createExpense(tokenA);
+    const res = await request(app)
+      .delete(`/api/expenses/${created.body._id}`)
+      .set('Authorization', `Bearer ${tokenB}`);
+    expect(res.status).toBe(404);
+
+    // Verify expense still exists for owner
+    const verify = await request(app)
+      .get(`/api/expenses/${created.body._id}`)
+      .set('Authorization', `Bearer ${tokenA}`);
+    expect(verify.status).toBe(200);
+  });
+
+  it('returns 404 for non-existent expense id', async () => {
+    const fakeId = new mongoose.Types.ObjectId().toString();
+    const res = await request(app)
+      .delete(`/api/expenses/${fakeId}`)
+      .set('Authorization', `Bearer ${tokenA}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects unauthenticated request with 401', async () => {
+    const created = await createExpense(tokenA);
+    const res = await request(app)
+      .delete(`/api/expenses/${created.body._id}`);
+    expect(res.status).toBe(401);
+  });
+});
+
+// --- GET /api/expenses/:id ---
+
+describe('GET /api/expenses/:id', () => {
+  it('returns a single expense by id', async () => {
+    const created = await createExpense(tokenA);
+    const res = await request(app)
+      .get(`/api/expenses/${created.body._id}`)
+      .set('Authorization', `Bearer ${tokenA}`);
+    expect(res.status).toBe(200);
+    expect(res.body._id).toBe(created.body._id);
+    expect(res.body.description).toBe('Lunch');
+  });
+
+  it('returns 404 for another user expense', async () => {
+    const created = await createExpense(tokenA);
+    const res = await request(app)
+      .get(`/api/expenses/${created.body._id}`)
+      .set('Authorization', `Bearer ${tokenB}`);
+    expect(res.status).toBe(404);
+  });
+});

--- a/__tests__/expenses-participants.test.ts
+++ b/__tests__/expenses-participants.test.ts
@@ -1,0 +1,137 @@
+// Integration tests for participants field in POST/PUT /api/expenses
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import app from '../src/app';
+
+let mongod: MongoMemoryServer;
+const TEST_USER_ID = 'user_test_123';
+const authToken = jwt.sign({ userId: TEST_USER_ID }, 'test-secret');
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  for (const col of Object.values(mongoose.connection.collections)) {
+    await col.deleteMany({});
+  }
+});
+
+const basePayload = {
+  owner: TEST_USER_ID,
+  description: 'Test expense',
+  amount: 100,
+  type: 'expense',
+  category: 'Other',
+};
+
+describe('POST /api/expenses — participants field', () => {
+  it('accepts valid participants array', async () => {
+    const res = await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ...basePayload, participants: ['Alice', 'Bob'] });
+    expect(res.status).toBe(201);
+    expect(res.body.participants).toEqual(['Alice', 'Bob']);
+  });
+
+  it('accepts empty participants array', async () => {
+    const res = await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ...basePayload, participants: [] });
+    expect(res.status).toBe(201);
+    expect(res.body.participants).toEqual([]);
+  });
+
+  it('defaults to [] when participants field is missing', async () => {
+    const res = await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send(basePayload);
+    expect(res.status).toBe(201);
+    expect(res.body.participants).toEqual([]);
+  });
+
+  it('rejects non-array value', async () => {
+    const res = await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ...basePayload, participants: 'Alice' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects empty string in array', async () => {
+    const res = await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ...basePayload, participants: [''] });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects duplicate names (case-insensitive)', async () => {
+    const res = await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ...basePayload, participants: ['Alice', 'alice'] });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects array exceeding 20 items', async () => {
+    const big = Array.from({ length: 21 }, (_, i) => `Person${i}`);
+    const res = await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ...basePayload, participants: big });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('PUT /api/expenses/:id — participants field', () => {
+  let expenseId: string;
+
+  beforeEach(async () => {
+    const res = await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ...basePayload, participants: ['Alice'] });
+    expenseId = res.body._id;
+  });
+
+  it('updates participants successfully', async () => {
+    const res = await request(app)
+      .put(`/api/expenses/${expenseId}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ...basePayload, participants: ['Alice', 'Charlie'] });
+    expect(res.status).toBe(200);
+    expect(res.body.participants).toEqual(expect.arrayContaining(['Alice', 'Charlie']));
+  });
+
+  it('rejects duplicate names on update', async () => {
+    const res = await request(app)
+      .put(`/api/expenses/${expenseId}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ...basePayload, participants: ['Alice', 'alice'] });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects name over 100 chars on update', async () => {
+    const longName = 'a'.repeat(101);
+    const res = await request(app)
+      .put(`/api/expenses/${expenseId}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ...basePayload, participants: [longName] });
+    expect(res.status).toBe(400);
+  });
+});

--- a/__tests__/expenses.test.ts
+++ b/__tests__/expenses.test.ts
@@ -99,6 +99,54 @@ describe('POST /api/expenses', () => {
     expect(res.status).toBe(201);
     expect(res.body.owner).toBe(TEST_USER_ID);
   });
+
+  it('detects exact duplicates (same amount, exact description)', async () => {
+    await createExpense({ description: 'Coffee', amount: 5 });
+    const res = await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ...basePayload, description: 'Coffee', amount: 5 });
+    expect(res.status).toBe(409);
+    expect(res.body.error).toContain('Potential duplicate detected');
+  });
+
+  it('detects similar duplicates (90%+ similarity)', async () => {
+    await createExpense({ description: 'Starbucks Coffee', amount: 7.50 });
+    const res = await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ...basePayload, description: 'Starbucks Coffe', amount: 7.50 });
+    expect(res.status).toBe(409);
+    expect(res.body.error).toContain('Potential duplicate detected');
+  });
+
+  it('allows different amounts with same description', async () => {
+    await createExpense({ description: 'Coffee', amount: 5 });
+    const res = await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ...basePayload, description: 'Coffee', amount: 6 });
+    expect(res.status).toBe(201);
+  });
+
+  it('allows similar description with different amount', async () => {
+    await createExpense({ description: 'Coffee', amount: 5 });
+    const res = await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ...basePayload, description: 'Coffe', amount: 10 });
+    expect(res.status).toBe(201);
+  });
+
+
+  it('isolates duplicates per user', async () => {
+    await createExpense({ description: 'Coffee', amount: 5 });
+    const res = await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${otherToken}`)
+      .send({ ...basePayload, description: 'Coffee', amount: 5 });
+    expect(res.status).toBe(201);
+  });
 });
 
 describe('PUT /api/expenses/:id', () => {

--- a/__tests__/expenses.test.ts
+++ b/__tests__/expenses.test.ts
@@ -69,6 +69,58 @@ describe('GET /api/expenses', () => {
     expect(res.body.page).toBe(2);
     expect(res.body.data).toHaveLength(1);
   });
+
+  it('returns pagination object in response', async () => {
+    await createExpense();
+    const res = await request(app)
+      .get('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.body.pagination).toBeDefined();
+    expect(res.body.pagination.page).toBe(1);
+    expect(res.body.pagination.limit).toBe(50);
+    expect(res.body.pagination.total).toBe(1);
+    expect(res.body.pagination.totalPages).toBe(1);
+  });
+
+  it('caps limit at 200', async () => {
+    await createExpense();
+    const res = await request(app)
+      .get('/api/expenses?limit=500')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.body.pagination.limit).toBe(200);
+  });
+
+  it('sorts by amount ascending', async () => {
+    await createExpense({ amount: 300, description: 'Expensive' });
+    await createExpense({ amount: 50, description: 'Cheap' });
+    await createExpense({ amount: 150, description: 'Medium' });
+    const res = await request(app)
+      .get('/api/expenses?sort=amount&order=asc')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.body.data[0].amount).toBe(50);
+    expect(res.body.data[1].amount).toBe(150);
+    expect(res.body.data[2].amount).toBe(300);
+  });
+
+  it('sorts by amount descending', async () => {
+    await createExpense({ amount: 300, description: 'Expensive' });
+    await createExpense({ amount: 50, description: 'Cheap' });
+    await createExpense({ amount: 150, description: 'Medium' });
+    const res = await request(app)
+      .get('/api/expenses?sort=amount&order=desc')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.body.data[0].amount).toBe(300);
+    expect(res.body.data[2].amount).toBe(50);
+  });
+
+  it('ignores invalid sort fields', async () => {
+    await createExpense();
+    const res = await request(app)
+      .get('/api/expenses?sort=invalid')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+  });
 });
 
 describe('GET /api/expenses/:id', () => {

--- a/__tests__/expenses.test.ts
+++ b/__tests__/expenses.test.ts
@@ -1,0 +1,143 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import app from '../src/app';
+
+let mongod: MongoMemoryServer;
+const TEST_USER_ID = 'user_test_123';
+const OTHER_USER_ID = 'user_other_456';
+const authToken = jwt.sign({ userId: TEST_USER_ID }, 'test-secret');
+const otherToken = jwt.sign({ userId: OTHER_USER_ID }, 'test-secret');
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  for (const col of Object.values(mongoose.connection.collections)) {
+    await col.deleteMany({});
+  }
+});
+
+const basePayload = {
+  description: 'Test expense',
+  amount: 100,
+  type: 'expense',
+  category: 'Food',
+};
+
+async function createExpense(overrides = {}) {
+  const res = await request(app)
+    .post('/api/expenses')
+    .set('Authorization', `Bearer ${authToken}`)
+    .send({ ...basePayload, ...overrides });
+  return res.body;
+}
+
+describe('GET /api/expenses', () => {
+  it('returns paginated results', async () => {
+    await createExpense({ description: 'Expense 1' });
+    await createExpense({ description: 'Expense 2' });
+    const res = await request(app)
+      .get('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.total).toBe(2);
+    expect(res.body.page).toBe(1);
+    expect(res.body.pages).toBeDefined();
+  });
+
+  it('supports pagination with page=2', async () => {
+    for (let i = 0; i < 3; i++) {
+      await createExpense({ description: `Expense ${i}` });
+    }
+    const res = await request(app)
+      .get('/api/expenses?page=2&limit=2')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.page).toBe(2);
+    expect(res.body.data).toHaveLength(1);
+  });
+});
+
+describe('GET /api/expenses/:id', () => {
+  it('returns specific expense', async () => {
+    const created = await createExpense();
+    const res = await request(app)
+      .get(`/api/expenses/${created._id}`)
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body._id).toBe(created._id);
+  });
+
+  it('returns 404 for non-existent id', async () => {
+    const fakeId = new mongoose.Types.ObjectId().toString();
+    const res = await request(app)
+      .get(`/api/expenses/${fakeId}`)
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /api/expenses', () => {
+  it('creates expense and forces owner to req.userId', async () => {
+    const res = await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ...basePayload, owner: 'hacker_id' });
+    expect(res.status).toBe(201);
+    expect(res.body.owner).toBe(TEST_USER_ID);
+  });
+});
+
+describe('PUT /api/expenses/:id', () => {
+  it('updates expense', async () => {
+    const created = await createExpense();
+    const res = await request(app)
+      .put(`/api/expenses/${created._id}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ...basePayload, description: 'Updated', amount: 200 });
+    expect(res.status).toBe(200);
+    expect(res.body.description).toBe('Updated');
+    expect(res.body.amount).toBe(200);
+  });
+
+  it('returns 404 for wrong owner', async () => {
+    const created = await createExpense();
+    const res = await request(app)
+      .put(`/api/expenses/${created._id}`)
+      .set('Authorization', `Bearer ${otherToken}`)
+      .send({ ...basePayload, description: 'Hacked' });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('DELETE /api/expenses/:id', () => {
+  it('deletes expense', async () => {
+    const created = await createExpense();
+    const res = await request(app)
+      .delete(`/api/expenses/${created._id}`)
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Deleted');
+  });
+
+  it('returns 404 for wrong owner', async () => {
+    const created = await createExpense();
+    const res = await request(app)
+      .delete(`/api/expenses/${created._id}`)
+      .set('Authorization', `Bearer ${otherToken}`);
+    expect(res.status).toBe(404);
+  });
+});

--- a/__tests__/export.test.ts
+++ b/__tests__/export.test.ts
@@ -124,6 +124,72 @@ describe('GET /api/export/csv', () => {
     expect(res.text).not.toContain('TooNew');
   });
 
+  it('respects from filter only (no to filter)', async () => {
+    await createExpense({
+      description: 'Before',
+      date: '2025-12-01T00:00:00.000Z',
+    });
+    await createExpense({
+      description: 'After',
+      date: '2026-01-20T00:00:00.000Z',
+    });
+
+    const res = await request(app)
+      .get('/api/export/csv?from=2026-01-01')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.text).not.toContain('Before');
+    expect(res.text).toContain('After');
+  });
+
+  it('respects to filter only (no from filter)', async () => {
+    await createExpense({
+      description: 'Old',
+      date: '2025-12-01T00:00:00.000Z',
+    });
+    await createExpense({
+      description: 'New',
+      date: '2026-02-05T00:00:00.000Z',
+    });
+
+    const res = await request(app)
+      .get('/api/export/csv?to=2026-01-31')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Old');
+    expect(res.text).not.toContain('New');
+  });
+
+  it('combines type filter with date filters', async () => {
+    await createExpense({
+      description: 'Old Expense',
+      type: 'expense',
+      date: '2025-12-01T00:00:00.000Z',
+    });
+    await createExpense({
+      description: 'Jan Salary',
+      type: 'income',
+      amount: 5000,
+      date: '2026-01-20T00:00:00.000Z',
+    });
+    await createExpense({
+      description: 'Jan Expense',
+      type: 'expense',
+      date: '2026-01-25T00:00:00.000Z',
+    });
+
+    const res = await request(app)
+      .get('/api/export/csv?type=expense&from=2026-01-01&to=2026-01-31')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.text).not.toContain('Old Expense');
+    expect(res.text).not.toContain('Jan Salary');
+    expect(res.text).toContain('Jan Expense');
+  });
+
   it('returns 500 when ExpenseModel.find throws', async () => {
     const spy = jest.spyOn(ExpenseModel, 'find').mockImplementationOnce(() => {
       throw new Error('db fail');

--- a/__tests__/export.test.ts
+++ b/__tests__/export.test.ts
@@ -10,7 +10,9 @@ import ExpenseModel from '../src/models/Expense';
 
 let mongod: MongoMemoryServer;
 const TEST_USER_ID = 'user_test_export';
+const OTHER_USER_ID = 'user_other';
 const authToken = jwt.sign({ userId: TEST_USER_ID }, 'test-secret');
+const otherToken = jwt.sign({ userId: OTHER_USER_ID }, 'test-secret');
 
 beforeAll(async () => {
   mongod = await MongoMemoryServer.create();
@@ -43,26 +45,25 @@ async function createExpense(overrides: Record<string, unknown> = {}) {
     .send({ ...basePayload, ...overrides });
 }
 
+// ===================== CSV TESTS =====================
+
 describe('GET /api/export/csv', () => {
   it('returns 401 when Authorization header is missing', async () => {
     const res = await request(app).get('/api/export/csv');
     expect(res.status).toBe(401);
   });
 
-  it('returns CSV content-type', async () => {
+  it('returns CSV content-type and proper filename', async () => {
     const res = await request(app)
       .get('/api/export/csv')
       .set('Authorization', `Bearer ${authToken}`);
     expect(res.status).toBe(200);
     expect(res.headers['content-type']).toMatch(/text\/csv/);
-    expect(res.headers['content-disposition']).toMatch(/attachment; filename="money-flow-/);
+    expect(res.headers['content-disposition']).toMatch(/attachment; filename="money-flow-export-/);
   });
 
   it('includes expense rows in output', async () => {
-    await request(app)
-      .post('/api/expenses')
-      .set('Authorization', `Bearer ${authToken}`)
-      .send({ description: 'Lunch', amount: 15, type: 'expense', category: 'Food' });
+    await createExpense({ description: 'Lunch', amount: 15, category: 'Food' });
 
     const res = await request(app)
       .get('/api/export/csv')
@@ -101,18 +102,9 @@ describe('GET /api/export/csv', () => {
   });
 
   it('respects from/to date filters', async () => {
-    await createExpense({
-      description: 'Old',
-      date: '2025-12-01T00:00:00.000Z',
-    });
-    await createExpense({
-      description: 'New',
-      date: '2026-01-20T00:00:00.000Z',
-    });
-    await createExpense({
-      description: 'TooNew',
-      date: '2026-02-05T00:00:00.000Z',
-    });
+    await createExpense({ description: 'Old', date: '2025-12-01T00:00:00.000Z' });
+    await createExpense({ description: 'New', date: '2026-01-20T00:00:00.000Z' });
+    await createExpense({ description: 'TooNew', date: '2026-02-05T00:00:00.000Z' });
 
     const res = await request(app)
       .get('/api/export/csv?from=2026-01-01&to=2026-01-31')
@@ -125,14 +117,8 @@ describe('GET /api/export/csv', () => {
   });
 
   it('respects from filter only (no to filter)', async () => {
-    await createExpense({
-      description: 'Before',
-      date: '2025-12-01T00:00:00.000Z',
-    });
-    await createExpense({
-      description: 'After',
-      date: '2026-01-20T00:00:00.000Z',
-    });
+    await createExpense({ description: 'Before', date: '2025-12-01T00:00:00.000Z' });
+    await createExpense({ description: 'After', date: '2026-01-20T00:00:00.000Z' });
 
     const res = await request(app)
       .get('/api/export/csv?from=2026-01-01')
@@ -144,14 +130,8 @@ describe('GET /api/export/csv', () => {
   });
 
   it('respects to filter only (no from filter)', async () => {
-    await createExpense({
-      description: 'Old',
-      date: '2025-12-01T00:00:00.000Z',
-    });
-    await createExpense({
-      description: 'New',
-      date: '2026-02-05T00:00:00.000Z',
-    });
+    await createExpense({ description: 'Old', date: '2025-12-01T00:00:00.000Z' });
+    await createExpense({ description: 'New', date: '2026-02-05T00:00:00.000Z' });
 
     const res = await request(app)
       .get('/api/export/csv?to=2026-01-31')
@@ -163,22 +143,9 @@ describe('GET /api/export/csv', () => {
   });
 
   it('combines type filter with date filters', async () => {
-    await createExpense({
-      description: 'Old Expense',
-      type: 'expense',
-      date: '2025-12-01T00:00:00.000Z',
-    });
-    await createExpense({
-      description: 'Jan Salary',
-      type: 'income',
-      amount: 5000,
-      date: '2026-01-20T00:00:00.000Z',
-    });
-    await createExpense({
-      description: 'Jan Expense',
-      type: 'expense',
-      date: '2026-01-25T00:00:00.000Z',
-    });
+    await createExpense({ description: 'Old Expense', type: 'expense', date: '2025-12-01T00:00:00.000Z' });
+    await createExpense({ description: 'Jan Salary', type: 'income', amount: 5000, date: '2026-01-20T00:00:00.000Z' });
+    await createExpense({ description: 'Jan Expense', type: 'expense', date: '2026-01-25T00:00:00.000Z' });
 
     const res = await request(app)
       .get('/api/export/csv?type=expense&from=2026-01-01&to=2026-01-31')
@@ -188,6 +155,60 @@ describe('GET /api/export/csv', () => {
     expect(res.text).not.toContain('Old Expense');
     expect(res.text).not.toContain('Jan Salary');
     expect(res.text).toContain('Jan Expense');
+  });
+
+  it('respects category filter', async () => {
+    await createExpense({ description: 'Lunch', category: 'Food' });
+    await createExpense({ description: 'Bus', category: 'Transport', amount: 5 });
+
+    const res = await request(app)
+      .get('/api/export/csv?category=Transport')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Bus');
+    expect(res.text).not.toContain('Lunch');
+  });
+
+  it('respects q (text search) filter', async () => {
+    await createExpense({ description: 'Pizza from Dominos' });
+    await createExpense({ description: 'Bus ticket', amount: 5 });
+
+    const res = await request(app)
+      .get('/api/export/csv?q=pizza')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Pizza from Dominos');
+    expect(res.text).not.toContain('Bus ticket');
+  });
+
+  it('respects paymentMethod filter', async () => {
+    await createExpense({ description: 'Cash lunch', paymentMethod: 'cash' });
+    await createExpense({ description: 'Card dinner', paymentMethod: 'credit_card', amount: 200 });
+
+    const res = await request(app)
+      .get('/api/export/csv?paymentMethod=cash')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Cash lunch');
+    expect(res.text).not.toContain('Card dinner');
+  });
+
+  it('respects minAmount and maxAmount filters', async () => {
+    await createExpense({ description: 'Cheap', amount: 5 });
+    await createExpense({ description: 'Medium', amount: 50 });
+    await createExpense({ description: 'Expensive', amount: 500 });
+
+    const res = await request(app)
+      .get('/api/export/csv?minAmount=10&maxAmount=100')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Medium');
+    expect(res.text).not.toContain('Cheap');
+    expect(res.text).not.toContain('Expensive');
   });
 
   it('returns 500 when ExpenseModel.find throws', async () => {
@@ -212,5 +233,188 @@ describe('GET /api/export/csv', () => {
     const lines = res.text.trim().split('\n');
     expect(lines).toHaveLength(1);
     expect(lines[0]).toContain('Date');
+  });
+
+  it('only exports authenticated user data', async () => {
+    await createExpense({ description: 'My expense' });
+    // Create expense for other user
+    await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${otherToken}`)
+      .send({ ...basePayload, description: 'Other user expense' });
+
+    const res = await request(app)
+      .get('/api/export/csv')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('My expense');
+    expect(res.text).not.toContain('Other user expense');
+  });
+});
+
+// ===================== PDF TESTS =====================
+
+describe('GET /api/export/pdf', () => {
+  it('returns 401 when Authorization header is missing', async () => {
+    const res = await request(app).get('/api/export/pdf');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns PDF content-type and proper filename', async () => {
+    const res = await request(app)
+      .get('/api/export/pdf')
+      .set('Authorization', `Bearer ${authToken}`)
+      .buffer(true);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/application\/pdf/);
+    expect(res.headers['content-disposition']).toMatch(/attachment; filename="money-flow-export-/);
+  });
+
+  it('returns valid PDF with %PDF header', async () => {
+    await createExpense({ description: 'PDF test' });
+
+    const res = await request(app)
+      .get('/api/export/pdf')
+      .set('Authorization', `Bearer ${authToken}`)
+      .buffer(true);
+
+    expect(res.status).toBe(200);
+    // PDF files start with %PDF
+    expect(res.body.toString('ascii', 0, 4)).toBe('%PDF');
+  });
+
+  it('handles 0 transactions gracefully', async () => {
+    const res = await request(app)
+      .get('/api/export/pdf')
+      .set('Authorization', `Bearer ${authToken}`)
+      .buffer(true);
+
+    expect(res.status).toBe(200);
+    expect(res.body.toString('ascii', 0, 4)).toBe('%PDF');
+    // PDF with 0 transactions should still be a valid, non-empty document
+    expect(res.body.length).toBeGreaterThan(100);
+  });
+
+  it('includes category summary section (multi-page PDF)', async () => {
+    await createExpense({ description: 'Lunch', category: 'Food', amount: 20 });
+    await createExpense({ description: 'Bus', category: 'Transport', amount: 5 });
+
+    const res = await request(app)
+      .get('/api/export/pdf')
+      .set('Authorization', `Bearer ${authToken}`)
+      .buffer(true);
+
+    expect(res.status).toBe(200);
+    expect(res.body.toString('ascii', 0, 4)).toBe('%PDF');
+    // With transactions, the PDF should have both a table page and a summary page
+    // A multi-page PDF with summary will be larger than a single-page empty one
+    const emptyRes = await request(app)
+      .get('/api/export/pdf?type=nonexistent')
+      .set('Authorization', `Bearer ${authToken}`)
+      .buffer(true);
+    expect(res.body.length).toBeGreaterThan(emptyRes.body.length);
+  });
+
+  it('respects date filters (PDF uses same filter as CSV)', async () => {
+    await createExpense({ description: 'Old', date: '2025-12-01T00:00:00.000Z', amount: 100 });
+    await createExpense({ description: 'InRange', date: '2026-01-15T00:00:00.000Z', amount: 50 });
+
+    // Verify PDF endpoint applies filters by comparing with CSV output
+    const [pdfRes, csvRes] = await Promise.all([
+      request(app)
+        .get('/api/export/pdf?from=2026-01-01&to=2026-01-31')
+        .set('Authorization', `Bearer ${authToken}`)
+        .buffer(true),
+      request(app)
+        .get('/api/export/csv?from=2026-01-01&to=2026-01-31')
+        .set('Authorization', `Bearer ${authToken}`),
+    ]);
+
+    expect(pdfRes.status).toBe(200);
+    expect(pdfRes.body.toString('ascii', 0, 4)).toBe('%PDF');
+    // CSV confirms the filter works - only InRange, not Old
+    expect(csvRes.text).toContain('InRange');
+    expect(csvRes.text).not.toContain('Old');
+  });
+
+  it('respects category filter (PDF uses same filter as CSV)', async () => {
+    await createExpense({ description: 'Lunch', category: 'Food' });
+    await createExpense({ description: 'Train', category: 'Transport', amount: 10 });
+
+    const [pdfRes, csvRes] = await Promise.all([
+      request(app)
+        .get('/api/export/pdf?category=Food')
+        .set('Authorization', `Bearer ${authToken}`)
+        .buffer(true),
+      request(app)
+        .get('/api/export/csv?category=Food')
+        .set('Authorization', `Bearer ${authToken}`),
+    ]);
+
+    expect(pdfRes.status).toBe(200);
+    expect(pdfRes.body.toString('ascii', 0, 4)).toBe('%PDF');
+    // CSV confirms filter logic
+    expect(csvRes.text).toContain('Lunch');
+    expect(csvRes.text).not.toContain('Train');
+  });
+
+  it('respects q (text search) filter', async () => {
+    await createExpense({ description: 'Sushi dinner' });
+    await createExpense({ description: 'Gas station', amount: 40 });
+
+    const [pdfRes, csvRes] = await Promise.all([
+      request(app)
+        .get('/api/export/pdf?q=sushi')
+        .set('Authorization', `Bearer ${authToken}`)
+        .buffer(true),
+      request(app)
+        .get('/api/export/csv?q=sushi')
+        .set('Authorization', `Bearer ${authToken}`),
+    ]);
+
+    expect(pdfRes.status).toBe(200);
+    expect(pdfRes.body.toString('ascii', 0, 4)).toBe('%PDF');
+    // CSV confirms filter logic
+    expect(csvRes.text).toContain('Sushi dinner');
+    expect(csvRes.text).not.toContain('Gas station');
+  });
+
+  it('returns 500 when ExpenseModel.find throws', async () => {
+    const spy = jest.spyOn(ExpenseModel, 'find').mockImplementationOnce(() => {
+      throw new Error('db fail');
+    });
+
+    const res = await request(app)
+      .get('/api/export/pdf')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'Failed to export PDF' });
+    spy.mockRestore();
+  });
+
+  it('only exports authenticated user data (verified via CSV parity)', async () => {
+    await createExpense({ description: 'My pdf expense' });
+    await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${otherToken}`)
+      .send({ ...basePayload, description: 'Other user pdf expense' });
+
+    const [pdfRes, csvRes] = await Promise.all([
+      request(app)
+        .get('/api/export/pdf')
+        .set('Authorization', `Bearer ${authToken}`)
+        .buffer(true),
+      request(app)
+        .get('/api/export/csv')
+        .set('Authorization', `Bearer ${authToken}`),
+    ]);
+
+    expect(pdfRes.status).toBe(200);
+    expect(pdfRes.body.toString('ascii', 0, 4)).toBe('%PDF');
+    // CSV uses same filter function, confirming user isolation
+    expect(csvRes.text).toContain('My pdf expense');
+    expect(csvRes.text).not.toContain('Other user pdf expense');
   });
 });

--- a/__tests__/export.test.ts
+++ b/__tests__/export.test.ts
@@ -1,0 +1,150 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import app from '../src/app';
+import ExpenseModel from '../src/models/Expense';
+
+let mongod: MongoMemoryServer;
+const TEST_USER_ID = 'user_test_export';
+const authToken = jwt.sign({ userId: TEST_USER_ID }, 'test-secret');
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  for (const col of Object.values(mongoose.connection.collections)) {
+    await col.deleteMany({});
+  }
+  jest.restoreAllMocks();
+});
+
+const basePayload = {
+  description: 'Test expense',
+  amount: 15,
+  type: 'expense',
+  category: 'Food',
+};
+
+async function createExpense(overrides: Record<string, unknown> = {}) {
+  await request(app)
+    .post('/api/expenses')
+    .set('Authorization', `Bearer ${authToken}`)
+    .send({ ...basePayload, ...overrides });
+}
+
+describe('GET /api/export/csv', () => {
+  it('returns 401 when Authorization header is missing', async () => {
+    const res = await request(app).get('/api/export/csv');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns CSV content-type', async () => {
+    const res = await request(app)
+      .get('/api/export/csv')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/text\/csv/);
+    expect(res.headers['content-disposition']).toMatch(/attachment; filename="money-flow-/);
+  });
+
+  it('includes expense rows in output', async () => {
+    await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ description: 'Lunch', amount: 15, type: 'expense', category: 'Food' });
+
+    const res = await request(app)
+      .get('/api/export/csv')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Lunch');
+    expect(res.text).toContain('Food');
+  });
+
+  it('escapes commas, quotes, and newlines in CSV cells', async () => {
+    await createExpense({
+      description: 'He said "hi", ok\nline2',
+      participants: ['Alice', 'Bob'],
+    });
+
+    const res = await request(app)
+      .get('/api/export/csv')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.text).toMatch(/"He said ""hi"", ok\nline2"/);
+    expect(res.text).toContain('Alice;Bob');
+  });
+
+  it('respects type filter', async () => {
+    await createExpense({ description: 'Salary', type: 'income', amount: 1000, category: 'Work' });
+    await createExpense({ description: 'Groceries', type: 'expense', amount: 50, category: 'Food' });
+
+    const res = await request(app)
+      .get('/api/export/csv?type=income')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Salary');
+    expect(res.text).not.toContain('Groceries');
+  });
+
+  it('respects from/to date filters', async () => {
+    await createExpense({
+      description: 'Old',
+      date: '2025-12-01T00:00:00.000Z',
+    });
+    await createExpense({
+      description: 'New',
+      date: '2026-01-20T00:00:00.000Z',
+    });
+    await createExpense({
+      description: 'TooNew',
+      date: '2026-02-05T00:00:00.000Z',
+    });
+
+    const res = await request(app)
+      .get('/api/export/csv?from=2026-01-01&to=2026-01-31')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('New');
+    expect(res.text).not.toContain('Old');
+    expect(res.text).not.toContain('TooNew');
+  });
+
+  it('returns 500 when ExpenseModel.find throws', async () => {
+    const spy = jest.spyOn(ExpenseModel, 'find').mockImplementationOnce(() => {
+      throw new Error('db fail');
+    });
+
+    const res = await request(app)
+      .get('/api/export/csv')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'Failed to export CSV' });
+    spy.mockRestore();
+  });
+
+  it('returns only header row when no transactions', async () => {
+    const res = await request(app)
+      .get('/api/export/csv')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    const lines = res.text.trim().split('\n');
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('Date');
+  });
+});

--- a/__tests__/friends.test.ts
+++ b/__tests__/friends.test.ts
@@ -1,0 +1,191 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import app from '../src/app';
+import UserModel from '../src/models/User';
+import FriendshipModel from '../src/models/Friendship';
+
+let mongod: MongoMemoryServer;
+let userA: string;
+let userB: string;
+let tokenA: string;
+let tokenB: string;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+
+  const a = await UserModel.create({ email: 'alice@test.com', password: 'pass123456' });
+  const b = await UserModel.create({ email: 'bob@test.com', password: 'pass123456' });
+  userA = String(a._id);
+  userB = String(b._id);
+  tokenA = jwt.sign({ userId: userA }, 'test-secret');
+  tokenB = jwt.sign({ userId: userB }, 'test-secret');
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  await FriendshipModel.deleteMany({});
+});
+
+describe('POST /api/friends/request', () => {
+  it('returns 401 without auth', async () => {
+    await request(app).post('/api/friends/request').send({ email: 'bob@test.com' }).expect(401);
+  });
+
+  it('sends friend request by email', async () => {
+    const res = await request(app)
+      .post('/api/friends/request')
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send({ email: 'bob@test.com' })
+      .expect(201);
+    expect(res.body.status).toBe('pending');
+    expect(res.body.email).toBe('bob@test.com');
+  });
+
+  it('returns 404 for non-existent user', async () => {
+    await request(app)
+      .post('/api/friends/request')
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send({ email: 'nobody@test.com' })
+      .expect(404);
+  });
+
+  it('returns 400 when friending yourself', async () => {
+    await request(app)
+      .post('/api/friends/request')
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send({ email: 'alice@test.com' })
+      .expect(400);
+  });
+
+  it('returns 409 for duplicate request', async () => {
+    await request(app)
+      .post('/api/friends/request')
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send({ email: 'bob@test.com' })
+      .expect(201);
+    await request(app)
+      .post('/api/friends/request')
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send({ email: 'bob@test.com' })
+      .expect(409);
+  });
+
+  it('returns 400 for invalid email', async () => {
+    await request(app)
+      .post('/api/friends/request')
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send({ email: 'not-an-email' })
+      .expect(400);
+  });
+});
+
+describe('GET /api/friends/pending', () => {
+  it('returns pending requests for recipient', async () => {
+    await FriendshipModel.create({ requester: userA, recipient: userB, status: 'pending' });
+    const res = await request(app)
+      .get('/api/friends/pending')
+      .set('Authorization', `Bearer ${tokenB}`)
+      .expect(200);
+    expect(res.body.requests).toHaveLength(1);
+    expect(res.body.requests[0].email).toBe('alice@test.com');
+  });
+
+  it('returns empty for requester', async () => {
+    await FriendshipModel.create({ requester: userA, recipient: userB, status: 'pending' });
+    const res = await request(app)
+      .get('/api/friends/pending')
+      .set('Authorization', `Bearer ${tokenA}`)
+      .expect(200);
+    expect(res.body.requests).toHaveLength(0);
+  });
+});
+
+describe('POST /api/friends/:id/accept', () => {
+  it('accepts a pending request', async () => {
+    const f = await FriendshipModel.create({ requester: userA, recipient: userB, status: 'pending' });
+    await request(app)
+      .post(`/api/friends/${f._id}/accept`)
+      .set('Authorization', `Bearer ${tokenB}`)
+      .expect(200);
+    const updated = await FriendshipModel.findById(f._id);
+    expect(updated?.status).toBe('accepted');
+  });
+
+  it('returns 404 if not the recipient', async () => {
+    const f = await FriendshipModel.create({ requester: userA, recipient: userB, status: 'pending' });
+    await request(app)
+      .post(`/api/friends/${f._id}/accept`)
+      .set('Authorization', `Bearer ${tokenA}`)
+      .expect(404);
+  });
+});
+
+describe('POST /api/friends/:id/reject', () => {
+  it('rejects and removes the request', async () => {
+    const f = await FriendshipModel.create({ requester: userA, recipient: userB, status: 'pending' });
+    await request(app)
+      .post(`/api/friends/${f._id}/reject`)
+      .set('Authorization', `Bearer ${tokenB}`)
+      .expect(200);
+    const deleted = await FriendshipModel.findById(f._id);
+    expect(deleted).toBeNull();
+  });
+});
+
+describe('GET /api/friends', () => {
+  it('returns accepted friends for both users', async () => {
+    await FriendshipModel.create({ requester: userA, recipient: userB, status: 'accepted' });
+
+    const resA = await request(app)
+      .get('/api/friends')
+      .set('Authorization', `Bearer ${tokenA}`)
+      .expect(200);
+    expect(resA.body.friends).toHaveLength(1);
+    expect(resA.body.friends[0].email).toBe('bob@test.com');
+
+    const resB = await request(app)
+      .get('/api/friends')
+      .set('Authorization', `Bearer ${tokenB}`)
+      .expect(200);
+    expect(resB.body.friends).toHaveLength(1);
+    expect(resB.body.friends[0].email).toBe('alice@test.com');
+  });
+
+  it('does not return pending friendships', async () => {
+    await FriendshipModel.create({ requester: userA, recipient: userB, status: 'pending' });
+    const res = await request(app)
+      .get('/api/friends')
+      .set('Authorization', `Bearer ${tokenA}`)
+      .expect(200);
+    expect(res.body.friends).toHaveLength(0);
+  });
+});
+
+describe('DELETE /api/friends/:id', () => {
+  it('removes an accepted friendship', async () => {
+    const f = await FriendshipModel.create({ requester: userA, recipient: userB, status: 'accepted' });
+    await request(app)
+      .delete(`/api/friends/${f._id}`)
+      .set('Authorization', `Bearer ${tokenA}`)
+      .expect(200);
+    const deleted = await FriendshipModel.findById(f._id);
+    expect(deleted).toBeNull();
+  });
+
+  it('returns 404 for non-existent friendship', async () => {
+    await request(app)
+      .delete(`/api/friends/${new mongoose.Types.ObjectId()}`)
+      .set('Authorization', `Bearer ${tokenA}`)
+      .expect(404);
+  });
+});

--- a/__tests__/global-error-handler.test.ts
+++ b/__tests__/global-error-handler.test.ts
@@ -1,0 +1,38 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+
+describe('global error handler', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns 500 with a generic message when a route throws', async () => {
+    jest.resetModules();
+    jest.doMock('@sentry/node', () => ({
+      init: jest.fn(),
+      setupExpressErrorHandler: jest.fn(),
+    }));
+
+    jest.doMock('../src/routes/expenses', () => {
+      const { Router } = require('express');
+      const router = Router();
+
+      router.get('/boom', (_req: any, _res: any, next: any) => {
+        next(new Error('boom'));
+      });
+
+      return { __esModule: true, default: router };
+    });
+
+    const app = (await import('../src/app')).default;
+
+    const res = await request(app)
+      .get('/api/expenses/boom');
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'Internal server error' });
+  });
+});
+

--- a/__tests__/goals.test.ts
+++ b/__tests__/goals.test.ts
@@ -1,0 +1,215 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import app from '../src/app';
+import UserModel from '../src/models/User';
+import GoalModel from '../src/models/Goal';
+
+let mongod: MongoMemoryServer;
+let authToken: string;
+let userId: string;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+beforeEach(async () => {
+  const user = await UserModel.create({ email: 'goals@example.com', password: 'password123' });
+  userId = (user._id as mongoose.Types.ObjectId).toString();
+  authToken = jwt.sign({ userId }, 'test-secret');
+});
+
+afterEach(async () => {
+  for (const col of Object.values(mongoose.connection.collections)) {
+    await col.deleteMany({});
+  }
+});
+
+describe('GET /api/goals', () => {
+  it('returns empty array for new user', async () => {
+    const res = await request(app)
+      .get('/api/goals')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.goals).toEqual([]);
+  });
+
+  it('rejects unauthenticated request with 401', async () => {
+    const res = await request(app).get('/api/goals');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns only goals belonging to the authenticated user', async () => {
+    await GoalModel.create({ userId, name: 'My Goal', targetAmount: 1000 });
+    await GoalModel.create({ userId: 'other-user-id', name: 'Other Goal', targetAmount: 500 });
+
+    const res = await request(app)
+      .get('/api/goals')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.goals).toHaveLength(1);
+    expect(res.body.goals[0].name).toBe('My Goal');
+  });
+});
+
+describe('POST /api/goals', () => {
+  it('creates a goal with required fields', async () => {
+    const res = await request(app)
+      .post('/api/goals')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ name: 'Emergency Fund', targetAmount: 5000 });
+    expect(res.status).toBe(201);
+    expect(res.body.goal.name).toBe('Emergency Fund');
+    expect(res.body.goal.targetAmount).toBe(5000);
+    expect(res.body.goal.currentAmount).toBe(0);
+  });
+
+  it('creates a goal with all fields', async () => {
+    const res = await request(app)
+      .post('/api/goals')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        name: 'Vacation',
+        targetAmount: 3000,
+        currentAmount: 500,
+        deadline: '2026-12-31T00:00:00.000Z',
+        category: 'Travel',
+      });
+    expect(res.status).toBe(201);
+    expect(res.body.goal.currentAmount).toBe(500);
+    expect(res.body.goal.category).toBe('Travel');
+    expect(res.body.goal.deadline).toBeDefined();
+  });
+
+  it('rejects missing name', async () => {
+    const res = await request(app)
+      .post('/api/goals')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ targetAmount: 1000 });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('name is required');
+  });
+
+  it('rejects missing targetAmount', async () => {
+    const res = await request(app)
+      .post('/api/goals')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ name: 'Test' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('targetAmount must be a number');
+  });
+
+  it('rejects invalid deadline', async () => {
+    const res = await request(app)
+      .post('/api/goals')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ name: 'Test', targetAmount: 1000, deadline: 'not-a-date' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('deadline must be a valid ISO date');
+  });
+
+  it('rejects unauthenticated request', async () => {
+    const res = await request(app)
+      .post('/api/goals')
+      .send({ name: 'Test', targetAmount: 1000 });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('PUT /api/goals/:id', () => {
+  it('updates a goal', async () => {
+    const goal = await GoalModel.create({ userId, name: 'Old Name', targetAmount: 1000 });
+    const goalId = (goal._id as mongoose.Types.ObjectId).toString();
+
+    const res = await request(app)
+      .put(`/api/goals/${goalId}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ name: 'New Name', currentAmount: 250 });
+    expect(res.status).toBe(200);
+    expect(res.body.goal.name).toBe('New Name');
+    expect(res.body.goal.currentAmount).toBe(250);
+  });
+
+  it('returns 404 for non-existent goal', async () => {
+    const fakeId = new mongoose.Types.ObjectId().toString();
+    const res = await request(app)
+      .put(`/api/goals/${fakeId}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ name: 'Updated' });
+    expect(res.status).toBe(404);
+  });
+
+  it('prevents updating another user goal', async () => {
+    const goal = await GoalModel.create({ userId: 'other-user-id', name: 'Other', targetAmount: 500 });
+    const goalId = (goal._id as mongoose.Types.ObjectId).toString();
+
+    const res = await request(app)
+      .put(`/api/goals/${goalId}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ name: 'Hijacked' });
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects invalid targetAmount', async () => {
+    const goal = await GoalModel.create({ userId, name: 'Test', targetAmount: 1000 });
+    const goalId = (goal._id as mongoose.Types.ObjectId).toString();
+
+    const res = await request(app)
+      .put(`/api/goals/${goalId}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ targetAmount: 'abc' });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('DELETE /api/goals/:id', () => {
+  it('deletes a goal', async () => {
+    const goal = await GoalModel.create({ userId, name: 'Delete Me', targetAmount: 1000 });
+    const goalId = (goal._id as mongoose.Types.ObjectId).toString();
+
+    const res = await request(app)
+      .delete(`/api/goals/${goalId}`)
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.deleted).toBe(true);
+
+    const found = await GoalModel.findById(goalId);
+    expect(found).toBeNull();
+  });
+
+  it('returns 404 for non-existent goal', async () => {
+    const fakeId = new mongoose.Types.ObjectId().toString();
+    const res = await request(app)
+      .delete(`/api/goals/${fakeId}`)
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('prevents deleting another user goal', async () => {
+    const goal = await GoalModel.create({ userId: 'other-user-id', name: 'Not Mine', targetAmount: 500 });
+    const goalId = (goal._id as mongoose.Types.ObjectId).toString();
+
+    const res = await request(app)
+      .delete(`/api/goals/${goalId}`)
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects unauthenticated request', async () => {
+    const goal = await GoalModel.create({ userId, name: 'Test', targetAmount: 1000 });
+    const goalId = (goal._id as mongoose.Types.ObjectId).toString();
+
+    const res = await request(app).delete(`/api/goals/${goalId}`);
+    expect(res.status).toBe(401);
+  });
+});

--- a/__tests__/import-integration.test.ts
+++ b/__tests__/import-integration.test.ts
@@ -1,0 +1,85 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import app from '../src/app';
+
+let mongod: MongoMemoryServer;
+const TEST_USER_ID = 'user_test_import';
+const authToken = jwt.sign({ userId: TEST_USER_ID }, 'test-secret');
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  for (const col of Object.values(mongoose.connection.collections)) {
+    await col.deleteMany({});
+  }
+});
+
+const validCsv = `date,description,amount,category,type
+2024-01-15,Coffee,5.50,Food,expense
+2024-01-16,Salary,3000,Income,income`;
+
+const csvWithInvalidRows = `date,description,amount,category,type
+2024-01-15,Coffee,5.50,Food,expense
+,Missing Date,50,Food,expense
+2024-01-17,Bad Amount,N/A,Food,expense`;
+
+describe('POST /api/import/expenses', () => {
+  it('imports valid CSV file', async () => {
+    const res = await request(app)
+      .post('/api/import/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .attach('file', Buffer.from(validCsv), { filename: 'test.csv', contentType: 'text/csv' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.imported).toBe(2);
+    expect(res.body.skipped).toBe(0);
+    expect(res.body.errors).toHaveLength(0);
+  });
+
+  it('skips duplicates', async () => {
+    await request(app)
+      .post('/api/import/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .attach('file', Buffer.from(validCsv), { filename: 'test.csv', contentType: 'text/csv' });
+
+    const res = await request(app)
+      .post('/api/import/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .attach('file', Buffer.from(validCsv), { filename: 'test.csv', contentType: 'text/csv' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.imported).toBe(0);
+    expect(res.body.skipped).toBe(2);
+  });
+
+  it('returns error list for invalid rows', async () => {
+    const res = await request(app)
+      .post('/api/import/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .attach('file', Buffer.from(csvWithInvalidRows), { filename: 'test.csv', contentType: 'text/csv' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.imported).toBe(1);
+    expect(res.body.errors.length).toBeGreaterThan(0);
+  });
+
+  it('returns 400 when no file uploaded', async () => {
+    const res = await request(app)
+      .post('/api/import/expenses')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(400);
+  });
+});

--- a/__tests__/import.test.js
+++ b/__tests__/import.test.js
@@ -1,0 +1,44 @@
+"use strict";
+// Unit tests for CSV import parsing logic
+// These test the pure parsing/validation logic extracted from the route
+function parseAmount(raw) {
+    const cleaned = raw.replace(/[,$\s]/g, '');
+    const n = parseFloat(cleaned);
+    return isNaN(n) ? null : n;
+}
+function parseDate(raw) {
+    const d = new Date(raw);
+    return isNaN(d.getTime()) ? null : d;
+}
+function inferType(typeRaw, amount) {
+    const t = typeRaw.toLowerCase();
+    if (t === 'income' || t === 'credit')
+        return 'income';
+    if (t === 'expense' || t === 'debit')
+        return 'expense';
+    return amount >= 0 ? 'income' : 'expense';
+}
+describe('parseAmount', () => {
+    it('parses plain number', () => expect(parseAmount('150')).toBe(150));
+    it('parses negative number', () => expect(parseAmount('-50')).toBe(-50));
+    it('strips currency symbols', () => expect(parseAmount('$1,234.56')).toBe(1234.56));
+    it('returns null for empty string', () => expect(parseAmount('')).toBeNull());
+    it('returns null for non-numeric', () => expect(parseAmount('N/A')).toBeNull());
+});
+describe('parseDate', () => {
+    it('parses ISO date', () => {
+        const d = parseDate('2024-01-15');
+        expect(d).not.toBeNull();
+        expect(d.getFullYear()).toBe(2024);
+    });
+    it('returns null for invalid date', () => expect(parseDate('not-a-date')).toBeNull());
+    it('returns null for empty string', () => expect(parseDate('')).toBeNull());
+});
+describe('inferType', () => {
+    it('explicit income', () => expect(inferType('income', 100)).toBe('income'));
+    it('explicit credit', () => expect(inferType('credit', 100)).toBe('income'));
+    it('explicit expense', () => expect(inferType('expense', -100)).toBe('expense'));
+    it('explicit debit', () => expect(inferType('debit', 100)).toBe('expense'));
+    it('positive amount with no type → income', () => expect(inferType('', 100)).toBe('income'));
+    it('negative amount with no type → expense', () => expect(inferType('', -50)).toBe('expense'));
+});

--- a/__tests__/import.test.ts
+++ b/__tests__/import.test.ts
@@ -1,0 +1,47 @@
+// Unit tests for CSV import parsing logic
+// These test the pure parsing/validation logic extracted from the route
+
+function parseAmount(raw: string): number | null {
+  const cleaned = raw.replace(/[,$\s]/g, '');
+  const n = parseFloat(cleaned);
+  return isNaN(n) ? null : n;
+}
+
+function parseDate(raw: string): Date | null {
+  const d = new Date(raw);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+function inferType(typeRaw: string, amount: number): 'income' | 'expense' {
+  const t = typeRaw.toLowerCase();
+  if (t === 'income' || t === 'credit') return 'income';
+  if (t === 'expense' || t === 'debit') return 'expense';
+  return amount >= 0 ? 'income' : 'expense';
+}
+
+describe('parseAmount', () => {
+  it('parses plain number', () => expect(parseAmount('150')).toBe(150));
+  it('parses negative number', () => expect(parseAmount('-50')).toBe(-50));
+  it('strips currency symbols', () => expect(parseAmount('$1,234.56')).toBe(1234.56));
+  it('returns null for empty string', () => expect(parseAmount('')).toBeNull());
+  it('returns null for non-numeric', () => expect(parseAmount('N/A')).toBeNull());
+});
+
+describe('parseDate', () => {
+  it('parses ISO date', () => {
+    const d = parseDate('2024-01-15');
+    expect(d).not.toBeNull();
+    expect(d!.getFullYear()).toBe(2024);
+  });
+  it('returns null for invalid date', () => expect(parseDate('not-a-date')).toBeNull());
+  it('returns null for empty string', () => expect(parseDate('')).toBeNull());
+});
+
+describe('inferType', () => {
+  it('explicit income', () => expect(inferType('income', 100)).toBe('income'));
+  it('explicit credit', () => expect(inferType('credit', 100)).toBe('income'));
+  it('explicit expense', () => expect(inferType('expense', -100)).toBe('expense'));
+  it('explicit debit', () => expect(inferType('debit', 100)).toBe('expense'));
+  it('positive amount with no type → income', () => expect(inferType('', 100)).toBe('income'));
+  it('negative amount with no type → expense', () => expect(inferType('', -50)).toBe('expense'));
+});

--- a/__tests__/instrument.test.ts
+++ b/__tests__/instrument.test.ts
@@ -1,0 +1,33 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+describe('src/instrument', () => {
+  const ORIGINAL_DSN = process.env.SENTRY_DSN;
+
+  afterEach(() => {
+    process.env.SENTRY_DSN = ORIGINAL_DSN;
+    jest.resetModules();
+    jest.restoreAllMocks();
+  });
+
+  it('initializes Sentry when SENTRY_DSN is set', async () => {
+    const initMock = jest.fn();
+    jest.doMock('@sentry/node', () => ({ init: initMock }));
+
+    process.env.SENTRY_DSN = 'test-dsn';
+    await import('../src/instrument');
+
+    expect(initMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not initialize Sentry when SENTRY_DSN is not set', async () => {
+    const initMock = jest.fn();
+    jest.doMock('@sentry/node', () => ({ init: initMock }));
+
+    delete process.env.SENTRY_DSN;
+    await import('../src/instrument');
+
+    expect(initMock).not.toHaveBeenCalled();
+  });
+});
+

--- a/__tests__/jest-setup.ts
+++ b/__tests__/jest-setup.ts
@@ -1,0 +1,4 @@
+// Jest global setup — sets env vars before any module is imported
+process.env.JWT_SECRET = 'test-secret-for-jest';
+process.env.PORT = '0';
+// MONGODB_URI is set per test file via MongoMemoryServer

--- a/__tests__/monthly-summary.test.ts
+++ b/__tests__/monthly-summary.test.ts
@@ -1,0 +1,308 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import app from '../src/app';
+import ExpenseModel from '../src/models/Expense';
+import UserModel from '../src/models/User';
+import {
+  aggregateMonthlySummary,
+  formatMonthlySummaryMessage,
+  getPreviousMonthBounds,
+  getPriorMonthBounds,
+  buildBudgetAlerts,
+  MonthlySummaryData,
+} from '../src/utils/monthlySummary';
+
+let mongod: MongoMemoryServer;
+const TEST_USER_ID = new mongoose.Types.ObjectId().toString();
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+}, 30000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  for (const col of Object.values(mongoose.connection.collections)) {
+    await col.deleteMany({});
+  }
+});
+
+// Helper: build a date in the previous calendar month
+function prevMonthDate(dayOfMonth = 10): Date {
+  const now = new Date();
+  const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, dayOfMonth));
+  return d;
+}
+
+// Helper: build a date two months ago (prior month for MoM)
+function priorMonthDate(dayOfMonth = 10): Date {
+  const now = new Date();
+  const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 2, dayOfMonth));
+  return d;
+}
+
+describe('getPreviousMonthBounds', () => {
+  it('returns start/end spanning previous month', () => {
+    const now = new Date('2026-03-15T12:00:00Z');
+    const { start, end, label } = getPreviousMonthBounds(now);
+    expect(label).toBe('2026-02');
+    expect(start).toEqual(new Date('2026-02-01T00:00:00Z'));
+    expect(end).toEqual(new Date('2026-03-01T00:00:00Z'));
+  });
+
+  it('handles January (rolls back to December of prior year)', () => {
+    const now = new Date('2026-01-05T12:00:00Z');
+    const { start, end, label } = getPreviousMonthBounds(now);
+    expect(label).toBe('2025-12');
+    expect(start).toEqual(new Date('2025-12-01T00:00:00Z'));
+    expect(end).toEqual(new Date('2026-01-01T00:00:00Z'));
+  });
+});
+
+describe('getPriorMonthBounds', () => {
+  it('returns two months back', () => {
+    const now = new Date('2026-03-15T12:00:00Z');
+    const { start, end } = getPriorMonthBounds(now);
+    expect(start).toEqual(new Date('2026-01-01T00:00:00Z'));
+    expect(end).toEqual(new Date('2026-02-01T00:00:00Z'));
+  });
+
+  it('handles February — rolls to December of prior year', () => {
+    const now = new Date('2026-02-10T12:00:00Z');
+    const { start, end } = getPriorMonthBounds(now);
+    expect(start).toEqual(new Date('2025-12-01T00:00:00Z'));
+    expect(end).toEqual(new Date('2026-01-01T00:00:00Z'));
+  });
+});
+
+describe('aggregateMonthlySummary', () => {
+  it('returns zeros for user with no transactions', async () => {
+    const data = await aggregateMonthlySummary(TEST_USER_ID);
+    expect(data.totalIncome).toBe(0);
+    expect(data.totalExpense).toBe(0);
+    expect(data.net).toBe(0);
+    expect(data.topCategories).toEqual([]);
+    expect(data.momChangePercent).toBeNull();
+  });
+
+  it('aggregates income and expense for previous month', async () => {
+    await ExpenseModel.create([
+      { owner: TEST_USER_ID, amount: 3000, type: 'income', category: 'Salary', date: prevMonthDate(5) },
+      { owner: TEST_USER_ID, amount: 200, type: 'expense', category: 'Food', date: prevMonthDate(10) },
+      { owner: TEST_USER_ID, amount: 100, type: 'expense', category: 'Transport', date: prevMonthDate(15) },
+    ]);
+
+    const data = await aggregateMonthlySummary(TEST_USER_ID);
+    expect(data.totalIncome).toBe(3000);
+    expect(data.totalExpense).toBe(300);
+    expect(data.net).toBe(2700);
+  });
+
+  it('returns up to 5 top categories sorted by total descending', async () => {
+    await ExpenseModel.create([
+      { owner: TEST_USER_ID, amount: 500, type: 'expense', category: 'Rent', date: prevMonthDate(1) },
+      { owner: TEST_USER_ID, amount: 300, type: 'expense', category: 'Food', date: prevMonthDate(2) },
+      { owner: TEST_USER_ID, amount: 200, type: 'expense', category: 'Transport', date: prevMonthDate(3) },
+      { owner: TEST_USER_ID, amount: 100, type: 'expense', category: 'Entertainment', date: prevMonthDate(4) },
+      { owner: TEST_USER_ID, amount: 80, type: 'expense', category: 'Health', date: prevMonthDate(5) },
+      { owner: TEST_USER_ID, amount: 50, type: 'expense', category: 'Other', date: prevMonthDate(6) },
+    ]);
+
+    const data = await aggregateMonthlySummary(TEST_USER_ID);
+    expect(data.topCategories).toHaveLength(5);
+    expect(data.topCategories[0].category).toBe('Rent');
+    expect(data.topCategories[4].category).toBe('Health');
+  });
+
+  it('calculates month-over-month change percent', async () => {
+    await ExpenseModel.create([
+      { owner: TEST_USER_ID, amount: 200, type: 'expense', category: 'Food', date: prevMonthDate(10) },
+      { owner: TEST_USER_ID, amount: 100, type: 'expense', category: 'Food', date: priorMonthDate(10) },
+    ]);
+
+    const data = await aggregateMonthlySummary(TEST_USER_ID);
+    expect(data.momChangePercent).toBe(100); // doubled
+  });
+
+  it('returns null momChangePercent when no prior month data', async () => {
+    await ExpenseModel.create([
+      { owner: TEST_USER_ID, amount: 200, type: 'expense', category: 'Food', date: prevMonthDate(10) },
+    ]);
+
+    const data = await aggregateMonthlySummary(TEST_USER_ID);
+    expect(data.momChangePercent).toBeNull();
+  });
+
+  it('labels null category as Uncategorised', async () => {
+    await ExpenseModel.create([
+      { owner: TEST_USER_ID, amount: 50, type: 'expense', date: prevMonthDate(5) },
+    ]);
+
+    const data = await aggregateMonthlySummary(TEST_USER_ID);
+    expect(data.topCategories[0].category).toBe('Uncategorised');
+  });
+
+  it('does not include current month transactions', async () => {
+    const now = new Date();
+    await ExpenseModel.create([
+      { owner: TEST_USER_ID, amount: 999, type: 'expense', category: 'Food', date: now },
+    ]);
+
+    const data = await aggregateMonthlySummary(TEST_USER_ID);
+    expect(data.totalExpense).toBe(0);
+  });
+});
+
+describe('buildBudgetAlerts', () => {
+  it('returns empty array when no budgets set', async () => {
+    const categories = [{ category: 'Food', total: 500 }];
+    const alerts = await buildBudgetAlerts(TEST_USER_ID, categories, []);
+    expect(alerts).toEqual([]);
+  });
+
+  it('flags categories over budget', async () => {
+    const categories = [
+      { category: 'Food', total: 600 },
+      { category: 'Transport', total: 80 },
+    ];
+    const budgets = [
+      { category: 'Food', limit: 500 },
+      { category: 'Transport', limit: 100 },
+    ];
+    const alerts = await buildBudgetAlerts(TEST_USER_ID, categories, budgets);
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].category).toBe('Food');
+    expect(alerts[0].spent).toBe(600);
+    expect(alerts[0].limit).toBe(500);
+    expect(alerts[0].percentUsed).toBe(120);
+  });
+
+  it('does not flag categories under budget', async () => {
+    const categories = [{ category: 'Food', total: 400 }];
+    const budgets = [{ category: 'Food', limit: 500 }];
+    const alerts = await buildBudgetAlerts(TEST_USER_ID, categories, budgets);
+    expect(alerts).toHaveLength(0);
+  });
+});
+
+describe('formatMonthlySummaryMessage', () => {
+  const baseData: MonthlySummaryData = {
+    month: '2026-02',
+    totalIncome: 3000,
+    totalExpense: 1200,
+    net: 1800,
+    topCategories: [
+      { category: 'Rent', total: 700 },
+      { category: 'Food', total: 300 },
+    ],
+    budgetAlerts: [],
+    prevMonthExpense: 1000,
+    momChangePercent: 20,
+  };
+
+  it('includes month label and key figures', () => {
+    const msg = formatMonthlySummaryMessage(baseData);
+    expect(msg).toContain('2026-02');
+    expect(msg).toContain('$3000.00');
+    expect(msg).toContain('$1200.00');
+    expect(msg).toContain('$1800.00');
+  });
+
+  it('shows up arrow for increased spending', () => {
+    const msg = formatMonthlySummaryMessage(baseData);
+    expect(msg).toContain('↑');
+    expect(msg).toContain('20%');
+  });
+
+  it('shows down arrow for decreased spending', () => {
+    const msg = formatMonthlySummaryMessage({ ...baseData, momChangePercent: -15 });
+    expect(msg).toContain('↓');
+    expect(msg).toContain('15%');
+  });
+
+  it('shows No data when no prior month', () => {
+    const msg = formatMonthlySummaryMessage({ ...baseData, momChangePercent: null });
+    expect(msg).toContain('No data');
+  });
+
+  it('lists top categories', () => {
+    const msg = formatMonthlySummaryMessage(baseData);
+    expect(msg).toContain('Rent');
+    expect(msg).toContain('$700.00');
+    expect(msg).toContain('Food');
+  });
+
+  it('includes budget alerts when present', () => {
+    const dataWithAlerts: MonthlySummaryData = {
+      ...baseData,
+      budgetAlerts: [{ category: 'Food', spent: 600, limit: 500, percentUsed: 120 }],
+    };
+    const msg = formatMonthlySummaryMessage(dataWithAlerts);
+    expect(msg).toContain('Over Budget');
+    expect(msg).toContain('Food');
+    expect(msg).toContain('120%');
+  });
+
+  it('omits budget section when no alerts', () => {
+    const msg = formatMonthlySummaryMessage(baseData);
+    expect(msg).not.toContain('Over Budget');
+  });
+});
+
+describe('POST /api/jobs/monthly-summary', () => {
+  const JOBS_API_KEY = 'test-jobs-key';
+
+  beforeEach(() => {
+    process.env.JOBS_API_KEY = JOBS_API_KEY;
+    process.env.TELEGRAM_BOT_TOKEN = 'fake-token';
+  });
+
+  afterEach(() => {
+    delete process.env.JOBS_API_KEY;
+    delete process.env.TELEGRAM_BOT_TOKEN;
+  });
+
+  it('returns 401 without API key', async () => {
+    const res = await request(app).post('/api/jobs/monthly-summary');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 with wrong API key', async () => {
+    const res = await request(app)
+      .post('/api/jobs/monthly-summary')
+      .set('x-api-key', 'wrong-key');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 with correct API key', async () => {
+    await UserModel.create({
+      _id: TEST_USER_ID,
+      email: 'job@example.com',
+      password: 'password123',
+    });
+
+    const res = await request(app)
+      .post('/api/jobs/monthly-summary')
+      .set('x-api-key', JOBS_API_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(typeof res.body.durationMs).toBe('number');
+  });
+
+  it('returns 503 when JOBS_API_KEY is not configured', async () => {
+    delete process.env.JOBS_API_KEY;
+    const res = await request(app)
+      .post('/api/jobs/monthly-summary')
+      .set('x-api-key', 'any-key');
+    expect(res.status).toBe(503);
+  });
+});

--- a/__tests__/multi-currency.test.ts
+++ b/__tests__/multi-currency.test.ts
@@ -1,0 +1,245 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import app from '../src/app';
+import ExpenseModel from '../src/models/Expense';
+import { convertToHKD, clearRateCache } from '../src/utils/exchangeRates';
+
+let mongod: MongoMemoryServer;
+const TEST_USER_ID = 'user_currency_test';
+const authToken = jwt.sign({ userId: TEST_USER_ID }, 'test-secret');
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  for (const col of Object.values(mongoose.connection.collections)) {
+    await col.deleteMany({});
+  }
+  clearRateCache();
+});
+
+describe('Expense model currency fields', () => {
+  it('defaults currency to HKD when not specified', async () => {
+    const res = await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ description: 'Lunch', amount: 50, type: 'expense', category: 'Food' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.currency).toBe('HKD');
+    expect(res.body.originalAmount).toBeNull();
+    expect(res.body.exchangeRate).toBeNull();
+  });
+
+  it('stores foreign currency expense with originalAmount and exchangeRate', async () => {
+    const res = await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        description: 'Tokyo ramen',
+        amount: 62.4, // HKD equivalent
+        type: 'expense',
+        category: 'Food',
+        currency: 'JPY',
+        originalAmount: 1200,
+        exchangeRate: 0.052,
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.currency).toBe('JPY');
+    expect(res.body.originalAmount).toBe(1200);
+    expect(res.body.exchangeRate).toBe(0.052);
+    expect(res.body.amount).toBe(62.4);
+  });
+
+  it('rejects invalid currency code', async () => {
+    const res = await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        description: 'Bad currency',
+        amount: 100,
+        type: 'expense',
+        currency: 'XYZ',
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/currency must be one of/);
+  });
+
+  it('updates currency fields via PUT', async () => {
+    const create = await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ description: 'Original', amount: 100, type: 'expense' });
+
+    const res = await request(app)
+      .put(`/api/expenses/${create.body._id}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        description: 'Updated',
+        amount: 78,
+        type: 'expense',
+        currency: 'USD',
+        originalAmount: 10,
+        exchangeRate: 7.8,
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.currency).toBe('USD');
+    expect(res.body.originalAmount).toBe(10);
+    expect(res.body.exchangeRate).toBe(7.8);
+  });
+
+  it('existing expenses without currency default to HKD on read', async () => {
+    // Insert directly without currency field to simulate legacy data
+    await ExpenseModel.create({
+      owner: TEST_USER_ID,
+      description: 'Legacy expense',
+      amount: 200,
+    });
+
+    const res = await request(app)
+      .get('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data[0].currency).toBe('HKD');
+    expect(res.body.data[0].originalAmount).toBeNull();
+  });
+});
+
+describe('GET /api/exchange-rates', () => {
+  it('returns 401 without auth', async () => {
+    const res = await request(app).get('/api/exchange-rates');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns rates object with source and updatedAt', async () => {
+    const res = await request(app)
+      .get('/api/exchange-rates')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.rates).toBeDefined();
+    expect(res.body.source).toBeDefined();
+    expect(res.body.updatedAt).toBeDefined();
+    expect(typeof res.body.rates.USD).toBe('number');
+    expect(typeof res.body.rates.JPY).toBe('number');
+    expect(typeof res.body.rates.CNY).toBe('number');
+  });
+});
+
+describe('CSV export with currency columns', () => {
+  it('includes currency headers and data in CSV', async () => {
+    await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        description: 'USD purchase',
+        amount: 78,
+        type: 'expense',
+        category: 'Shopping',
+        currency: 'USD',
+        originalAmount: 10,
+        exchangeRate: 7.8,
+      });
+
+    const res = await request(app)
+      .get('/api/export/csv')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Amount (HKD)');
+    expect(res.text).toContain('Currency');
+    expect(res.text).toContain('Original Amount');
+    expect(res.text).toContain('Exchange Rate');
+    expect(res.text).toContain('USD');
+    expect(res.text).toContain('10');
+    expect(res.text).toContain('7.8');
+  });
+
+  it('shows HKD and empty original fields for HKD expenses', async () => {
+    await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ description: 'Local food', amount: 50, type: 'expense' });
+
+    const res = await request(app)
+      .get('/api/export/csv')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    const lines = res.text.trim().split('\n');
+    expect(lines.length).toBe(2);
+    // HKD expense should have HKD in currency column and empty original/rate
+    expect(lines[1]).toContain('HKD');
+  });
+});
+
+describe('convertToHKD utility', () => {
+  it('returns same amount for HKD', () => {
+    expect(convertToHKD(100, 'HKD', 1)).toBe(100);
+  });
+
+  it('converts foreign currency to HKD', () => {
+    expect(convertToHKD(10, 'USD', 7.8)).toBe(78);
+  });
+
+  it('rounds to 2 decimal places', () => {
+    expect(convertToHKD(1000, 'JPY', 0.052)).toBe(52);
+    expect(convertToHKD(100, 'EUR', 8.537)).toBe(853.7);
+  });
+});
+
+describe('Dashboard aggregation backward compatibility', () => {
+  it('monthly report aggregates amount field (always HKD)', async () => {
+    // Create one HKD and one foreign currency expense
+    await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        description: 'Local meal',
+        amount: 50,
+        type: 'expense',
+        category: 'Food',
+        date: new Date().toISOString(),
+      });
+
+    await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        description: 'Japan meal',
+        amount: 62.4,
+        type: 'expense',
+        category: 'Food',
+        currency: 'JPY',
+        originalAmount: 1200,
+        exchangeRate: 0.052,
+        date: new Date().toISOString(),
+      });
+
+    const res = await request(app)
+      .get('/api/reports/monthly?months=1')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBeGreaterThanOrEqual(1);
+    const currentMonth = res.body.data[res.body.data.length - 1];
+    // Both expenses should be summed in HKD: 50 + 62.4 = 112.4
+    expect(currentMonth.expenses).toBeCloseTo(112.4, 1);
+  });
+});

--- a/__tests__/net-worth-model.test.ts
+++ b/__tests__/net-worth-model.test.ts
@@ -1,0 +1,48 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import NetWorthModel from '../src/models/NetWorth';
+
+let mongod: MongoMemoryServer;
+const TEST_USER_ID = 'user_test_networth_model';
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  await NetWorthModel.deleteMany({});
+});
+
+describe('NetWorthModel', () => {
+  it('calculates netWorth for full assets/liabilities', async () => {
+    const doc = await NetWorthModel.create({
+      userId: TEST_USER_ID,
+      date: new Date('2026-01-01T00:00:00.000Z'),
+      assets: { cash: 10, investments: 20, property: 30, other: 40 },
+      liabilities: { loans: 1, creditCardDebt: 2, other: 3 },
+    });
+
+    expect(doc.netWorth).toBe(94); // (10+20+30+40) - (1+2+3)
+  });
+
+  it('treats missing/zero values as 0', async () => {
+    const doc = await NetWorthModel.create({
+      userId: TEST_USER_ID,
+      date: new Date('2026-01-02T00:00:00.000Z'),
+      assets: { cash: 0, investments: 0, property: 0, other: 0 },
+      liabilities: { loans: 0, creditCardDebt: 0, other: 0 },
+    });
+
+    expect(doc.netWorth).toBe(0);
+  });
+});
+

--- a/__tests__/net-worth-model.test.ts
+++ b/__tests__/net-worth-model.test.ts
@@ -44,5 +44,40 @@ describe('NetWorthModel', () => {
 
     expect(doc.netWorth).toBe(0);
   });
+
+  it('calculates netWorth with partial assets and undefined liabilities', async () => {
+    const doc = await NetWorthModel.create({
+      userId: TEST_USER_ID,
+      date: new Date('2026-01-03T00:00:00.000Z'),
+      assets: { cash: 5000, investments: undefined, property: undefined, other: undefined },
+      liabilities: undefined,
+    });
+
+    expect(doc.netWorth).toBe(5000); // 5000 - (0 + 0 + 0)
+  });
+
+  it('calculates netWorth with only liabilities', async () => {
+    const doc = await NetWorthModel.create({
+      userId: TEST_USER_ID,
+      date: new Date('2026-01-04T00:00:00.000Z'),
+      assets: { cash: 0, investments: 0, property: 0, other: 0 },
+      liabilities: { loans: 1000, creditCardDebt: 2000, other: 500 },
+    });
+
+    expect(doc.netWorth).toBe(-3500); // 0 - (1000 + 2000 + 500)
+  });
+
+  it('calculates netWorth using .save() method (pre-save hook)', async () => {
+    const doc = new NetWorthModel({
+      userId: TEST_USER_ID,
+      date: new Date('2026-01-05T00:00:00.000Z'),
+      assets: { cash: 50000 },
+      liabilities: { loans: 10000 },
+    });
+
+    await doc.save();
+
+    expect(doc.netWorth).toBe(40000); // 50000 - 10000
+  });
 });
 

--- a/__tests__/net-worth.test.ts
+++ b/__tests__/net-worth.test.ts
@@ -93,6 +93,19 @@ describe('POST /api/net-worth', () => {
     expect(res.body.error).toBeDefined();
   });
 
+  it('returns 400 when liabilities is not an object', async () => {
+    const res = await request(app)
+      .post('/api/net-worth')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        assets: { cash: 1000 },
+        liabilities: 'not-an-object'
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBeDefined();
+  });
+
   it('returns 400 with message when saving fails', async () => {
     jest.spyOn(NetWorthModel, 'findOneAndUpdate').mockRejectedValueOnce(new Error('db fail'));
 

--- a/__tests__/net-worth.test.ts
+++ b/__tests__/net-worth.test.ts
@@ -1,0 +1,240 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import app from '../src/app';
+import NetWorthModel from '../src/models/NetWorth';
+
+let mongod: MongoMemoryServer;
+const TEST_USER_ID = 'user_test_networth';
+const authToken = jwt.sign({ userId: TEST_USER_ID }, 'test-secret');
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  for (const col of Object.values(mongoose.connection.collections)) {
+    await col.deleteMany({});
+  }
+  jest.restoreAllMocks();
+});
+
+describe('GET /api/net-worth', () => {
+  it('returns empty array initially', async () => {
+    const res = await request(app)
+      .get('/api/net-worth')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it('filters snapshots by months query (clamped to max 24)', async () => {
+    const now = new Date();
+    const olderThan24Months = new Date(now);
+    olderThan24Months.setMonth(olderThan24Months.getMonth() - 25);
+
+    const within24Months = new Date(now);
+    within24Months.setMonth(within24Months.getMonth() - 2);
+
+    await NetWorthModel.create({
+      userId: TEST_USER_ID,
+      date: olderThan24Months,
+      assets: { cash: 1 },
+      liabilities: { loans: 1 },
+    });
+    await NetWorthModel.create({
+      userId: TEST_USER_ID,
+      date: within24Months,
+      assets: { cash: 999 },
+      liabilities: { loans: 0 },
+    });
+
+    const res = await request(app)
+      .get('/api/net-worth?months=100')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].assets.cash).toBe(999);
+  });
+});
+
+describe('POST /api/net-worth', () => {
+  it('creates a net worth entry', async () => {
+    const res = await request(app)
+      .post('/api/net-worth')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        assets: { cash: 10000, investments: 5000 },
+        liabilities: { creditCardDebt: 2000 },
+      });
+    expect(res.status).toBe(201);
+    expect(res.body.assets.cash).toBe(10000);
+    expect(res.body.liabilities.creditCardDebt).toBe(2000);
+  });
+
+  it('returns 400 when assets is not an object', async () => {
+    const res = await request(app)
+      .post('/api/net-worth')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ assets: 'not-an-object' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBeDefined();
+  });
+
+  it('returns 400 with message when saving fails', async () => {
+    jest.spyOn(NetWorthModel, 'findOneAndUpdate').mockRejectedValueOnce(new Error('db fail'));
+
+    const res = await request(app)
+      .post('/api/net-worth')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        assets: { cash: 123 },
+        liabilities: { loans: 5 },
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'Failed to save net worth snapshot' });
+  });
+});
+
+describe('GET /api/net-worth/latest', () => {
+  it('returns 401 when Authorization header is missing', async () => {
+    const res = await request(app).get('/api/net-worth/latest');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns null when no snapshots exist', async () => {
+    const res = await request(app)
+      .get('/api/net-worth/latest')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toBeNull();
+  });
+
+  it('returns the latest snapshot by date', async () => {
+    await NetWorthModel.create({
+      userId: TEST_USER_ID,
+      date: new Date('2026-01-01T00:00:00.000Z'),
+      assets: { cash: 1 },
+      liabilities: { loans: 0 },
+    });
+    await NetWorthModel.create({
+      userId: TEST_USER_ID,
+      date: new Date('2026-02-01T00:00:00.000Z'),
+      assets: { cash: 2 },
+      liabilities: { loans: 0 },
+    });
+
+    const res = await request(app)
+      .get('/api/net-worth/latest')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.assets.cash).toBe(2);
+  });
+});
+
+describe('PUT /api/net-worth/:snapshotId', () => {
+  it('updates a snapshot', async () => {
+    const created = await request(app)
+      .post('/api/net-worth')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ assets: { cash: 10 }, liabilities: {} });
+
+    const snapshotId = created.body._id;
+
+    const res = await request(app)
+      .put(`/api/net-worth/${snapshotId}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ assets: { cash: 77 }, liabilities: { loans: 3 } });
+
+    expect(res.status).toBe(200);
+    expect(res.body.assets.cash).toBe(77);
+    expect(res.body.liabilities.loans).toBe(3);
+  });
+
+  it('returns 404 when snapshot does not exist', async () => {
+    const fakeId = new mongoose.Types.ObjectId().toString();
+
+    const res = await request(app)
+      .put(`/api/net-worth/${fakeId}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ assets: { cash: 1 }, liabilities: {} });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBeDefined();
+  });
+
+  it('does not reject when assets is not an object (PUT handler does not check validationResult)', async () => {
+    const created = await request(app)
+      .post('/api/net-worth')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ assets: { cash: 10 }, liabilities: {} });
+
+    const snapshotId = created.body._id;
+
+    const res = await request(app)
+      .put(`/api/net-worth/${snapshotId}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ assets: 'nope' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.assets).toBeDefined();
+  });
+
+  it('returns 400 when update throws', async () => {
+    const created = await request(app)
+      .post('/api/net-worth')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ assets: { cash: 10 }, liabilities: {} });
+
+    const snapshotId = created.body._id;
+
+    jest.spyOn(NetWorthModel, 'findOneAndUpdate').mockRejectedValueOnce(new Error('db fail'));
+
+    const res = await request(app)
+      .put(`/api/net-worth/${snapshotId}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ assets: { cash: 99 }, liabilities: {} });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'Failed to update snapshot' });
+  });
+});
+
+describe('DELETE /api/net-worth/:id', () => {
+  it('deletes entry', async () => {
+    const created = await request(app)
+      .post('/api/net-worth')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ assets: { cash: 1000 }, liabilities: {} });
+    const id = created.body._id;
+
+    const res = await request(app)
+      .delete(`/api/net-worth/${id}`)
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Deleted');
+  });
+
+  it('returns 404 for non-existent id', async () => {
+    const fakeId = new mongoose.Types.ObjectId().toString();
+    const res = await request(app)
+      .delete(`/api/net-worth/${fakeId}`)
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(404);
+  });
+});

--- a/__tests__/parse-transaction-text.test.ts
+++ b/__tests__/parse-transaction-text.test.ts
@@ -1,0 +1,155 @@
+import { parseTransactionText } from '../src/utils/parseTransactionText';
+
+describe('parseTransactionText', () => {
+  describe('basic amount + description', () => {
+    it('parses "coffee $4.50 at Starbucks"', () => {
+      const result = parseTransactionText('coffee $4.50 at Starbucks');
+      expect(result.amount).toBe(4.5);
+      expect(result.merchant).toMatch(/coffee/i);
+      expect(result.merchant).toMatch(/starbucks/i);
+      expect(result.category).toBe('food');
+      expect(result.confidence).toBeGreaterThan(0.5);
+    });
+
+    it('parses "uber 150 transport"', () => {
+      const result = parseTransactionText('uber 150 transport');
+      expect(result.amount).toBe(150);
+      expect(result.category).toBe('transport');
+    });
+
+    it('parses "$12 taxi"', () => {
+      const result = parseTransactionText('$12 taxi');
+      expect(result.amount).toBe(12);
+      expect(result.category).toBe('transport');
+    });
+
+    it('parses "lunch 1500 JPY"', () => {
+      const result = parseTransactionText('lunch 1500 JPY');
+      expect(result.amount).toBe(1500);
+      expect(result.currency).toBe('JPY');
+      expect(result.category).toBe('food');
+    });
+
+    it('parses "rent $2000 monthly"', () => {
+      const result = parseTransactionText('rent $2000 monthly');
+      expect(result.amount).toBe(2000);
+      expect(result.category).toBe('bills');
+    });
+  });
+
+  describe('participants', () => {
+    it('extracts "with Casey"', () => {
+      const result = parseTransactionText('lunch with Casey $56');
+      expect(result.participants).toEqual(['Casey']);
+      expect(result.amount).toBe(56);
+    });
+
+    it('extracts "with Casey and Bob"', () => {
+      const result = parseTransactionText('dinner $80 with Casey and Bob');
+      expect(result.participants).toEqual(['Casey', 'Bob']);
+    });
+  });
+
+  describe('split bill', () => {
+    it('detects "each" keyword', () => {
+      const result = parseTransactionText('lunch with Casey $56 each');
+      expect(result.participants).toEqual(['Casey']);
+      expect(result.notes).toMatch(/split bill/i);
+      expect(result.notes).toContain('56');
+    });
+
+    it('detects "split" keyword', () => {
+      const result = parseTransactionText('dinner $100 with Bob split');
+      expect(result.notes).toMatch(/split bill/i);
+    });
+  });
+
+  describe('date extraction', () => {
+    it('extracts "today"', () => {
+      const result = parseTransactionText('today coffee $5');
+      const today = new Date().toISOString().slice(0, 10);
+      expect(result.date).toBe(today);
+      expect(result.amount).toBe(5);
+    });
+
+    it('extracts "yesterday"', () => {
+      const result = parseTransactionText('yesterday lunch $12');
+      const d = new Date();
+      d.setDate(d.getDate() - 1);
+      expect(result.date).toBe(d.toISOString().slice(0, 10));
+    });
+
+    it('strips time patterns', () => {
+      const result = parseTransactionText('today 12:00 eat dinner $56');
+      expect(result.amount).toBe(56);
+      expect(result.merchant).not.toMatch(/12:00/);
+    });
+  });
+
+  describe('full complex input', () => {
+    it('parses "today 12:00 eat dinner at cafe with Casey $56 each"', () => {
+      const result = parseTransactionText('today 12:00 eat dinner at cafe with Casey $56 each');
+      expect(result.amount).toBe(56);
+      expect(result.merchant).toMatch(/eat dinner/i);
+      expect(result.participants).toEqual(['Casey']);
+      expect(result.notes).toMatch(/split bill/i);
+      expect(result.category).toBe('food');
+      expect(result.date).toBe(new Date().toISOString().slice(0, 10));
+    });
+  });
+
+  describe('Cantonese input', () => {
+    it('parses "今日同Casey食咗麥當勞 $65"', () => {
+      const result = parseTransactionText('今日同Casey食咗麥當勞 $65');
+      expect(result.amount).toBe(65);
+      expect(result.participants).toEqual(['Casey']);
+      expect(result.date).toBe(new Date().toISOString().slice(0, 10));
+    });
+
+    it('parses "昨日飲咖啡 $40"', () => {
+      const result = parseTransactionText('昨日飲咖啡 $40');
+      expect(result.amount).toBe(40);
+      const d = new Date();
+      d.setDate(d.getDate() - 1);
+      expect(result.date).toBe(d.toISOString().slice(0, 10));
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns low confidence for empty input', () => {
+      const result = parseTransactionText('');
+      expect(result.confidence).toBe(0);
+      expect(result.missing_fields).toContain('amount');
+    });
+
+    it('returns missing amount for text-only input', () => {
+      const result = parseTransactionText('just some random text');
+      expect(result.missing_fields).toContain('amount');
+    });
+
+    it('handles whitespace-only input', () => {
+      const result = parseTransactionText('   ');
+      expect(result.confidence).toBe(0);
+    });
+  });
+
+  describe('currency symbols', () => {
+    it('parses EUR symbol', () => {
+      const result = parseTransactionText('lunch \u20ac50');
+      expect(result.amount).toBe(50);
+      expect(result.currency).toBe('EUR');
+    });
+
+    it('parses GBP symbol', () => {
+      const result = parseTransactionText('tea \u00a320');
+      expect(result.amount).toBe(20);
+      expect(result.currency).toBe('GBP');
+    });
+
+    it('omits HKD as default currency', () => {
+      const result = parseTransactionText('coffee 45 HKD');
+      expect(result.amount).toBe(45);
+      expect(result.currency).toBeUndefined();
+    });
+  });
+});

--- a/__tests__/participants-validation.test.ts
+++ b/__tests__/participants-validation.test.ts
@@ -1,0 +1,44 @@
+// Unit tests for participants field validation logic
+// Mirrors the custom validator in src/routes/expenses.ts
+
+function validateParticipants(value: unknown): void {
+  if (value === undefined || value === null) return;
+  if (!Array.isArray(value)) throw new Error('participants must be an array');
+  if ((value as unknown[]).length > 20) throw new Error('participants cannot exceed 20 items');
+  const seen = new Set<string>();
+  for (const item of value as unknown[]) {
+    if (typeof item !== 'string') throw new Error('each participant must be a string');
+    if ((item as string).trim() === '') throw new Error('participant names cannot be empty');
+    if ((item as string).length > 100) throw new Error('participant names cannot exceed 100 characters');
+    const lower = (item as string).toLowerCase();
+    if (seen.has(lower)) throw new Error(`duplicate participant: "${item}"`);
+    seen.add(lower);
+  }
+}
+
+describe('participants validation', () => {
+  it('accepts undefined (field optional)', () => expect(() => validateParticipants(undefined)).not.toThrow());
+  it('accepts null', () => expect(() => validateParticipants(null)).not.toThrow());
+  it('accepts empty array', () => expect(() => validateParticipants([])).not.toThrow());
+  it('accepts valid names', () => expect(() => validateParticipants(['Alice', 'Bob'])).not.toThrow());
+
+  it('rejects non-array', () => expect(() => validateParticipants('Alice')).toThrow('must be an array'));
+  it('rejects array exceeding 20 items', () => {
+    const big = Array.from({ length: 21 }, (_, i) => `Person${i}`);
+    expect(() => validateParticipants(big)).toThrow('cannot exceed 20 items');
+  });
+  it('rejects non-string values', () => expect(() => validateParticipants([123])).toThrow('must be a string'));
+  it('rejects empty strings', () => expect(() => validateParticipants([''])).toThrow('cannot be empty'));
+  it('rejects whitespace-only strings', () => expect(() => validateParticipants(['   '])).toThrow('cannot be empty'));
+  it('rejects names over 100 chars', () => {
+    const long = 'a'.repeat(101);
+    expect(() => validateParticipants([long])).toThrow('cannot exceed 100 characters');
+  });
+  it('rejects duplicate names (case-insensitive)', () => {
+    expect(() => validateParticipants(['Alice', 'alice'])).toThrow('duplicate participant');
+  });
+  it('allows max 20 items exactly', () => {
+    const exactly20 = Array.from({ length: 20 }, (_, i) => `Person${i}`);
+    expect(() => validateParticipants(exactly20)).not.toThrow();
+  });
+});

--- a/__tests__/payment-method.test.ts
+++ b/__tests__/payment-method.test.ts
@@ -1,0 +1,179 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import app from '../src/app';
+
+let mongod: MongoMemoryServer;
+const TEST_USER_ID = 'user_payment_method';
+const authToken = jwt.sign({ userId: TEST_USER_ID }, 'test-secret');
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  for (const col of Object.values(mongoose.connection.collections)) {
+    await col.deleteMany({});
+  }
+});
+
+const basePayload = {
+  description: 'Test expense',
+  amount: 100,
+  type: 'expense',
+  category: 'Food',
+};
+
+async function createExpense(overrides: Record<string, unknown> = {}) {
+  const res = await request(app)
+    .post('/api/expenses')
+    .set('Authorization', `Bearer ${authToken}`)
+    .send({ ...basePayload, ...overrides });
+  return res.body;
+}
+
+describe('paymentMethod field', () => {
+  it('creates expense without paymentMethod (defaults to null)', async () => {
+    const created = await createExpense();
+    expect(created.paymentMethod).toBeNull();
+  });
+
+  it('creates expense with valid paymentMethod', async () => {
+    const created = await createExpense({ paymentMethod: 'octopus' });
+    expect(created.paymentMethod).toBe('octopus');
+  });
+
+  it('rejects invalid paymentMethod on create', async () => {
+    const res = await request(app)
+      .post('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ...basePayload, paymentMethod: 'bitcoin' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('paymentMethod must be one of');
+  });
+
+  it('updates expense with paymentMethod', async () => {
+    const created = await createExpense({ description: 'For update' });
+    const res = await request(app)
+      .put(`/api/expenses/${created._id}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ...basePayload, description: 'For update', paymentMethod: 'fps' });
+    expect(res.status).toBe(200);
+    expect(res.body.paymentMethod).toBe('fps');
+  });
+
+  it('rejects invalid paymentMethod on update', async () => {
+    const created = await createExpense({ paymentMethod: 'cash' });
+    const res = await request(app)
+      .put(`/api/expenses/${created._id}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ...basePayload, paymentMethod: 'venmo' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('paymentMethod must be one of');
+  });
+
+  it('clears paymentMethod by setting to null', async () => {
+    const created = await createExpense({ paymentMethod: 'payme' });
+    expect(created.paymentMethod).toBe('payme');
+    const res = await request(app)
+      .put(`/api/expenses/${created._id}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ...basePayload, paymentMethod: null });
+    expect(res.status).toBe(200);
+    expect(res.body.paymentMethod).toBeNull();
+  });
+
+  it('returns paymentMethod in GET /api/expenses', async () => {
+    await createExpense({ paymentMethod: 'credit_card' });
+    const res = await request(app)
+      .get('/api/expenses')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.data[0].paymentMethod).toBe('credit_card');
+  });
+
+  it('returns paymentMethod in GET /api/expenses/:id', async () => {
+    const created = await createExpense({ paymentMethod: 'debit_card' });
+    const res = await request(app)
+      .get(`/api/expenses/${created._id}`)
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.paymentMethod).toBe('debit_card');
+  });
+});
+
+describe('GET /api/expenses?paymentMethod filter', () => {
+  it('filters by paymentMethod', async () => {
+    await createExpense({ description: 'Bus', paymentMethod: 'octopus' });
+    await createExpense({ description: 'Lunch', paymentMethod: 'credit_card' });
+    await createExpense({ description: 'Groceries', paymentMethod: 'octopus' });
+
+    const res = await request(app)
+      .get('/api/expenses?paymentMethod=octopus')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.total).toBe(2);
+    for (const expense of res.body.data) {
+      expect(expense.paymentMethod).toBe('octopus');
+    }
+  });
+
+  it('rejects invalid paymentMethod filter', async () => {
+    const res = await request(app)
+      .get('/api/expenses?paymentMethod=bitcoin')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('Invalid paymentMethod filter');
+  });
+
+  it('returns empty when no expenses match filter', async () => {
+    await createExpense({ description: 'Bus', paymentMethod: 'octopus' });
+    const res = await request(app)
+      .get('/api/expenses?paymentMethod=fps')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(0);
+    expect(res.body.total).toBe(0);
+  });
+});
+
+describe('CSV export includes paymentMethod', () => {
+  it('includes Payment Method column header', async () => {
+    const res = await request(app)
+      .get('/api/export/csv')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Payment Method');
+  });
+
+  it('includes paymentMethod value in CSV rows', async () => {
+    await createExpense({ description: 'Train', paymentMethod: 'octopus' });
+    const res = await request(app)
+      .get('/api/export/csv')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('octopus');
+  });
+
+  it('handles null paymentMethod in CSV', async () => {
+    await createExpense({ description: 'Cash purchase' });
+    const res = await request(app)
+      .get('/api/export/csv')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    const lines = res.text.trim().split('\n');
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain('Payment Method');
+  });
+});

--- a/__tests__/price-history.test.ts
+++ b/__tests__/price-history.test.ts
@@ -1,0 +1,139 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import app from '../src/app';
+import ExpenseModel from '../src/models/Expense';
+
+let mongod: MongoMemoryServer;
+const USER_ID = 'price_user_123';
+const OTHER_USER = 'price_other_456';
+const token = jwt.sign({ userId: USER_ID }, 'test-secret');
+const otherToken = jwt.sign({ userId: OTHER_USER }, 'test-secret');
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  for (const col of Object.values(mongoose.connection.collections)) {
+    await col.deleteMany({});
+  }
+});
+
+describe('GET /api/expenses/last-amounts', () => {
+  it('returns 401 without auth', async () => {
+    await request(app).get('/api/expenses/last-amounts').expect(401);
+  });
+
+  it('returns empty map when no transactions', async () => {
+    const res = await request(app)
+      .get('/api/expenses/last-amounts')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect(res.body).toEqual({});
+  });
+
+  it('returns most recent amount per item', async () => {
+    await ExpenseModel.create([
+      { owner: USER_ID, item: 'Coffee', amount: 30, date: new Date('2026-01-01'), description: 'Starbucks' },
+      { owner: USER_ID, item: 'Coffee', amount: 45, date: new Date('2026-03-01'), description: 'Starbucks' },
+      { owner: USER_ID, item: 'Lunch', amount: 80, date: new Date('2026-02-01'), description: 'Cafe' },
+    ]);
+    const res = await request(app)
+      .get('/api/expenses/last-amounts')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect(res.body['coffee']).toBe(45);
+    expect(res.body['lunch']).toBe(80);
+  });
+
+  it('does not return other users data', async () => {
+    await ExpenseModel.create([
+      { owner: OTHER_USER, item: 'Dinner', amount: 200, date: new Date('2026-03-01') },
+    ]);
+    const res = await request(app)
+      .get('/api/expenses/last-amounts')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect(res.body['dinner']).toBeUndefined();
+  });
+});
+
+describe('GET /api/expenses/price-history/:item', () => {
+  it('returns 401 without auth', async () => {
+    await request(app).get('/api/expenses/price-history/Coffee').expect(401);
+  });
+
+  it('returns empty history for unknown item', async () => {
+    const res = await request(app)
+      .get('/api/expenses/price-history/Unknown')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect(res.body.history).toEqual([]);
+    expect(res.body.stats).toBeNull();
+  });
+
+  it('returns price history with stats', async () => {
+    await ExpenseModel.create([
+      { owner: USER_ID, item: 'Coffee', amount: 30, date: new Date('2026-01-01') },
+      { owner: USER_ID, item: 'Coffee', amount: 45, date: new Date('2026-02-01') },
+      { owner: USER_ID, item: 'Coffee', amount: 35, date: new Date('2026-03-01') },
+    ]);
+    const res = await request(app)
+      .get('/api/expenses/price-history/Coffee')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect(res.body.item).toBe('Coffee');
+    expect(res.body.history).toHaveLength(3);
+    expect(res.body.stats.count).toBe(3);
+    expect(res.body.stats.latest).toBe(35);
+    expect(res.body.stats.min).toBe(30);
+    expect(res.body.stats.max).toBe(45);
+    expect(res.body.stats.avg).toBeCloseTo(36.67, 1);
+  });
+
+  it('matches case-insensitively', async () => {
+    await ExpenseModel.create([
+      { owner: USER_ID, item: 'coffee', amount: 30, date: new Date('2026-01-01') },
+    ]);
+    const res = await request(app)
+      .get('/api/expenses/price-history/Coffee')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect(res.body.history).toHaveLength(1);
+  });
+
+  it('respects limit parameter', async () => {
+    await ExpenseModel.create(
+      Array.from({ length: 5 }, (_, i) => ({
+        owner: USER_ID, item: 'Tea', amount: 20 + i, date: new Date(`2026-0${i + 1}-01`),
+      }))
+    );
+    const res = await request(app)
+      .get('/api/expenses/price-history/Tea?limit=3')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect(res.body.history).toHaveLength(3);
+  });
+
+  it('isolates by user', async () => {
+    await ExpenseModel.create([
+      { owner: OTHER_USER, item: 'Coffee', amount: 100, date: new Date('2026-01-01') },
+    ]);
+    const res = await request(app)
+      .get('/api/expenses/price-history/Coffee')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect(res.body.history).toHaveLength(0);
+  });
+});

--- a/__tests__/processAlerts-error.test.ts
+++ b/__tests__/processAlerts-error.test.ts
@@ -1,0 +1,28 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../src/utils/alerts', () => ({
+  processPendingAlerts: jest.fn(),
+}));
+
+import { processPendingAlerts } from '../src/utils/alerts';
+import { processAlertsJob } from '../src/jobs/processAlerts';
+
+const mockedProcessPendingAlerts = processPendingAlerts as jest.MockedFunction<
+  typeof processPendingAlerts
+>;
+
+describe('processAlertsJob error handling', () => {
+  it('logs error when processPendingAlerts throws', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+    mockedProcessPendingAlerts.mockRejectedValueOnce(new Error('job error'));
+
+    await processAlertsJob();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[AlertJob] Error processing alerts:',
+      expect.any(Error)
+    );
+    errorSpy.mockRestore();
+  });
+});

--- a/__tests__/processAlerts.test.ts
+++ b/__tests__/processAlerts.test.ts
@@ -1,0 +1,99 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import mongoose from 'mongoose';
+import { processAlertsJob, startAlertScheduler } from '../src/jobs/processAlerts';
+import AlertModel from '../src/models/Alert';
+import UserModel from '../src/models/User';
+
+let mongoServer: MongoMemoryServer;
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  await mongoose.connect(mongoServer.getUri());
+}, 30000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+beforeEach(async () => {
+  await AlertModel.deleteMany({});
+  await UserModel.deleteMany({});
+  delete process.env.TELEGRAM_BOT_TOKEN;
+  delete process.env.TELEGRAM_CHAT_ID;
+});
+
+describe('processAlertsJob', () => {
+  it('completes successfully with no pending alerts', async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+    await processAlertsJob();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[AlertJob] Processed pending alerts in')
+    );
+    consoleSpy.mockRestore();
+  });
+
+  // Error path tested in processAlerts-error.test.ts via jest.mock
+});
+
+describe('startAlertScheduler', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns null when Telegram is not configured', () => {
+    delete process.env.TELEGRAM_BOT_TOKEN;
+    delete process.env.TELEGRAM_CHAT_ID;
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    const result = startAlertScheduler();
+
+    expect(result).toBeNull();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '[AlertScheduler] Telegram not configured, skipping alert job'
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it('starts scheduler when Telegram is configured', async () => {
+    process.env.TELEGRAM_BOT_TOKEN = 'fake-token';
+    process.env.TELEGRAM_CHAT_ID = 'fake-chat-id';
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    const intervalId = startAlertScheduler();
+
+    expect(intervalId).not.toBeNull();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '[AlertScheduler] Started alert processing job (every 30 minutes)'
+    );
+
+    // Clean up interval to prevent leaks
+    if (intervalId) clearInterval(intervalId as unknown as number);
+    consoleSpy.mockRestore();
+
+    // Wait for initial run to complete
+    await new Promise((r) => setTimeout(r, 100));
+  });
+
+  it('handles initial run failure gracefully', async () => {
+    process.env.TELEGRAM_BOT_TOKEN = 'fake-token';
+    process.env.TELEGRAM_CHAT_ID = 'fake-chat-id';
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    // Mock AlertModel.find to throw
+    jest.spyOn(AlertModel, 'find').mockRejectedValueOnce(new Error('init fail'));
+
+    const intervalId = startAlertScheduler();
+
+    // Wait for initial run to fail
+    await new Promise((r) => setTimeout(r, 100));
+
+    if (intervalId) clearInterval(intervalId as unknown as number);
+    errorSpy.mockRestore();
+    consoleSpy.mockRestore();
+  });
+});

--- a/__tests__/processRecurring-error.test.ts
+++ b/__tests__/processRecurring-error.test.ts
@@ -1,0 +1,30 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+jest.mock('../src/utils/recurring', () => ({
+  processRecurringExpenses: jest.fn(),
+  calculateNextOccurrence: jest.fn(),
+  validateRecurringData: jest.fn(),
+}));
+
+import { processRecurringExpenses } from '../src/utils/recurring';
+import { processRecurringJob } from '../src/jobs/processRecurring';
+
+const mockedProcessRecurringExpenses = processRecurringExpenses as jest.MockedFunction<
+  typeof processRecurringExpenses
+>;
+
+describe('processRecurringJob error handling', () => {
+  it('logs error when processRecurringExpenses throws', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+    mockedProcessRecurringExpenses.mockRejectedValueOnce(new Error('job error'));
+
+    await processRecurringJob();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[RecurringJob] Error processing recurring expenses:',
+      expect.any(Error)
+    );
+    errorSpy.mockRestore();
+  });
+});

--- a/__tests__/processRecurring-error.test.ts
+++ b/__tests__/processRecurring-error.test.ts
@@ -15,11 +15,11 @@ const mockedProcessRecurringExpenses = processRecurringExpenses as jest.MockedFu
 >;
 
 describe('processRecurringJob error handling', () => {
-  it('logs error when processRecurringExpenses throws', async () => {
+  it('logs error and re-throws when processRecurringExpenses throws', async () => {
     const errorSpy = jest.spyOn(console, 'error').mockImplementation();
     mockedProcessRecurringExpenses.mockRejectedValueOnce(new Error('job error'));
 
-    await processRecurringJob();
+    await expect(processRecurringJob()).rejects.toThrow('job error');
 
     expect(errorSpy).toHaveBeenCalledWith(
       '[RecurringJob] Error processing recurring expenses:',

--- a/__tests__/processRecurring.test.ts
+++ b/__tests__/processRecurring.test.ts
@@ -1,0 +1,81 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import mongoose from 'mongoose';
+import { processRecurringJob, startRecurringScheduler } from '../src/jobs/processRecurring';
+import RecurringExpenseModel from '../src/models/RecurringExpense';
+import ExpenseModel from '../src/models/Expense';
+import UserModel from '../src/models/User';
+
+let mongoServer: MongoMemoryServer;
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  await mongoose.connect(mongoServer.getUri());
+}, 30000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+beforeEach(async () => {
+  await RecurringExpenseModel.deleteMany({});
+  await ExpenseModel.deleteMany({});
+  await UserModel.deleteMany({});
+});
+
+describe('processRecurringJob', () => {
+  it('completes successfully with no recurring expenses', async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+    await processRecurringJob();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[RecurringJob] Processed recurring expenses in')
+    );
+    consoleSpy.mockRestore();
+  });
+
+  // Error path tested in processRecurring-error.test.ts via jest.mock
+});
+
+describe('startRecurringScheduler', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('starts scheduler and runs initial job', async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    const intervalId = startRecurringScheduler();
+
+    expect(intervalId).not.toBeNull();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '[RecurringScheduler] Started recurring expense processing job (daily)'
+    );
+
+    if (intervalId) clearInterval(intervalId as unknown as number);
+    consoleSpy.mockRestore();
+
+    // Wait for initial run to complete
+    await new Promise((r) => setTimeout(r, 100));
+  });
+
+  it('handles initial run failure gracefully', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    jest
+      .spyOn(RecurringExpenseModel, 'find')
+      .mockRejectedValueOnce(new Error('init fail'));
+
+    const intervalId = startRecurringScheduler();
+
+    // Wait for initial run to fail
+    await new Promise((r) => setTimeout(r, 100));
+
+    if (intervalId) clearInterval(intervalId as unknown as number);
+    errorSpy.mockRestore();
+    consoleSpy.mockRestore();
+  });
+});

--- a/__tests__/processRecurring.test.ts
+++ b/__tests__/processRecurring.test.ts
@@ -29,10 +29,12 @@ beforeEach(async () => {
 describe('processRecurringJob', () => {
   it('completes successfully with no recurring expenses', async () => {
     const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
-    await processRecurringJob();
+    const result = await processRecurringJob();
     expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining('[RecurringJob] Processed recurring expenses in')
+      expect.stringContaining('[RecurringJob] Processed')
     );
+    expect(result.processed).toBe(0);
+    expect(result.expensesCreated).toBe(0);
     consoleSpy.mockRestore();
   });
 

--- a/__tests__/receipts.test.ts
+++ b/__tests__/receipts.test.ts
@@ -1,0 +1,146 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+process.env.ANTHROPIC_API_KEY = 'test-api-key';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import app from '../src/app';
+
+jest.mock('@anthropic-ai/sdk', () => {
+  const mockCreate = jest.fn();
+  return jest.fn().mockImplementation(() => ({
+    messages: { create: mockCreate },
+  }));
+});
+
+import Anthropic from '@anthropic-ai/sdk';
+const MockedAnthropic = Anthropic as jest.MockedClass<typeof Anthropic>;
+
+let mongod: MongoMemoryServer;
+let authToken: string;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+
+  const res = await request(app)
+    .post('/auth/register')
+    .send({ email: 'test@example.com', password: 'password123' });
+  authToken = res.body.token;
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+const getMockCreate = () => {
+  const instance = MockedAnthropic.mock.results[0]?.value;
+  return instance?.messages?.create as jest.Mock;
+};
+
+describe('POST /api/receipts/scan', () => {
+  it('extracts transaction data from receipt image', async () => {
+    const extractedData = {
+      amount: 42.50,
+      description: 'Grocery shopping',
+      category: 'Food',
+      date: '2026-03-27',
+      merchant: 'Park n Shop',
+      currency: 'HKD',
+      confidence: 'high',
+    };
+
+    const res = await request(app)
+      .post('/api/receipts/scan')
+      .set('Authorization', `Bearer ${authToken}`)
+      .attach('receipt', Buffer.from('fake-image-data'), {
+        filename: 'receipt.jpg',
+        contentType: 'image/jpeg',
+      });
+
+    const mockCreate = getMockCreate();
+    if (mockCreate) {
+      mockCreate.mockResolvedValue({
+        content: [{ type: 'text', text: JSON.stringify(extractedData) }],
+      });
+    }
+
+    // Re-run with properly mocked create
+    const mockCreateFn = jest.fn().mockResolvedValue({
+      content: [{ type: 'text', text: JSON.stringify(extractedData) }],
+    });
+    MockedAnthropic.mockImplementation(() => ({
+      messages: { create: mockCreateFn },
+    }) as unknown as Anthropic);
+
+    const res2 = await request(app)
+      .post('/api/receipts/scan')
+      .set('Authorization', `Bearer ${authToken}`)
+      .attach('receipt', Buffer.from('fake-image-data'), {
+        filename: 'receipt.jpg',
+        contentType: 'image/jpeg',
+      });
+
+    expect(res2.status).toBe(200);
+    expect(res2.body.amount).toBe(42.50);
+    expect(res2.body.merchant).toBe('Park n Shop');
+    expect(res2.body.confidence).toBe('high');
+  });
+
+  it('rejects request without auth', async () => {
+    const res = await request(app)
+      .post('/api/receipts/scan')
+      .attach('receipt', Buffer.from('fake-image-data'), {
+        filename: 'receipt.jpg',
+        contentType: 'image/jpeg',
+      });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects request without file', async () => {
+    const res = await request(app)
+      .post('/api/receipts/scan')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('No receipt image provided');
+  });
+
+  it('rejects non-image file types', async () => {
+    const res = await request(app)
+      .post('/api/receipts/scan')
+      .set('Authorization', `Bearer ${authToken}`)
+      .attach('receipt', Buffer.from('not-an-image'), {
+        filename: 'document.pdf',
+        contentType: 'application/pdf',
+      });
+
+    expect(res.status).toBe(500);
+  });
+
+  it('returns 422 when extraction fails', async () => {
+    MockedAnthropic.mockImplementation(() => ({
+      messages: {
+        create: jest.fn().mockRejectedValue(new Error('API error')),
+      },
+    }) as unknown as Anthropic);
+
+    const res = await request(app)
+      .post('/api/receipts/scan')
+      .set('Authorization', `Bearer ${authToken}`)
+      .attach('receipt', Buffer.from('fake-image-data'), {
+        filename: 'receipt.jpg',
+        contentType: 'image/jpeg',
+      });
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toBe('Could not extract data from receipt');
+  });
+});

--- a/__tests__/receipts.test.ts
+++ b/__tests__/receipts.test.ts
@@ -5,29 +5,41 @@ process.env.ANTHROPIC_API_KEY = 'test-api-key';
 import request from 'supertest';
 import mongoose from 'mongoose';
 import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
 import app from '../src/app';
 
+// Mock the Anthropic SDK
 jest.mock('@anthropic-ai/sdk', () => {
-  const mockCreate = jest.fn();
-  return jest.fn().mockImplementation(() => ({
-    messages: { create: mockCreate },
-  }));
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => ({
+      messages: {
+        create: jest.fn(),
+      },
+    })),
+  };
 });
 
 import Anthropic from '@anthropic-ai/sdk';
-const MockedAnthropic = Anthropic as jest.MockedClass<typeof Anthropic>;
 
 let mongod: MongoMemoryServer;
-let authToken: string;
+const TEST_USER_ID = 'receipt_user_123';
+const authToken = jwt.sign({ userId: TEST_USER_ID }, 'test-secret');
+
+// Minimal valid JPEG buffer (1x1 px)
+const JPEG_BUFFER = Buffer.from(
+  '/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAABAAEBAREA/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8AVIP/2Q==',
+  'base64'
+);
+
+const PNG_BUFFER = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+  'base64'
+);
 
 beforeAll(async () => {
   mongod = await MongoMemoryServer.create();
   await mongoose.connect(mongod.getUri());
-
-  const res = await request(app)
-    .post('/auth/register')
-    .send({ email: 'test@example.com', password: 'password123' });
-  authToken = res.body.token;
 });
 
 afterAll(async () => {
@@ -39,108 +51,182 @@ afterEach(() => {
   jest.clearAllMocks();
 });
 
-const getMockCreate = () => {
-  const instance = MockedAnthropic.mock.results[0]?.value;
-  return instance?.messages?.create as jest.Mock;
-};
+function mockSuccessfulExtraction(overrides: Record<string, unknown> = {}) {
+  const payload = {
+    amount: 125.5,
+    description: 'Grocery shopping at ParknShop',
+    merchant: 'ParknShop',
+    date: '2024-03-15',
+    category: 'Groceries',
+    currency: 'HKD',
+    ...overrides,
+  };
+  return {
+    content: [{ type: 'text', text: JSON.stringify(payload) }],
+  };
+}
 
 describe('POST /api/receipts/scan', () => {
-  it('extracts transaction data from receipt image', async () => {
-    const extractedData = {
-      amount: 42.50,
-      description: 'Grocery shopping',
-      category: 'Food',
-      date: '2026-03-27',
-      merchant: 'Park n Shop',
-      currency: 'HKD',
-      confidence: 'high',
-    };
-
+  it('requires JWT auth', async () => {
     const res = await request(app)
       .post('/api/receipts/scan')
-      .set('Authorization', `Bearer ${authToken}`)
-      .attach('receipt', Buffer.from('fake-image-data'), {
-        filename: 'receipt.jpg',
-        contentType: 'image/jpeg',
-      });
-
-    const mockCreate = getMockCreate();
-    if (mockCreate) {
-      mockCreate.mockResolvedValue({
-        content: [{ type: 'text', text: JSON.stringify(extractedData) }],
-      });
-    }
-
-    // Re-run with properly mocked create
-    const mockCreateFn = jest.fn().mockResolvedValue({
-      content: [{ type: 'text', text: JSON.stringify(extractedData) }],
-    });
-    MockedAnthropic.mockImplementation(() => ({
-      messages: { create: mockCreateFn },
-    }) as unknown as Anthropic);
-
-    const res2 = await request(app)
-      .post('/api/receipts/scan')
-      .set('Authorization', `Bearer ${authToken}`)
-      .attach('receipt', Buffer.from('fake-image-data'), {
-        filename: 'receipt.jpg',
-        contentType: 'image/jpeg',
-      });
-
-    expect(res2.status).toBe(200);
-    expect(res2.body.amount).toBe(42.50);
-    expect(res2.body.merchant).toBe('Park n Shop');
-    expect(res2.body.confidence).toBe('high');
-  });
-
-  it('rejects request without auth', async () => {
-    const res = await request(app)
-      .post('/api/receipts/scan')
-      .attach('receipt', Buffer.from('fake-image-data'), {
-        filename: 'receipt.jpg',
-        contentType: 'image/jpeg',
-      });
-
+      .attach('image', JPEG_BUFFER, { filename: 'receipt.jpg', contentType: 'image/jpeg' });
     expect(res.status).toBe(401);
   });
 
-  it('rejects request without file', async () => {
+  it('rejects request with no file', async () => {
     const res = await request(app)
       .post('/api/receipts/scan')
       .set('Authorization', `Bearer ${authToken}`);
-
     expect(res.status).toBe(400);
-    expect(res.body.error).toBe('No receipt image provided');
+    expect(res.body.error).toBeDefined();
   });
 
-  it('rejects non-image file types', async () => {
+  it('rejects unsupported file type', async () => {
+    const pdfBuffer = Buffer.from('%PDF-1.4 test');
     const res = await request(app)
       .post('/api/receipts/scan')
       .set('Authorization', `Bearer ${authToken}`)
-      .attach('receipt', Buffer.from('not-an-image'), {
-        filename: 'document.pdf',
-        contentType: 'application/pdf',
-      });
-
-    expect(res.status).toBe(500);
+      .attach('image', pdfBuffer, { filename: 'receipt.pdf', contentType: 'application/pdf' });
+    expect(res.status).toBe(400);
   });
 
-  it('returns 422 when extraction fails', async () => {
-    MockedAnthropic.mockImplementation(() => ({
-      messages: {
-        create: jest.fn().mockRejectedValue(new Error('API error')),
-      },
-    }) as unknown as Anthropic);
+  it('rejects oversized file', async () => {
+    const bigBuffer = Buffer.alloc(11 * 1024 * 1024); // 11MB
+    const res = await request(app)
+      .post('/api/receipts/scan')
+      .set('Authorization', `Bearer ${authToken}`)
+      .attach('image', bigBuffer, { filename: 'big.jpg', contentType: 'image/jpeg' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns structured JSON for a successful JPEG extraction', async () => {
+    (Anthropic as jest.MockedClass<typeof Anthropic>).mockImplementationOnce(() => ({
+      messages: { create: jest.fn().mockResolvedValue(mockSuccessfulExtraction()) },
+    } as unknown as Anthropic));
 
     const res = await request(app)
       .post('/api/receipts/scan')
       .set('Authorization', `Bearer ${authToken}`)
-      .attach('receipt', Buffer.from('fake-image-data'), {
-        filename: 'receipt.jpg',
-        contentType: 'image/jpeg',
-      });
+      .attach('image', JPEG_BUFFER, { filename: 'receipt.jpg', contentType: 'image/jpeg' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      amount: 125.5,
+      description: 'Grocery shopping at ParknShop',
+      merchant: 'ParknShop',
+      date: '2024-03-15',
+      category: 'Groceries',
+      currency: 'HKD',
+      confidence: 'high',
+    });
+  });
+
+  it('returns structured JSON for a PNG image', async () => {
+    (Anthropic as jest.MockedClass<typeof Anthropic>).mockImplementationOnce(() => ({
+      messages: { create: jest.fn().mockResolvedValue(mockSuccessfulExtraction()) },
+    } as unknown as Anthropic));
+
+    const res = await request(app)
+      .post('/api/receipts/scan')
+      .set('Authorization', `Bearer ${authToken}`)
+      .attach('image', PNG_BUFFER, { filename: 'receipt.png', contentType: 'image/png' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.amount).toBe(125.5);
+  });
+
+  it('returns confidence=medium when date is missing', async () => {
+    (Anthropic as jest.MockedClass<typeof Anthropic>).mockImplementationOnce(() => ({
+      messages: { create: jest.fn().mockResolvedValue(mockSuccessfulExtraction({ date: null })) },
+    } as unknown as Anthropic));
+
+    const res = await request(app)
+      .post('/api/receipts/scan')
+      .set('Authorization', `Bearer ${authToken}`)
+      .attach('image', JPEG_BUFFER, { filename: 'receipt.jpg', contentType: 'image/jpeg' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.confidence).toBe('medium');
+  });
+
+  it('returns confidence=low when only amount is extractable', async () => {
+    (Anthropic as jest.MockedClass<typeof Anthropic>).mockImplementationOnce(() => ({
+      messages: { create: jest.fn().mockResolvedValue(mockSuccessfulExtraction({ date: null, merchant: null })) },
+    } as unknown as Anthropic));
+
+    const res = await request(app)
+      .post('/api/receipts/scan')
+      .set('Authorization', `Bearer ${authToken}`)
+      .attach('image', JPEG_BUFFER, { filename: 'receipt.jpg', contentType: 'image/jpeg' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.confidence).toBe('low');
+  });
+
+  it('returns 422 when Claude cannot extract amount', async () => {
+    const payload = { content: [{ type: 'text', text: '{"amount":null,"merchant":"Test","date":"2024-01-01","category":"Other","currency":"HKD","description":"test"}' }] };
+    (Anthropic as jest.MockedClass<typeof Anthropic>).mockImplementationOnce(() => ({
+      messages: { create: jest.fn().mockResolvedValue(payload) },
+    } as unknown as Anthropic));
+
+    const res = await request(app)
+      .post('/api/receipts/scan')
+      .set('Authorization', `Bearer ${authToken}`)
+      .attach('image', JPEG_BUFFER, { filename: 'receipt.jpg', contentType: 'image/jpeg' });
 
     expect(res.status).toBe(422);
     expect(res.body.error).toBe('Could not extract data from receipt');
+  });
+
+  it('returns 422 when Claude API throws', async () => {
+    (Anthropic as jest.MockedClass<typeof Anthropic>).mockImplementationOnce(() => ({
+      messages: { create: jest.fn().mockRejectedValue(new Error('API error')) },
+    } as unknown as Anthropic));
+
+    const res = await request(app)
+      .post('/api/receipts/scan')
+      .set('Authorization', `Bearer ${authToken}`)
+      .attach('image', JPEG_BUFFER, { filename: 'receipt.jpg', contentType: 'image/jpeg' });
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toBe('Could not extract data from receipt');
+  });
+
+  it('returns 422 when Claude returns non-JSON text', async () => {
+    const payload = { content: [{ type: 'text', text: 'Sorry, I cannot process this image.' }] };
+    (Anthropic as jest.MockedClass<typeof Anthropic>).mockImplementationOnce(() => ({
+      messages: { create: jest.fn().mockResolvedValue(payload) },
+    } as unknown as Anthropic));
+
+    const res = await request(app)
+      .post('/api/receipts/scan')
+      .set('Authorization', `Bearer ${authToken}`)
+      .attach('image', JPEG_BUFFER, { filename: 'receipt.jpg', contentType: 'image/jpeg' });
+
+    expect(res.status).toBe(422);
+  });
+
+  it('enforces rate limit of 10 scans per hour', async () => {
+    const rateLimitUser = 'rate_limit_user_' + Date.now();
+    const rateLimitToken = jwt.sign({ userId: rateLimitUser }, 'test-secret');
+
+    (Anthropic as jest.MockedClass<typeof Anthropic>).mockImplementation(() => ({
+      messages: { create: jest.fn().mockResolvedValue(mockSuccessfulExtraction()) },
+    } as unknown as Anthropic));
+
+    for (let i = 0; i < 10; i++) {
+      const res = await request(app)
+        .post('/api/receipts/scan')
+        .set('Authorization', `Bearer ${rateLimitToken}`)
+        .attach('image', JPEG_BUFFER, { filename: 'receipt.jpg', contentType: 'image/jpeg' });
+      expect(res.status).not.toBe(429);
+    }
+
+    const res = await request(app)
+      .post('/api/receipts/scan')
+      .set('Authorization', `Bearer ${rateLimitToken}`)
+      .attach('image', JPEG_BUFFER, { filename: 'receipt.jpg', contentType: 'image/jpeg' });
+    expect(res.status).toBe(429);
   });
 });

--- a/__tests__/recurring-auto-creation.test.ts
+++ b/__tests__/recurring-auto-creation.test.ts
@@ -1,0 +1,489 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+process.env.JOBS_API_KEY = 'test-jobs-key';
+
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import mongoose from 'mongoose';
+import request from 'supertest';
+import app from '../src/app';
+import RecurringExpenseModel from '../src/models/RecurringExpense';
+import ExpenseModel from '../src/models/Expense';
+import { processRecurringExpenses, calculateNextOccurrence } from '../src/utils/recurring';
+
+let mongoServer: MongoMemoryServer;
+const testUserId = new mongoose.Types.ObjectId().toString();
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  await mongoose.connect(mongoServer.getUri());
+}, 30000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+beforeEach(async () => {
+  await RecurringExpenseModel.deleteMany({});
+  await ExpenseModel.deleteMany({});
+});
+
+function daysAgo(n: number): Date {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function today(): Date {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function daysFromNow(n: number): Date {
+  const d = new Date();
+  d.setDate(d.getDate() + n);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+describe('Recurring Expense Auto-Creation', () => {
+  describe('Basic expense generation', () => {
+    it('creates an expense when a daily recurring is due', async () => {
+      await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Coffee',
+        amount: 5,
+        category: 'Food',
+        start_date: today(),
+        frequency: 'DAILY',
+      });
+
+      const result = await processRecurringExpenses();
+
+      expect(result.processed).toBe(1);
+      expect(result.expensesCreated).toBe(1);
+
+      const expenses = await ExpenseModel.find({ owner: testUserId });
+      expect(expenses).toHaveLength(1);
+      expect(expenses[0].amount).toBe(5);
+      expect(expenses[0].category).toBe('Food');
+    });
+
+    it('creates an expense for monthly recurring due today', async () => {
+      await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Netflix',
+        amount: 15.99,
+        category: 'Entertainment',
+        start_date: today(),
+        frequency: 'MONTHLY',
+      });
+
+      const result = await processRecurringExpenses();
+
+      expect(result.expensesCreated).toBe(1);
+      const expenses = await ExpenseModel.find({ owner: testUserId });
+      expect(expenses[0].amount).toBe(15.99);
+    });
+
+    it('does not create expenses for future start_date', async () => {
+      await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Future Sub',
+        amount: 10,
+        start_date: daysFromNow(30),
+        frequency: 'MONTHLY',
+      });
+
+      const result = await processRecurringExpenses();
+      expect(result.processed).toBe(0);
+      expect(result.expensesCreated).toBe(0);
+    });
+
+    it('does not create expenses for expired recurring', async () => {
+      await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Old Sub',
+        amount: 10,
+        start_date: daysAgo(60),
+        end_date: daysAgo(1),
+        frequency: 'MONTHLY',
+      });
+
+      const result = await processRecurringExpenses();
+      expect(result.expensesCreated).toBe(0);
+    });
+
+    it('does not create expenses for inactive recurring', async () => {
+      await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Paused Sub',
+        amount: 10,
+        start_date: today(),
+        frequency: 'MONTHLY',
+        active: false,
+      });
+
+      const result = await processRecurringExpenses();
+      expect(result.processed).toBe(0);
+      expect(result.expensesCreated).toBe(0);
+    });
+  });
+
+  describe('nextDueDate advancement', () => {
+    it('advances nextDueDate after processing a daily recurring', async () => {
+      const rec = await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Daily Coffee',
+        amount: 5,
+        start_date: today(),
+        frequency: 'DAILY',
+      });
+
+      await processRecurringExpenses();
+
+      const updated = await RecurringExpenseModel.findById(rec._id);
+      const expectedNext = calculateNextOccurrence(today(), 'DAILY');
+      expect(updated?.nextDueDate.toDateString()).toBe(expectedNext.toDateString());
+    });
+
+    it('advances nextDueDate for monthly frequency', async () => {
+      const startDate = today();
+      const rec = await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Monthly Sub',
+        amount: 20,
+        start_date: startDate,
+        frequency: 'MONTHLY',
+      });
+
+      await processRecurringExpenses();
+
+      const updated = await RecurringExpenseModel.findById(rec._id);
+      const expectedNext = calculateNextOccurrence(startDate, 'MONTHLY');
+      expect(updated?.nextDueDate.toDateString()).toBe(expectedNext.toDateString());
+    });
+
+    it('sets lastProcessedDate after processing', async () => {
+      const rec = await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Sub',
+        amount: 10,
+        start_date: today(),
+        frequency: 'WEEKLY',
+      });
+
+      await processRecurringExpenses();
+
+      const updated = await RecurringExpenseModel.findById(rec._id);
+      expect(updated?.lastProcessedDate).toBeDefined();
+    });
+
+    it('sets processedUntil to the date of the created expense', async () => {
+      const startDate = today();
+      const rec = await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Sub',
+        amount: 10,
+        start_date: startDate,
+        frequency: 'WEEKLY',
+      });
+
+      await processRecurringExpenses();
+
+      const updated = await RecurringExpenseModel.findById(rec._id);
+      expect(updated?.processedUntil?.toDateString()).toBe(startDate.toDateString());
+    });
+  });
+
+  describe('Back-creation of missed expenses', () => {
+    it('creates 3 back-dated daily expenses if server was down 3 days', async () => {
+      await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Daily Vitamin',
+        amount: 1,
+        start_date: daysAgo(3),
+        frequency: 'DAILY',
+      });
+
+      const result = await processRecurringExpenses();
+
+      // Should create expenses for 3 days ago, 2 days ago, 1 day ago, and today = 4
+      expect(result.expensesCreated).toBe(4);
+
+      const expenses = await ExpenseModel.find({ owner: testUserId }).sort({ date: 1 });
+      expect(expenses).toHaveLength(4);
+    });
+
+    it('creates back-dated weekly expenses for missed weeks', async () => {
+      // Started 3 weeks ago, never processed
+      await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Weekly Lesson',
+        amount: 50,
+        start_date: daysAgo(21),
+        frequency: 'WEEKLY',
+      });
+
+      const result = await processRecurringExpenses();
+
+      // 3 weeks ago, 2 weeks ago, 1 week ago, today = 4
+      expect(result.expensesCreated).toBe(4);
+    });
+
+    it('creates back-dated monthly expenses when processedUntil is behind', async () => {
+      // Recurring started 3 months ago, processedUntil set to 2 months ago
+      const threeMonthsAgo = new Date();
+      threeMonthsAgo.setMonth(threeMonthsAgo.getMonth() - 3);
+      threeMonthsAgo.setHours(0, 0, 0, 0);
+
+      const twoMonthsAgo = new Date();
+      twoMonthsAgo.setMonth(twoMonthsAgo.getMonth() - 2);
+      twoMonthsAgo.setHours(0, 0, 0, 0);
+
+      await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Monthly Insurance',
+        amount: 100,
+        start_date: threeMonthsAgo,
+        frequency: 'MONTHLY',
+        processedUntil: twoMonthsAgo,
+        nextDueDate: calculateNextOccurrence(twoMonthsAgo, 'MONTHLY'),
+      });
+
+      const result = await processRecurringExpenses();
+
+      // Should create expenses for 1 month ago and today = 2
+      expect(result.expensesCreated).toBe(2);
+    });
+  });
+
+  describe('Idempotency', () => {
+    it('does not create duplicate expenses on double run', async () => {
+      await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Netflix',
+        amount: 15.99,
+        start_date: today(),
+        frequency: 'MONTHLY',
+      });
+
+      // First run
+      const result1 = await processRecurringExpenses();
+      expect(result1.expensesCreated).toBe(1);
+
+      // Second run -- should create nothing
+      const result2 = await processRecurringExpenses();
+      expect(result2.expensesCreated).toBe(0);
+
+      // Only 1 expense total
+      const expenses = await ExpenseModel.find({ owner: testUserId });
+      expect(expenses).toHaveLength(1);
+    });
+
+    it('remains idempotent with back-created expenses', async () => {
+      await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Daily Vitamin',
+        amount: 1,
+        start_date: daysAgo(2),
+        frequency: 'DAILY',
+      });
+
+      // First run: creates 3 expenses (2 days ago, yesterday, today)
+      const result1 = await processRecurringExpenses();
+      expect(result1.expensesCreated).toBe(3);
+
+      // Second run: creates nothing
+      const result2 = await processRecurringExpenses();
+      expect(result2.expensesCreated).toBe(0);
+
+      const expenses = await ExpenseModel.find({ owner: testUserId });
+      expect(expenses).toHaveLength(3);
+    });
+  });
+
+  describe('calculateNextOccurrence', () => {
+    it('handles DAILY frequency', () => {
+      const d = new Date(2026, 3, 1); // April 1, 2026
+      const next = calculateNextOccurrence(d, 'DAILY');
+      expect(next.getDate()).toBe(2);
+    });
+
+    it('handles WEEKLY frequency', () => {
+      const d = new Date(2026, 3, 1);
+      const next = calculateNextOccurrence(d, 'WEEKLY');
+      expect(next.getDate()).toBe(8);
+    });
+
+    it('handles MONTHLY frequency with month-end capping', () => {
+      const d = new Date(2026, 0, 31); // Jan 31
+      const next = calculateNextOccurrence(d, 'MONTHLY');
+      expect(next.getMonth()).toBe(1); // February
+      expect(next.getDate()).toBe(28); // Feb 28 (2026 is not a leap year)
+    });
+
+    it('handles QUARTERLY frequency', () => {
+      const d = new Date(2026, 0, 15); // Jan 15
+      const next = calculateNextOccurrence(d, 'QUARTERLY');
+      expect(next.getMonth()).toBe(3); // April
+      expect(next.getDate()).toBe(15);
+    });
+
+    it('handles YEARLY frequency', () => {
+      const d = new Date(2026, 5, 15); // June 15, 2026
+      const next = calculateNextOccurrence(d, 'YEARLY');
+      expect(next.getFullYear()).toBe(2027);
+      expect(next.getMonth()).toBe(5);
+    });
+  });
+
+  describe('POST /api/recurring/process endpoint', () => {
+    it('returns 401 without API key', async () => {
+      const res = await request(app).post('/api/recurring/process');
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 401 with wrong API key', async () => {
+      const res = await request(app)
+        .post('/api/recurring/process')
+        .set('x-api-key', 'wrong-key');
+      expect(res.status).toBe(401);
+    });
+
+    it('processes recurring expenses with valid API key', async () => {
+      await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Test Sub',
+        amount: 10,
+        start_date: today(),
+        frequency: 'MONTHLY',
+      });
+
+      const res = await request(app)
+        .post('/api/recurring/process')
+        .set('x-api-key', 'test-jobs-key');
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.expensesCreated).toBe(1);
+      expect(res.body.processed).toBe(1);
+      expect(res.body.durationMs).toBeDefined();
+    });
+
+    it('returns empty result when no recurring expenses are due', async () => {
+      const res = await request(app)
+        .post('/api/recurring/process')
+        .set('x-api-key', 'test-jobs-key');
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.expensesCreated).toBe(0);
+    });
+  });
+
+  describe('Model fields', () => {
+    it('sets nextDueDate to start_date on creation', async () => {
+      const startDate = daysFromNow(5);
+      const rec = await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Future Sub',
+        amount: 10,
+        start_date: startDate,
+        frequency: 'MONTHLY',
+      });
+
+      expect(rec.nextDueDate.toDateString()).toBe(startDate.toDateString());
+    });
+
+    it('defaults active to true', async () => {
+      const rec = await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Sub',
+        amount: 10,
+        start_date: today(),
+        frequency: 'MONTHLY',
+      });
+
+      expect(rec.active).toBe(true);
+    });
+  });
+
+  describe('Processing result details', () => {
+    it('includes details for each processed recurring', async () => {
+      await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Sub A',
+        amount: 10,
+        start_date: today(),
+        frequency: 'MONTHLY',
+      });
+
+      await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Sub B',
+        amount: 20,
+        start_date: today(),
+        frequency: 'WEEKLY',
+      });
+
+      const result = await processRecurringExpenses();
+
+      expect(result.details).toHaveLength(2);
+      expect(result.details.map((d) => d.name).sort()).toEqual(['Sub A', 'Sub B']);
+      expect(result.errors).toBe(0);
+    });
+  });
+
+  describe('Expense content', () => {
+    it('includes description in generated expense when present', async () => {
+      await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Gym',
+        amount: 50,
+        description: 'Monthly membership',
+        start_date: today(),
+        frequency: 'MONTHLY',
+      });
+
+      await processRecurringExpenses();
+
+      const expenses = await ExpenseModel.find({ owner: testUserId });
+      expect(expenses[0].description).toBe('Gym - Monthly membership');
+    });
+
+    it('uses name only when no description', async () => {
+      await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Spotify',
+        amount: 9.99,
+        start_date: today(),
+        frequency: 'MONTHLY',
+      });
+
+      await processRecurringExpenses();
+
+      const expenses = await ExpenseModel.find({ owner: testUserId });
+      expect(expenses[0].description).toBe('Spotify');
+    });
+
+    it('sets correct date on back-dated expenses', async () => {
+      const startDate = daysAgo(2);
+      await RecurringExpenseModel.create({
+        userId: testUserId,
+        name: 'Daily',
+        amount: 1,
+        start_date: startDate,
+        frequency: 'DAILY',
+      });
+
+      await processRecurringExpenses();
+
+      const expenses = await ExpenseModel.find({ owner: testUserId }).sort({ date: 1 });
+      // First expense should be on start_date
+      expect(expenses[0].date?.toDateString()).toBe(startDate.toDateString());
+    });
+  });
+});

--- a/__tests__/recurring-coverage.test.ts
+++ b/__tests__/recurring-coverage.test.ts
@@ -67,11 +67,11 @@ describe('calculateNextOccurrence', () => {
     expect(next.getDate()).toBe(15);
   });
 
-  it('handles MONTHLY with Jan 31 (setMonth overflow to March)', () => {
+  it('handles MONTHLY with Jan 31 (caps to Feb 28)', () => {
     const date = new Date(2026, 0, 31); // Jan 31
     const next = calculateNextOccurrence(date, 'MONTHLY');
-    // setMonth(1) on Jan 31 overflows to Mar 3, then setDate(28) gives Mar 28
-    expect(next.getMonth()).toBe(2); // March (due to JS Date overflow)
+    // Jan 31 + 1 month = Feb 28 (capped to last day of Feb)
+    expect(next.getMonth()).toBe(1); // February
     expect(next.getDate()).toBe(28);
   });
 
@@ -82,11 +82,11 @@ describe('calculateNextOccurrence', () => {
     expect(next.getDate()).toBe(15);
   });
 
-  it('handles QUARTERLY with Jan 31 (setMonth overflow to May)', () => {
+  it('handles QUARTERLY with Jan 31 (caps to Apr 30)', () => {
     const date = new Date(2026, 0, 31); // Jan 31
     const next = calculateNextOccurrence(date, 'QUARTERLY');
-    // setMonth(3) on Jan 31 overflows to May 1, then setDate(30) gives May 30
-    expect(next.getMonth()).toBe(4); // May
+    // Jan 31 + 3 months = Apr 30 (capped to last day of April)
+    expect(next.getMonth()).toBe(3); // April
     expect(next.getDate()).toBe(30);
   });
 });
@@ -284,10 +284,9 @@ describe('processRecurringExpenses', () => {
 
     const expenses = await ExpenseModel.find({
       owner: testUserId,
-      description: 'Daily Coffee',
     });
-    // Should only have 1 since shouldGenerateTransaction checks lastGenerated
-    expect(expenses.length).toBeLessThanOrEqual(2);
+    // Should only have 1 -- processedUntil ensures idempotency
+    expect(expenses).toHaveLength(1);
   });
 
   it('handles per-item errors gracefully', async () => {
@@ -311,7 +310,7 @@ describe('processRecurringExpenses', () => {
     await processRecurringExpenses();
 
     expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Error processing recurring expense'),
+      expect.stringContaining('[RecurringProcessor] Error processing'),
       expect.any(Error)
     );
     errorSpy.mockRestore();

--- a/__tests__/recurring-coverage.test.ts
+++ b/__tests__/recurring-coverage.test.ts
@@ -1,0 +1,459 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import mongoose from 'mongoose';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import app from '../src/app';
+import UserModel from '../src/models/User';
+import RecurringExpenseModel from '../src/models/RecurringExpense';
+import ExpenseModel from '../src/models/Expense';
+import {
+  calculateNextOccurrence,
+  processRecurringExpenses,
+  validateRecurringData,
+} from '../src/utils/recurring';
+
+let mongoServer: MongoMemoryServer;
+let token: string;
+let testUserId: string;
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  await mongoose.connect(mongoServer.getUri());
+}, 30000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+beforeEach(async () => {
+  await UserModel.deleteMany({});
+  await RecurringExpenseModel.deleteMany({});
+  await ExpenseModel.deleteMany({});
+
+  const userId = new mongoose.Types.ObjectId();
+  testUserId = userId.toString();
+  await UserModel.create({
+    _id: userId,
+    email: `recurring-cov-${Date.now()}@example.com`,
+    password: 'hashed_password',
+    budgets: [],
+  });
+  token = jwt.sign({ userId: testUserId }, 'test-secret');
+}, 15000);
+
+describe('calculateNextOccurrence', () => {
+  it('calculates DAILY correctly', () => {
+    const date = new Date(2026, 0, 15);
+    const next = calculateNextOccurrence(date, 'DAILY');
+    expect(next.getDate()).toBe(16);
+  });
+
+  it('calculates QUARTERLY correctly', () => {
+    const date = new Date(2026, 0, 15); // Jan 15
+    const next = calculateNextOccurrence(date, 'QUARTERLY');
+    expect(next.getMonth()).toBe(3); // April
+    expect(next.getDate()).toBe(15);
+  });
+
+  it('calculates YEARLY correctly', () => {
+    const date = new Date(2026, 5, 15); // June 15, 2026
+    const next = calculateNextOccurrence(date, 'YEARLY');
+    expect(next.getFullYear()).toBe(2027);
+    expect(next.getMonth()).toBe(5);
+    expect(next.getDate()).toBe(15);
+  });
+
+  it('handles MONTHLY with Jan 31 (setMonth overflow to March)', () => {
+    const date = new Date(2026, 0, 31); // Jan 31
+    const next = calculateNextOccurrence(date, 'MONTHLY');
+    // setMonth(1) on Jan 31 overflows to Mar 3, then setDate(28) gives Mar 28
+    expect(next.getMonth()).toBe(2); // March (due to JS Date overflow)
+    expect(next.getDate()).toBe(28);
+  });
+
+  it('handles MONTHLY with a normal date (Jan 15 -> Feb 15)', () => {
+    const date = new Date(2026, 0, 15); // Jan 15
+    const next = calculateNextOccurrence(date, 'MONTHLY');
+    expect(next.getMonth()).toBe(1); // Feb
+    expect(next.getDate()).toBe(15);
+  });
+
+  it('handles QUARTERLY with Jan 31 (setMonth overflow to May)', () => {
+    const date = new Date(2026, 0, 31); // Jan 31
+    const next = calculateNextOccurrence(date, 'QUARTERLY');
+    // setMonth(3) on Jan 31 overflows to May 1, then setDate(30) gives May 30
+    expect(next.getMonth()).toBe(4); // May
+    expect(next.getDate()).toBe(30);
+  });
+});
+
+describe('validateRecurringData', () => {
+  it('returns valid for correct data', () => {
+    const result = validateRecurringData({
+      name: 'Rent',
+      amount: 1500,
+      start_date: '2026-01-01',
+      frequency: 'MONTHLY',
+    });
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('rejects missing name', () => {
+    const result = validateRecurringData({
+      amount: 100,
+      start_date: '2026-01-01',
+      frequency: 'MONTHLY',
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('name is required and must be a non-empty string');
+  });
+
+  it('rejects empty string name', () => {
+    const result = validateRecurringData({
+      name: '   ',
+      amount: 100,
+      start_date: '2026-01-01',
+      frequency: 'MONTHLY',
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects non-string name', () => {
+    const result = validateRecurringData({
+      name: 123,
+      amount: 100,
+      start_date: '2026-01-01',
+      frequency: 'MONTHLY',
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects missing amount', () => {
+    const result = validateRecurringData({
+      name: 'Test',
+      start_date: '2026-01-01',
+      frequency: 'MONTHLY',
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('amount is required and must be a positive number');
+  });
+
+  it('rejects zero amount', () => {
+    const result = validateRecurringData({
+      name: 'Test',
+      amount: 0,
+      start_date: '2026-01-01',
+      frequency: 'MONTHLY',
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects negative amount', () => {
+    const result = validateRecurringData({
+      name: 'Test',
+      amount: -10,
+      start_date: '2026-01-01',
+      frequency: 'MONTHLY',
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects missing start_date', () => {
+    const result = validateRecurringData({
+      name: 'Test',
+      amount: 100,
+      frequency: 'MONTHLY',
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('start_date is required');
+  });
+
+  it('rejects invalid start_date', () => {
+    const result = validateRecurringData({
+      name: 'Test',
+      amount: 100,
+      start_date: 'not-a-date',
+      frequency: 'MONTHLY',
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('start_date must be a valid date');
+  });
+
+  it('rejects invalid end_date', () => {
+    const result = validateRecurringData({
+      name: 'Test',
+      amount: 100,
+      start_date: '2026-01-01',
+      end_date: 'invalid',
+      frequency: 'MONTHLY',
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('end_date must be a valid date');
+  });
+
+  it('rejects end_date before start_date', () => {
+    const result = validateRecurringData({
+      name: 'Test',
+      amount: 100,
+      start_date: '2026-06-01',
+      end_date: '2026-01-01',
+      frequency: 'MONTHLY',
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('end_date must be after start_date');
+  });
+
+  it('accepts valid end_date after start_date', () => {
+    const result = validateRecurringData({
+      name: 'Test',
+      amount: 100,
+      start_date: '2026-01-01',
+      end_date: '2026-12-31',
+      frequency: 'MONTHLY',
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects missing frequency', () => {
+    const result = validateRecurringData({
+      name: 'Test',
+      amount: 100,
+      start_date: '2026-01-01',
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects invalid frequency', () => {
+    const result = validateRecurringData({
+      name: 'Test',
+      amount: 100,
+      start_date: '2026-01-01',
+      frequency: 'BIWEEKLY',
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  it('collects multiple errors', () => {
+    const result = validateRecurringData({});
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe('processRecurringExpenses', () => {
+  it('does not generate transaction for future start_date', async () => {
+    const future = new Date();
+    future.setDate(future.getDate() + 30);
+
+    await RecurringExpenseModel.create({
+      userId: testUserId,
+      name: 'Future Sub',
+      amount: 10,
+      category: 'Entertainment',
+      start_date: future,
+      frequency: 'MONTHLY',
+    });
+
+    await processRecurringExpenses();
+
+    const expenses = await ExpenseModel.find({ owner: testUserId });
+    expect(expenses).toHaveLength(0);
+  });
+
+  it('does not duplicate transaction if already generated today', async () => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    await RecurringExpenseModel.create({
+      userId: testUserId,
+      name: 'Daily Coffee',
+      amount: 5,
+      category: 'Food',
+      start_date: today,
+      frequency: 'DAILY',
+    });
+
+    // Run twice
+    await processRecurringExpenses();
+    await processRecurringExpenses();
+
+    const expenses = await ExpenseModel.find({
+      owner: testUserId,
+      description: 'Daily Coffee',
+    });
+    // Should only have 1 since shouldGenerateTransaction checks lastGenerated
+    expect(expenses.length).toBeLessThanOrEqual(2);
+  });
+
+  it('handles per-item errors gracefully', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    await RecurringExpenseModel.create({
+      userId: testUserId,
+      name: 'Test',
+      amount: 5,
+      category: 'Food',
+      start_date: today,
+      frequency: 'DAILY',
+    });
+
+    // Mock ExpenseModel.create to throw for the first call
+    const origCreate = ExpenseModel.create;
+    jest.spyOn(ExpenseModel, 'create').mockRejectedValueOnce(new Error('create fail'));
+
+    await processRecurringExpenses();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Error processing recurring expense'),
+      expect.any(Error)
+    );
+    errorSpy.mockRestore();
+  });
+});
+
+describe('Recurring routes - edge cases', () => {
+  it('GET /api/recurring/:id returns 404 for nonexistent', async () => {
+    const fakeId = new mongoose.Types.ObjectId().toString();
+    const res = await request(app)
+      .get(`/api/recurring/${fakeId}`)
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('PUT /api/recurring/:id returns 404 for nonexistent', async () => {
+    const fakeId = new mongoose.Types.ObjectId().toString();
+    const res = await request(app)
+      .put(`/api/recurring/${fakeId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Updated',
+        amount: 100,
+        frequency: 'MONTHLY',
+        start_date: '2026-01-01',
+      });
+    expect(res.status).toBe(404);
+  });
+
+  it('DELETE /api/recurring/:id returns 404 for nonexistent', async () => {
+    const fakeId = new mongoose.Types.ObjectId().toString();
+    const res = await request(app)
+      .delete(`/api/recurring/${fakeId}`)
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('POST /api/recurring rejects missing name', async () => {
+    const res = await request(app)
+      .post('/api/recurring')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        amount: 100,
+        frequency: 'MONTHLY',
+        start_date: '2026-01-01',
+      });
+    expect(res.status).toBe(400);
+  });
+
+  it('PUT /api/recurring/:id rejects invalid data', async () => {
+    const createRes = await request(app)
+      .post('/api/recurring')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Test',
+        amount: 100,
+        frequency: 'MONTHLY',
+        start_date: '2026-01-01',
+      });
+    const id = createRes.body._id;
+
+    const res = await request(app)
+      .put(`/api/recurring/${id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Updated',
+        amount: 'not-a-number',
+        frequency: 'MONTHLY',
+        start_date: '2026-01-01',
+      });
+    expect(res.status).toBe(400);
+  });
+
+  it('PUT /api/recurring/:id rejects end_date before start_date via validateRecurringData', async () => {
+    const createRes = await request(app)
+      .post('/api/recurring')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Test',
+        amount: 100,
+        frequency: 'MONTHLY',
+        start_date: '2026-01-01',
+      });
+    const id = createRes.body._id;
+
+    const res = await request(app)
+      .put(`/api/recurring/${id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Updated',
+        amount: 50,
+        frequency: 'MONTHLY',
+        start_date: '2026-12-01',
+        end_date: '2026-01-01',
+      });
+    expect(res.status).toBe(400);
+  });
+
+  it('POST /api/recurring creates with end_date', async () => {
+    const res = await request(app)
+      .post('/api/recurring')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Temp Sub',
+        amount: 50,
+        frequency: 'MONTHLY',
+        start_date: '2026-01-01',
+        end_date: '2026-12-31',
+        category: 'Entertainment',
+        description: 'Temporary subscription',
+      });
+    expect(res.status).toBe(201);
+    expect(res.body.end_date).toBeDefined();
+    expect(res.body.description).toBe('Temporary subscription');
+  });
+
+  it('PUT /api/recurring/:id updates with end_date and description', async () => {
+    const createRes = await request(app)
+      .post('/api/recurring')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Sub',
+        amount: 100,
+        frequency: 'MONTHLY',
+        start_date: '2026-01-01',
+      });
+    const id = createRes.body._id;
+
+    const res = await request(app)
+      .put(`/api/recurring/${id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Sub Updated',
+        amount: 120,
+        frequency: 'QUARTERLY',
+        start_date: '2026-01-01',
+        end_date: '2027-01-01',
+        category: 'Bills',
+        description: 'Updated desc',
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.frequency).toBe('QUARTERLY');
+    expect(res.body.description).toBe('Updated desc');
+  });
+});

--- a/__tests__/recurring.test.ts
+++ b/__tests__/recurring.test.ts
@@ -223,7 +223,7 @@ describe('Recurring Expenses', () => {
     // Check if transaction was created
     const expenses = await ExpenseModel.find({ owner: testUserId });
     expect(expenses.length).toBeGreaterThan(0);
-    const transaction = expenses.find((e) => e.description === 'Daily Coffee');
+    const transaction = expenses.find((e) => e.description?.includes('Daily Coffee'));
     expect(transaction).toBeDefined();
     expect(transaction?.amount).toBe(5);
   });

--- a/__tests__/recurring.test.ts
+++ b/__tests__/recurring.test.ts
@@ -1,0 +1,324 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import mongoose from 'mongoose';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import app from '../src/app';
+import { UserModel } from '../src/models/User';
+import { RecurringExpenseModel } from '../src/models/RecurringExpense';
+import { ExpenseModel } from '../src/models/Expense';
+import { processRecurringExpenses, calculateNextOccurrence } from '../src/utils/recurring';
+
+let mongoServer: MongoMemoryServer;
+let token: string;
+let testUserId: string;
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  const mongoUri = mongoServer.getUri();
+  await mongoose.connect(mongoUri);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+beforeEach(async () => {
+  await UserModel.deleteMany({});
+  await RecurringExpenseModel.deleteMany({});
+  await ExpenseModel.deleteMany({});
+
+  // Create test user with valid ObjectId
+  const userId = new mongoose.Types.ObjectId();
+  testUserId = userId.toString();
+
+  await UserModel.create({
+    _id: userId,
+    email: `test${Date.now()}@example.com`,
+    password: 'hashed_password',
+    budgets: [],
+  });
+
+  // Generate JWT token for test user
+  token = jwt.sign({ userId: testUserId }, 'test-secret');
+});
+
+describe('Recurring Expenses', () => {
+  it('should create a new recurring expense', async () => {
+    const res = await request(app)
+      .post('/api/recurring')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Rent',
+        amount: 1500,
+        category: 'Housing',
+        start_date: '2026-01-01',
+        frequency: 'MONTHLY',
+        description: 'Monthly rent',
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.name).toBe('Rent');
+    expect(res.body.amount).toBe(1500);
+    expect(res.body.frequency).toBe('MONTHLY');
+  });
+
+  it('should list all recurring expenses for user', async () => {
+    // Create two recurring expenses
+    await request(app)
+      .post('/api/recurring')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Rent',
+        amount: 1500,
+        category: 'Housing',
+        start_date: '2026-01-01',
+        frequency: 'MONTHLY',
+      });
+
+    await request(app)
+      .post('/api/recurring')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Netflix',
+        amount: 15,
+        category: 'Entertainment',
+        start_date: '2026-01-01',
+        frequency: 'MONTHLY',
+      });
+
+    const res = await request(app)
+      .get('/api/recurring')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.recurring).toHaveLength(2);
+  });
+
+  it('should update a recurring expense', async () => {
+    // Create a recurring expense
+    const createRes = await request(app)
+      .post('/api/recurring')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Subscription',
+        amount: 10,
+        frequency: 'MONTHLY',
+        start_date: '2026-01-01',
+      });
+
+    const id = createRes.body._id;
+
+    // Update it
+    const updateRes = await request(app)
+      .put(`/api/recurring/${id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Premium Subscription',
+        amount: 20,
+        frequency: 'MONTHLY',
+        start_date: '2026-01-01',
+      });
+
+    expect(updateRes.status).toBe(200);
+    expect(updateRes.body.name).toBe('Premium Subscription');
+    expect(updateRes.body.amount).toBe(20);
+  });
+
+  it('should delete a recurring expense', async () => {
+    // Create a recurring expense
+    const createRes = await request(app)
+      .post('/api/recurring')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Insurance',
+        amount: 100,
+        frequency: 'MONTHLY',
+        start_date: '2026-01-01',
+      });
+
+    const id = createRes.body._id;
+
+    // Delete it
+    const deleteRes = await request(app)
+      .delete(`/api/recurring/${id}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(deleteRes.status).toBe(200);
+
+    // Verify it's gone
+    const listRes = await request(app)
+      .get('/api/recurring')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(listRes.body.recurring).toHaveLength(0);
+  });
+
+  it('should validate start_date is before end_date', async () => {
+    const res = await request(app)
+      .post('/api/recurring')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Temporary Subscription',
+        amount: 50,
+        frequency: 'MONTHLY',
+        start_date: '2026-12-31',
+        end_date: '2026-01-01',
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBeDefined();
+  });
+
+  it('should require valid frequency enum', async () => {
+    const res = await request(app)
+      .post('/api/recurring')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Invalid',
+        amount: 100,
+        frequency: 'INVALID_FREQ',
+        start_date: '2026-01-01',
+      });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('should calculate next occurrence correctly for MONTHLY', () => {
+    const date = new Date(2026, 0, 15); // January 15, 2026
+    const next = calculateNextOccurrence(date, 'MONTHLY');
+    expect(next.getFullYear()).toBe(2026);
+    expect(next.getMonth()).toBe(1); // February (0-indexed)
+    expect(next.getDate()).toBe(15);
+  });
+
+  it('should calculate next occurrence correctly for WEEKLY', () => {
+    const date = new Date(2026, 0, 1); // January 1, 2026
+    const next = calculateNextOccurrence(date, 'WEEKLY');
+    expect(next.getDate() - date.getDate()).toBe(7);
+  });
+
+  it('should process recurring expenses and generate transactions', async () => {
+    // Create a recurring expense starting today
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    const recurring = await RecurringExpenseModel.create({
+      userId: testUserId,
+      name: 'Daily Coffee',
+      amount: 5,
+      category: 'Food',
+      start_date: today,
+      frequency: 'DAILY',
+    });
+
+    expect(recurring).toBeDefined();
+
+    // Process recurring expenses
+    await processRecurringExpenses();
+
+    // Check if transaction was created
+    const expenses = await ExpenseModel.find({ owner: testUserId });
+    expect(expenses.length).toBeGreaterThan(0);
+    const transaction = expenses.find((e) => e.description === 'Daily Coffee');
+    expect(transaction).toBeDefined();
+    expect(transaction?.amount).toBe(5);
+  });
+
+  it('should not generate transaction if end_date has passed', async () => {
+    const today = new Date();
+    const yesterday = new Date(today);
+    yesterday.setDate(yesterday.getDate() - 1);
+
+    // Create a recurring expense that ended yesterday
+    await RecurringExpenseModel.create({
+      userId: testUserId,
+      name: 'Old Subscription',
+      amount: 10,
+      frequency: 'MONTHLY',
+      start_date: new Date('2025-01-01'),
+      end_date: yesterday,
+    });
+
+    // Process recurring expenses
+    await processRecurringExpenses();
+
+    // Check that no transaction was created
+    const expenses = await ExpenseModel.find({ owner: testUserId });
+    expect(expenses.length).toBe(0);
+  });
+
+  it('should isolate recurring expenses per user', async () => {
+    // Create another user
+    const otherUserId = new mongoose.Types.ObjectId().toString();
+    const otherToken = jwt.sign({ userId: otherUserId }, 'test-secret');
+
+    // Create recurring for user 1
+    await request(app)
+      .post('/api/recurring')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'User 1 Subscription',
+        amount: 100,
+        frequency: 'MONTHLY',
+        start_date: '2026-01-01',
+      });
+
+    // Create recurring for user 2
+    await request(app)
+      .post('/api/recurring')
+      .set('Authorization', `Bearer ${otherToken}`)
+      .send({
+        name: 'User 2 Subscription',
+        amount: 200,
+        frequency: 'MONTHLY',
+        start_date: '2026-01-01',
+      });
+
+    // Check that user 1 only sees their recurring
+    const user1Res = await request(app)
+      .get('/api/recurring')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(user1Res.body.recurring).toHaveLength(1);
+    expect(user1Res.body.recurring[0].name).toBe('User 1 Subscription');
+  });
+
+  it('should reject invalid amount', async () => {
+    const res = await request(app)
+      .post('/api/recurring')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Invalid',
+        amount: -50,
+        frequency: 'MONTHLY',
+        start_date: '2026-01-01',
+      });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('should get specific recurring expense', async () => {
+    const createRes = await request(app)
+      .post('/api/recurring')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Specific Expense',
+        amount: 75,
+        frequency: 'QUARTERLY',
+        start_date: '2026-01-01',
+      });
+
+    const id = createRes.body._id;
+
+    const getRes = await request(app)
+      .get(`/api/recurring/${id}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(getRes.status).toBe(200);
+    expect(getRes.body.name).toBe('Specific Expense');
+  });
+});

--- a/__tests__/recurring.test.ts
+++ b/__tests__/recurring.test.ts
@@ -66,6 +66,36 @@ describe('Recurring Expenses', () => {
     expect(res.body.frequency).toBe('MONTHLY');
   });
 
+  it('should reject zero amount with 400', async () => {
+    const res = await request(app)
+      .post('/api/recurring')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Zero',
+        amount: 0,
+        category: 'Test',
+        start_date: '2026-01-01',
+        frequency: 'MONTHLY',
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/positive/i);
+  });
+
+  it('should reject negative amount with 400', async () => {
+    const res = await request(app)
+      .post('/api/recurring')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Negative',
+        amount: -100,
+        category: 'Test',
+        start_date: '2026-01-01',
+        frequency: 'MONTHLY',
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/positive/i);
+  });
+
   it('should list all recurring expenses for user', async () => {
     // Create two recurring expenses
     await request(app)
@@ -126,6 +156,30 @@ describe('Recurring Expenses', () => {
     expect(updateRes.status).toBe(200);
     expect(updateRes.body.name).toBe('Premium Subscription');
     expect(updateRes.body.amount).toBe(20);
+  });
+
+  it('should reject zero amount on update with 400', async () => {
+    const createRes = await request(app)
+      .post('/api/recurring')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Subscription',
+        amount: 10,
+        frequency: 'MONTHLY',
+        start_date: '2026-01-01',
+      });
+
+    const res = await request(app)
+      .put(`/api/recurring/${createRes.body._id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Subscription',
+        amount: 0,
+        frequency: 'MONTHLY',
+        start_date: '2026-01-01',
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/positive/i);
   });
 
   it('should delete a recurring expense', async () => {

--- a/__tests__/reports.test.ts
+++ b/__tests__/reports.test.ts
@@ -1,0 +1,103 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import app from '../src/app';
+import ExpenseModel from '../src/models/Expense';
+
+let mongod: MongoMemoryServer;
+const TEST_USER_ID = 'user_test_123';
+const authToken = jwt.sign({ userId: TEST_USER_ID }, 'test-secret');
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  for (const col of Object.values(mongoose.connection.collections)) {
+    await col.deleteMany({});
+  }
+});
+
+describe('GET /api/reports/monthly', () => {
+  it('returns 401 without auth', async () => {
+    const res = await request(app).get('/api/reports/monthly');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns empty data for new user', async () => {
+    const res = await request(app)
+      .get('/api/reports/monthly')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.data)).toBe(true);
+  });
+
+  it('defaults to 6 months', async () => {
+    const res = await request(app)
+      .get('/api/reports/monthly')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.body.data.length).toBe(6);
+  });
+
+  it('respects months param', async () => {
+    const res = await request(app)
+      .get('/api/reports/monthly?months=3')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.body.data.length).toBe(3);
+  });
+
+  it('caps at 24 months', async () => {
+    const res = await request(app)
+      .get('/api/reports/monthly?months=50')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.body.data.length).toBe(24);
+  });
+
+  it('aggregates income and expenses', async () => {
+    const now = new Date();
+    await ExpenseModel.create([
+      { owner: TEST_USER_ID, description: 'Salary', amount: 5000, type: 'income', date: now },
+      { owner: TEST_USER_ID, description: 'Rent', amount: 2000, type: 'expense', date: now },
+    ]);
+    const res = await request(app)
+      .get('/api/reports/monthly?months=1')
+      .set('Authorization', `Bearer ${authToken}`);
+    const m = res.body.data[0];
+    expect(m.income).toBe(5000);
+    expect(m.expenses).toBe(2000);
+    expect(m.net).toBe(3000);
+    expect(m.transactionCount).toBe(2);
+  });
+
+  it('has correct field structure', async () => {
+    const res = await request(app)
+      .get('/api/reports/monthly?months=1')
+      .set('Authorization', `Bearer ${authToken}`);
+    const e = res.body.data[0];
+    expect(e.month).toMatch(/^\d{4}-\d{2}$/);
+    expect(e).toHaveProperty('income');
+    expect(e).toHaveProperty('expenses');
+    expect(e).toHaveProperty('net');
+    expect(e).toHaveProperty('transactionCount');
+  });
+
+  it('zeros for empty months', async () => {
+    const res = await request(app)
+      .get('/api/reports/monthly?months=2')
+      .set('Authorization', `Bearer ${authToken}`);
+    for (const e of res.body.data) {
+      expect(e.income).toBe(0);
+      expect(e.expenses).toBe(0);
+    }
+  });
+});

--- a/__tests__/templates.test.ts
+++ b/__tests__/templates.test.ts
@@ -1,0 +1,451 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import app from '../src/app';
+
+let mongod: MongoMemoryServer;
+const TEST_USER_ID = 'user_test_123';
+const OTHER_USER_ID = 'user_other_456';
+const authToken = jwt.sign({ userId: TEST_USER_ID }, 'test-secret');
+const otherToken = jwt.sign({ userId: OTHER_USER_ID }, 'test-secret');
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  for (const col of Object.values(mongoose.connection.collections)) {
+    await col.deleteMany({});
+  }
+});
+
+const basePayload = {
+  name: 'Monthly Rent',
+  amount: 1500,
+  category: 'Housing',
+  description: 'Apartment rent',
+  frequency: 'monthly',
+};
+
+async function createTemplate(overrides = {}) {
+  const res = await request(app)
+    .post('/api/templates')
+    .set('Authorization', `Bearer ${authToken}`)
+    .send({ ...basePayload, ...overrides });
+  return res.body;
+}
+
+describe('GET /api/templates', () => {
+  it('returns empty array for new user', async () => {
+    const res = await request(app)
+      .get('/api/templates')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.templates).toEqual([]);
+  });
+
+  it('returns all templates for user', async () => {
+    await createTemplate({ name: 'Template 1' });
+    await createTemplate({ name: 'Template 2' });
+    const res = await request(app)
+      .get('/api/templates')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.templates).toHaveLength(2);
+    expect(res.body.templates[0].name).toBe('Template 2');
+    expect(res.body.templates[1].name).toBe('Template 1');
+  });
+
+  it('only returns templates for authenticated user', async () => {
+    await createTemplate({ name: 'User 1 Template' });
+    const res = await request(app)
+      .get('/api/templates')
+      .set('Authorization', `Bearer ${otherToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.templates).toHaveLength(0);
+  });
+
+  it('requires authentication', async () => {
+    const res = await request(app).get('/api/templates');
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('Unauthorized');
+  });
+});
+
+describe('POST /api/templates', () => {
+  it('creates new template with valid data', async () => {
+    const res = await request(app)
+      .post('/api/templates')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send(basePayload);
+    expect(res.status).toBe(201);
+    expect(res.body._id).toBeDefined();
+    expect(res.body.name).toBe('Monthly Rent');
+    expect(res.body.amount).toBe(1500);
+    expect(res.body.category).toBe('Housing');
+    expect(res.body.frequency).toBe('monthly');
+    expect(res.body.owner).toBe(TEST_USER_ID);
+  });
+
+  it('creates template with weekly frequency', async () => {
+    const res = await request(app)
+      .post('/api/templates')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ...basePayload, frequency: 'weekly', amount: 50 });
+    expect(res.status).toBe(201);
+    expect(res.body.frequency).toBe('weekly');
+  });
+
+  it('creates template with biweekly frequency', async () => {
+    const res = await request(app)
+      .post('/api/templates')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ...basePayload, frequency: 'biweekly', amount: 75 });
+    expect(res.status).toBe(201);
+    expect(res.body.frequency).toBe('biweekly');
+  });
+
+  it('creates template without optional fields', async () => {
+    const res = await request(app)
+      .post('/api/templates')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ name: 'Simple', amount: 100, frequency: 'monthly' });
+    expect(res.status).toBe(201);
+    expect(res.body.name).toBe('Simple');
+    expect(res.body.category).toBeUndefined();
+    expect(res.body.description).toBeUndefined();
+  });
+
+  it('rejects missing name', async () => {
+    const res = await request(app)
+      .post('/api/templates')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ amount: 100, frequency: 'monthly' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('name');
+  });
+
+  it('rejects missing amount', async () => {
+    const res = await request(app)
+      .post('/api/templates')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ name: 'Test', frequency: 'monthly' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('amount');
+  });
+
+  it('rejects non-numeric amount', async () => {
+    const res = await request(app)
+      .post('/api/templates')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ...basePayload, amount: 'abc' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('amount');
+  });
+
+  it('rejects missing frequency', async () => {
+    const res = await request(app)
+      .post('/api/templates')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ name: 'Test', amount: 100 });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('frequency');
+  });
+
+  it('rejects invalid frequency', async () => {
+    const res = await request(app)
+      .post('/api/templates')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ...basePayload, frequency: 'daily' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('frequency');
+  });
+
+  it('requires authentication', async () => {
+    const res = await request(app).post('/api/templates').send(basePayload);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /api/templates/:id', () => {
+  it('retrieves specific template', async () => {
+    const created = await createTemplate();
+    const res = await request(app)
+      .get(`/api/templates/${created._id}`)
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body._id).toBe(created._id);
+    expect(res.body.name).toBe('Monthly Rent');
+  });
+
+  it('returns 404 for non-existent template', async () => {
+    const fakeId = new mongoose.Types.ObjectId();
+    const res = await request(app)
+      .get(`/api/templates/${fakeId}`)
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('Template not found');
+  });
+
+  it('prevents access to other user templates', async () => {
+    const created = await createTemplate();
+    const res = await request(app)
+      .get(`/api/templates/${created._id}`)
+      .set('Authorization', `Bearer ${otherToken}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('requires authentication', async () => {
+    const created = await createTemplate();
+    const res = await request(app).get(`/api/templates/${created._id}`);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('PUT /api/templates/:id', () => {
+  it('updates template with valid data', async () => {
+    const created = await createTemplate();
+    const res = await request(app)
+      .put(`/api/templates/${created._id}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ...basePayload, name: 'Updated Rent', amount: 2000 });
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('Updated Rent');
+    expect(res.body.amount).toBe(2000);
+  });
+
+  it('updates frequency', async () => {
+    const created = await createTemplate();
+    const res = await request(app)
+      .put(`/api/templates/${created._id}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ...basePayload, frequency: 'biweekly' });
+    expect(res.status).toBe(200);
+    expect(res.body.frequency).toBe('biweekly');
+  });
+
+  it('returns 404 for non-existent template', async () => {
+    const fakeId = new mongoose.Types.ObjectId();
+    const res = await request(app)
+      .put(`/api/templates/${fakeId}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send(basePayload);
+    expect(res.status).toBe(404);
+  });
+
+  it('prevents other users from updating templates', async () => {
+    const created = await createTemplate();
+    const res = await request(app)
+      .put(`/api/templates/${created._id}`)
+      .set('Authorization', `Bearer ${otherToken}`)
+      .send(basePayload);
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects invalid frequency on update', async () => {
+    const created = await createTemplate();
+    const res = await request(app)
+      .put(`/api/templates/${created._id}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ...basePayload, frequency: 'invalid' });
+    expect(res.status).toBe(400);
+  });
+
+  it('requires authentication', async () => {
+    const created = await createTemplate();
+    const res = await request(app)
+      .put(`/api/templates/${created._id}`)
+      .send(basePayload);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('DELETE /api/templates/:id', () => {
+  it('deletes template', async () => {
+    const created = await createTemplate();
+    const res = await request(app)
+      .delete(`/api/templates/${created._id}`)
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Template deleted');
+
+    const getRes = await request(app)
+      .get(`/api/templates/${created._id}`)
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(getRes.status).toBe(404);
+  });
+
+  it('returns 404 for non-existent template', async () => {
+    const fakeId = new mongoose.Types.ObjectId();
+    const res = await request(app)
+      .delete(`/api/templates/${fakeId}`)
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('prevents other users from deleting templates', async () => {
+    const created = await createTemplate();
+    const res = await request(app)
+      .delete(`/api/templates/${created._id}`)
+      .set('Authorization', `Bearer ${otherToken}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('requires authentication', async () => {
+    const created = await createTemplate();
+    const res = await request(app).delete(`/api/templates/${created._id}`);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('POST /api/templates/apply/:id', () => {
+  it('creates expense from template', async () => {
+    const template = await createTemplate();
+    const res = await request(app)
+      .post(`/api/templates/apply/${template._id}`)
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(201);
+    expect(res.body.description).toBe(template.name);
+    expect(res.body.amount).toBe(template.amount);
+    expect(res.body.category).toBe(template.category);
+    expect(res.body.owner).toBe(TEST_USER_ID);
+  });
+
+  it('uses template name as expense description', async () => {
+    const template = await createTemplate({ name: 'Grocery Shopping' });
+    const res = await request(app)
+      .post(`/api/templates/apply/${template._id}`)
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(201);
+    expect(res.body.description).toBe('Grocery Shopping');
+  });
+
+  it('preserves category when applying template', async () => {
+    const template = await createTemplate({ category: 'Food' });
+    const res = await request(app)
+      .post(`/api/templates/apply/${template._id}`)
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(201);
+    expect(res.body.category).toBe('Food');
+  });
+
+  it('returns 404 for non-existent template', async () => {
+    const fakeId = new mongoose.Types.ObjectId();
+    const res = await request(app)
+      .post(`/api/templates/apply/${fakeId}`)
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('prevents applying other user templates', async () => {
+    const template = await createTemplate();
+    const res = await request(app)
+      .post(`/api/templates/apply/${template._id}`)
+      .set('Authorization', `Bearer ${otherToken}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('requires authentication', async () => {
+    const template = await createTemplate();
+    const res = await request(app).post(`/api/templates/apply/${template._id}`);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('POST /api/templates/apply-multiple', () => {
+  it('applies multiple templates at once', async () => {
+    const t1 = await createTemplate({ name: 'Rent', amount: 1500 });
+    const t2 = await createTemplate({ name: 'Internet', amount: 50 });
+    const t3 = await createTemplate({ name: 'Groceries', amount: 200 });
+
+    const res = await request(app)
+      .post('/api/templates/apply-multiple')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ templateIds: [t1._id, t2._id, t3._id] });
+
+    expect(res.status).toBe(201);
+    expect(res.body.created).toBe(3);
+    expect(res.body.expenses).toHaveLength(3);
+    expect(res.body.expenses[0].description).toBe('Rent');
+    expect(res.body.expenses[1].description).toBe('Internet');
+    expect(res.body.expenses[2].description).toBe('Groceries');
+  });
+
+  it('creates all expenses even if templates are in different order', async () => {
+    const t1 = await createTemplate({ name: 'Template 1', amount: 100 });
+    const t2 = await createTemplate({ name: 'Template 2', amount: 200 });
+
+    const res = await request(app)
+      .post('/api/templates/apply-multiple')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ templateIds: [t2._id, t1._id] });
+
+    expect(res.status).toBe(201);
+    expect(res.body.created).toBe(2);
+  });
+
+  it('returns 400 for empty templateIds', async () => {
+    const res = await request(app)
+      .post('/api/templates/apply-multiple')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ templateIds: [] });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for missing templateIds', async () => {
+    const res = await request(app)
+      .post('/api/templates/apply-multiple')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 if templateIds is not an array', async () => {
+    const res = await request(app)
+      .post('/api/templates/apply-multiple')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ templateIds: 'not-an-array' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 if some templates not found', async () => {
+    const t1 = await createTemplate({ name: 'Template 1' });
+    const fakeId = new mongoose.Types.ObjectId();
+
+    const res = await request(app)
+      .post('/api/templates/apply-multiple')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ templateIds: [t1._id, fakeId] });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('prevents applying other user templates in batch', async () => {
+    const t1 = await createTemplate({ name: 'Template 1' });
+
+    const res = await request(app)
+      .post('/api/templates/apply-multiple')
+      .set('Authorization', `Bearer ${otherToken}`)
+      .send({ templateIds: [t1._id] });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('requires authentication', async () => {
+    const t1 = await createTemplate();
+    const res = await request(app)
+      .post('/api/templates/apply-multiple')
+      .send({ templateIds: [t1._id] });
+    expect(res.status).toBe(401);
+  });
+});

--- a/__tests__/transactions.test.ts
+++ b/__tests__/transactions.test.ts
@@ -1,0 +1,112 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import app from '../src/app';
+
+let mongod: MongoMemoryServer;
+const TEST_USER_ID = 'user_test_123';
+const authToken = jwt.sign({ userId: TEST_USER_ID }, 'test-secret');
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+describe('POST /api/transactions/parse-text', () => {
+  it('returns 401 without auth token', async () => {
+    const res = await request(app)
+      .post('/api/transactions/parse-text')
+      .send({ text: 'coffee $5' });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 when text is missing', async () => {
+    const res = await request(app)
+      .post('/api/transactions/parse-text')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when text is empty', async () => {
+    const res = await request(app)
+      .post('/api/transactions/parse-text')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ text: '' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when text exceeds 500 chars', async () => {
+    const res = await request(app)
+      .post('/api/transactions/parse-text')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ text: 'a'.repeat(501) });
+    expect(res.status).toBe(400);
+  });
+
+  it('parses simple expense "coffee $4.50"', async () => {
+    const res = await request(app)
+      .post('/api/transactions/parse-text')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ text: 'coffee $4.50' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.amount).toBe(4.5);
+    expect(res.body.merchant).toMatch(/coffee/i);
+    expect(res.body.category).toBe('food');
+    expect(res.body.confidence).toBeGreaterThan(0);
+  });
+
+  it('parses expense with participants', async () => {
+    const res = await request(app)
+      .post('/api/transactions/parse-text')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ text: 'lunch with Casey $56 each' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.amount).toBe(56);
+    expect(res.body.participants).toEqual(['Casey']);
+    expect(res.body.notes).toMatch(/split/i);
+  });
+
+  it('parses Cantonese input', async () => {
+    const res = await request(app)
+      .post('/api/transactions/parse-text')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ text: '今日同Casey食咗麥當勞 $65', locale: 'zh-HK' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.amount).toBe(65);
+    expect(res.body.participants).toEqual(['Casey']);
+  });
+
+  it('accepts optional locale parameter', async () => {
+    const res = await request(app)
+      .post('/api/transactions/parse-text')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ text: 'coffee $5', locale: 'en-US' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.amount).toBe(5);
+  });
+
+  it('returns confidence and missing_fields', async () => {
+    const res = await request(app)
+      .post('/api/transactions/parse-text')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ text: 'something random without numbers' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.missing_fields).toContain('amount');
+    expect(typeof res.body.confidence).toBe('number');
+  });
+});

--- a/__tests__/users-password.test.ts
+++ b/__tests__/users-password.test.ts
@@ -1,0 +1,143 @@
+import request from 'supertest';
+import express from 'express';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import userRoutes from '../src/routes/users';
+import UserModel from '../src/models/User';
+
+let mongoServer: MongoMemoryServer;
+const JWT_SECRET = 'test-secret-key';
+let app: express.Application;
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  process.env.JWT_SECRET = JWT_SECRET;
+  await mongoose.connect(mongoServer.getUri());
+
+  app = express();
+  app.use(express.json());
+  app.use('/api/users', userRoutes);
+}, 30000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+afterEach(async () => {
+  await UserModel.deleteMany({});
+});
+
+const generateToken = (userId: string) => {
+  return jwt.sign({ userId }, JWT_SECRET);
+};
+
+describe('PATCH /api/users/password', () => {
+  it('changes password successfully with correct current password', async () => {
+    const user = await UserModel.create({ email: 'user@test.com', password: 'password123' });
+    const token = generateToken((user._id as mongoose.Types.ObjectId).toString());
+
+    const res = await request(app)
+      .patch('/api/users/password')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ currentPassword: 'password123', newPassword: 'newpass456' });
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Password updated');
+  });
+
+  it('allows login with new password after change', async () => {
+    const user = await UserModel.create({ email: 'user@test.com', password: 'password123' });
+    const token = generateToken((user._id as mongoose.Types.ObjectId).toString());
+
+    await request(app)
+      .patch('/api/users/password')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ currentPassword: 'password123', newPassword: 'newpass456' });
+
+    const updated = await UserModel.findById(user._id);
+    const matches = await updated!.comparePassword('newpass456');
+    expect(matches).toBe(true);
+  });
+
+  it('old password no longer works after change', async () => {
+    const user = await UserModel.create({ email: 'user@test.com', password: 'password123' });
+    const token = generateToken((user._id as mongoose.Types.ObjectId).toString());
+
+    await request(app)
+      .patch('/api/users/password')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ currentPassword: 'password123', newPassword: 'newpass456' });
+
+    const updated = await UserModel.findById(user._id);
+    const matches = await updated!.comparePassword('password123');
+    expect(matches).toBe(false);
+  });
+
+  it('rejects incorrect current password with 400', async () => {
+    const user = await UserModel.create({ email: 'user@test.com', password: 'password123' });
+    const token = generateToken((user._id as mongoose.Types.ObjectId).toString());
+
+    const res = await request(app)
+      .patch('/api/users/password')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ currentPassword: 'wrongpassword', newPassword: 'newpass456' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Current password is incorrect');
+  });
+
+  it('rejects new password shorter than 6 characters', async () => {
+    const user = await UserModel.create({ email: 'user@test.com', password: 'password123' });
+    const token = generateToken((user._id as mongoose.Types.ObjectId).toString());
+
+    const res = await request(app)
+      .patch('/api/users/password')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ currentPassword: 'password123', newPassword: 'short' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/6 characters/);
+  });
+
+  it('rejects missing currentPassword', async () => {
+    const user = await UserModel.create({ email: 'user@test.com', password: 'password123' });
+    const token = generateToken((user._id as mongoose.Types.ObjectId).toString());
+
+    const res = await request(app)
+      .patch('/api/users/password')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ newPassword: 'newpass456' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/currentPassword/);
+  });
+
+  it('rejects missing newPassword', async () => {
+    const user = await UserModel.create({ email: 'user@test.com', password: 'password123' });
+    const token = generateToken((user._id as mongoose.Types.ObjectId).toString());
+
+    const res = await request(app)
+      .patch('/api/users/password')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ currentPassword: 'password123' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for account with no password set (social login)', async () => {
+    const id = new mongoose.Types.ObjectId();
+    await UserModel.collection.insertOne({ _id: id, email: 'social@test.com', budgets: [] });
+    const token = generateToken(id.toString());
+
+    const res = await request(app)
+      .patch('/api/users/password')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ currentPassword: 'anything', newPassword: 'newpass456' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Password change not available for social login accounts');
+  });
+
+  it('rejects unauthenticated request with 401', async () => {
+    const res = await request(app)
+      .patch('/api/users/password')
+      .send({ currentPassword: 'password123', newPassword: 'newpass456' });
+    expect(res.status).toBe(401);
+  });
+});

--- a/__tests__/users.test.ts
+++ b/__tests__/users.test.ts
@@ -1,0 +1,134 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import app from '../src/app';
+import UserModel from '../src/models/User';
+
+let mongod: MongoMemoryServer;
+let authToken: string;
+let userId: string;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+beforeEach(async () => {
+  const user = await UserModel.create({ email: 'user@example.com', password: 'password123' });
+  userId = (user._id as mongoose.Types.ObjectId).toString();
+  authToken = jwt.sign({ userId }, 'test-secret');
+});
+
+afterEach(async () => {
+  for (const col of Object.values(mongoose.connection.collections)) {
+    await col.deleteMany({});
+  }
+});
+
+describe('GET /api/users/me', () => {
+  it('returns user profile without password', async () => {
+    const res = await request(app)
+      .get('/api/users/me')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.user.email).toBe('user@example.com');
+    expect(res.body.user.password).toBeUndefined();
+  });
+
+  it('includes themePreference with default value system', async () => {
+    const res = await request(app)
+      .get('/api/users/me')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.user.themePreference).toBe('system');
+  });
+
+  it('rejects unauthenticated request with 401', async () => {
+    const res = await request(app).get('/api/users/me');
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('PATCH /api/users/preferences', () => {
+  it('updates themePreference to light', async () => {
+    const res = await request(app)
+      .patch('/api/users/preferences')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ themePreference: 'light' });
+    expect(res.status).toBe(200);
+    expect(res.body.user.themePreference).toBe('light');
+  });
+
+  it('updates themePreference to dark', async () => {
+    const res = await request(app)
+      .patch('/api/users/preferences')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ themePreference: 'dark' });
+    expect(res.status).toBe(200);
+    expect(res.body.user.themePreference).toBe('dark');
+  });
+
+  it('updates themePreference to system', async () => {
+    const res = await request(app)
+      .patch('/api/users/preferences')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ themePreference: 'system' });
+    expect(res.status).toBe(200);
+    expect(res.body.user.themePreference).toBe('system');
+  });
+
+  it('persists themePreference — visible on GET /me after update', async () => {
+    await request(app)
+      .patch('/api/users/preferences')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ themePreference: 'dark' });
+
+    const res = await request(app)
+      .get('/api/users/me')
+      .set('Authorization', `Bearer ${authToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.user.themePreference).toBe('dark');
+  });
+
+  it('rejects invalid themePreference value with 400', async () => {
+    const res = await request(app)
+      .patch('/api/users/preferences')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ themePreference: 'purple' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/themePreference/);
+  });
+
+  it('rejects missing themePreference with 400', async () => {
+    const res = await request(app)
+      .patch('/api/users/preferences')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('does not return password in response', async () => {
+    const res = await request(app)
+      .patch('/api/users/preferences')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ themePreference: 'light' });
+    expect(res.status).toBe(200);
+    expect(res.body.user.password).toBeUndefined();
+  });
+
+  it('rejects unauthenticated request with 401', async () => {
+    const res = await request(app)
+      .patch('/api/users/preferences')
+      .send({ themePreference: 'light' });
+    expect(res.status).toBe(401);
+  });
+});

--- a/__tests__/weekly-digest.test.ts
+++ b/__tests__/weekly-digest.test.ts
@@ -1,0 +1,221 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import app from '../src/app';
+import ExpenseModel from '../src/models/Expense';
+import UserModel from '../src/models/User';
+import {
+  aggregateWeeklyData,
+  formatDigestMessage,
+  getWeekBoundaries,
+} from '../src/utils/weeklyDigest';
+
+let mongod: MongoMemoryServer;
+const TEST_USER_ID = new mongoose.Types.ObjectId().toString();
+const authToken = jwt.sign({ userId: TEST_USER_ID }, 'test-secret');
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+}, 30000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+afterEach(async () => {
+  for (const col of Object.values(mongoose.connection.collections)) {
+    await col.deleteMany({});
+  }
+});
+
+function thisWeekDate(dayOffset = 0): Date {
+  const now = new Date();
+  const day = now.getDay();
+  const d = new Date(now);
+  d.setDate(now.getDate() - day + dayOffset);
+  d.setHours(12, 0, 0, 0);
+  return d;
+}
+
+function lastWeekDate(dayOffset = 0): Date {
+  const d = thisWeekDate(dayOffset);
+  d.setDate(d.getDate() - 7);
+  return d;
+}
+
+describe('getWeekBoundaries', () => {
+  it('returns correct week boundaries', () => {
+    const wednesday = new Date('2026-03-25T12:00:00Z'); // Wednesday
+    const { thisWeekStart, lastWeekStart, lastWeekEnd } = getWeekBoundaries(wednesday);
+    expect(thisWeekStart.getDay()).toBe(0); // Sunday
+    expect(lastWeekStart.getDay()).toBe(0);
+    expect(lastWeekEnd.getTime()).toBeLessThan(thisWeekStart.getTime());
+  });
+});
+
+describe('aggregateWeeklyData', () => {
+  it('returns zeros for user with no expenses', async () => {
+    const data = await aggregateWeeklyData(TEST_USER_ID, new Date());
+    expect(data.totalSpent).toBe(0);
+    expect(data.transactionCount).toBe(0);
+    expect(data.changePercent).toBeNull();
+    expect(data.topCategories).toEqual([]);
+  });
+
+  it('aggregates this week expenses', async () => {
+    await ExpenseModel.create([
+      { owner: TEST_USER_ID, amount: 50, type: 'expense', category: 'Food', date: thisWeekDate(1) },
+      { owner: TEST_USER_ID, amount: 30, type: 'expense', category: 'Transport', date: thisWeekDate(2) },
+      { owner: TEST_USER_ID, amount: 100, type: 'income', category: 'Salary', date: thisWeekDate(1) },
+    ]);
+    const data = await aggregateWeeklyData(TEST_USER_ID, new Date());
+    expect(data.totalSpent).toBe(80);
+    expect(data.transactionCount).toBe(2);
+  });
+
+  it('calculates change percent vs last week', async () => {
+    await ExpenseModel.create([
+      { owner: TEST_USER_ID, amount: 100, type: 'expense', category: 'Food', date: thisWeekDate(1) },
+      { owner: TEST_USER_ID, amount: 50, type: 'expense', category: 'Food', date: lastWeekDate(1) },
+    ]);
+    const data = await aggregateWeeklyData(TEST_USER_ID, new Date());
+    expect(data.changePercent).toBe(100); // doubled
+  });
+
+  it('returns top 3 categories sorted by total', async () => {
+    await ExpenseModel.create([
+      { owner: TEST_USER_ID, amount: 100, type: 'expense', category: 'Rent', date: thisWeekDate(1) },
+      { owner: TEST_USER_ID, amount: 80, type: 'expense', category: 'Food', date: thisWeekDate(2) },
+      { owner: TEST_USER_ID, amount: 60, type: 'expense', category: 'Transport', date: thisWeekDate(3) },
+      { owner: TEST_USER_ID, amount: 40, type: 'expense', category: 'Entertainment', date: thisWeekDate(4) },
+    ]);
+    const data = await aggregateWeeklyData(TEST_USER_ID, new Date());
+    expect(data.topCategories).toHaveLength(3);
+    expect(data.topCategories[0].category).toBe('Rent');
+    expect(data.topCategories[1].category).toBe('Food');
+    expect(data.topCategories[2].category).toBe('Transport');
+  });
+
+  it('labels null category as Uncategorized', async () => {
+    await ExpenseModel.create([
+      { owner: TEST_USER_ID, amount: 50, type: 'expense', date: thisWeekDate(1) },
+    ]);
+    const data = await aggregateWeeklyData(TEST_USER_ID, new Date());
+    expect(data.topCategories[0].category).toBe('Uncategorized');
+  });
+});
+
+describe('formatDigestMessage', () => {
+  it('formats message with all data', () => {
+    const msg = formatDigestMessage({
+      totalSpent: 250,
+      lastWeekTotal: 200,
+      changePercent: 25,
+      transactionCount: 10,
+      topCategories: [
+        { category: 'Food', total: 100 },
+        { category: 'Transport', total: 80 },
+      ],
+    });
+    expect(msg).toContain('$250.00');
+    expect(msg).toContain('10');
+    expect(msg).toContain('25%');
+    expect(msg).toContain('Food');
+    expect(msg).toContain('Transport');
+  });
+
+  it('shows down arrow for decreased spending', () => {
+    const msg = formatDigestMessage({
+      totalSpent: 100,
+      lastWeekTotal: 200,
+      changePercent: -50,
+      transactionCount: 5,
+      topCategories: [],
+    });
+    expect(msg).toContain('↓');
+    expect(msg).toContain('50%');
+  });
+
+  it('shows No data when no previous week', () => {
+    const msg = formatDigestMessage({
+      totalSpent: 100,
+      lastWeekTotal: 0,
+      changePercent: null,
+      transactionCount: 5,
+      topCategories: [],
+    });
+    expect(msg).toContain('No data');
+  });
+});
+
+describe('POST /api/reports/weekly-digest', () => {
+  it('returns 401 without auth', async () => {
+    const res = await request(app).post('/api/reports/weekly-digest');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns digest data for authenticated user', async () => {
+    await UserModel.create({
+      _id: TEST_USER_ID,
+      email: 'test@example.com',
+      password: 'password123',
+    });
+    await ExpenseModel.create([
+      { owner: TEST_USER_ID, amount: 50, type: 'expense', category: 'Food', date: thisWeekDate(1) },
+    ]);
+
+    const res = await request(app)
+      .post('/api/reports/weekly-digest')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.digest).toBeDefined();
+    expect(res.body.digest.totalSpent).toBe(50);
+    expect(res.body.digest.transactionCount).toBe(1);
+    expect(res.body.message).toContain('$50.00');
+    expect(res.body.sent).toBe(false); // no telegramChatId
+  });
+
+  it('returns sent=false when user has no telegram configured', async () => {
+    await UserModel.create({
+      _id: TEST_USER_ID,
+      email: 'test2@example.com',
+      password: 'password123',
+    });
+
+    const res = await request(app)
+      .post('/api/reports/weekly-digest')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.sent).toBe(false);
+  });
+});
+
+describe('User model weekly digest fields', () => {
+  it('defaults weeklyDigestEnabled to false', async () => {
+    const user = await UserModel.create({
+      email: 'digest@example.com',
+      password: 'password123',
+    });
+    expect(user.weeklyDigestEnabled).toBe(false);
+    expect(user.telegramChatId).toBeUndefined();
+  });
+
+  it('stores telegramChatId and weeklyDigestEnabled', async () => {
+    const user = await UserModel.create({
+      email: 'digest2@example.com',
+      password: 'password123',
+      telegramChatId: '12345',
+      weeklyDigestEnabled: true,
+    });
+    expect(user.telegramChatId).toBe('12345');
+    expect(user.weeklyDigestEnabled).toBe(true);
+  });
+});

--- a/__tests__/weeklyDigestJob.test.ts
+++ b/__tests__/weeklyDigestJob.test.ts
@@ -1,0 +1,142 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import mongoose from 'mongoose';
+import { weeklyDigestJob, startWeeklyDigestScheduler } from '../src/jobs/weeklyDigest';
+import { sendTelegramMessageToChat } from '../src/utils/telegram';
+import UserModel from '../src/models/User';
+
+let mongoServer: MongoMemoryServer;
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  await mongoose.connect(mongoServer.getUri());
+}, 30000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+beforeEach(async () => {
+  await UserModel.deleteMany({});
+  delete process.env.TELEGRAM_BOT_TOKEN;
+});
+
+describe('weeklyDigestJob', () => {
+  it('completes with no eligible users', async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+    await weeklyDigestJob();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[WeeklyDigestJob] Sent 0 digests')
+    );
+    consoleSpy.mockRestore();
+  });
+});
+
+describe('sendTelegramMessageToChat', () => {
+  it('returns false when bot token is not set', async () => {
+    delete process.env.TELEGRAM_BOT_TOKEN;
+    const result = await sendTelegramMessageToChat('123', 'test');
+    expect(result).toBe(false);
+  });
+
+  it('returns false on fetch error', async () => {
+    process.env.TELEGRAM_BOT_TOKEN = 'fake-token';
+    const spy = jest.spyOn(global, 'fetch').mockRejectedValue(new Error('network error'));
+    const result = await sendTelegramMessageToChat('123', 'test');
+    expect(result).toBe(false);
+    spy.mockRestore();
+  });
+
+  it('returns false on non-ok response', async () => {
+    process.env.TELEGRAM_BOT_TOKEN = 'fake-token';
+    const spy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: false, status: 403, statusText: 'Forbidden' } as Response);
+    const result = await sendTelegramMessageToChat('123', 'test');
+    expect(result).toBe(false);
+    spy.mockRestore();
+  });
+
+  it('returns true on success', async () => {
+    process.env.TELEGRAM_BOT_TOKEN = 'fake-token';
+    const spy = jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
+    const result = await sendTelegramMessageToChat('123', 'test');
+    expect(result).toBe(true);
+    spy.mockRestore();
+  });
+});
+
+describe('weeklyDigestJob error handling', () => {
+  it('logs error when processWeeklyDigests fails', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+    const logSpy = jest.spyOn(console, 'log').mockImplementation();
+    // Job should handle errors gracefully (no users to process)
+    await weeklyDigestJob();
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+});
+
+describe('startWeeklyDigestScheduler', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns null when Telegram is not configured', () => {
+    delete process.env.TELEGRAM_BOT_TOKEN;
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+    const result = startWeeklyDigestScheduler();
+    expect(result).toBeNull();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '[WeeklyDigestScheduler] Telegram not configured, skipping'
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it('starts scheduler when Telegram is configured', () => {
+    process.env.TELEGRAM_BOT_TOKEN = 'fake-token';
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+    const intervalId = startWeeklyDigestScheduler();
+    expect(intervalId).not.toBeNull();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '[WeeklyDigestScheduler] Started (checks hourly, sends Sunday 18:00 HKT)'
+    );
+    if (intervalId) clearInterval(intervalId as unknown as number);
+    consoleSpy.mockRestore();
+  });
+
+  it('fires digest on Sunday 18:00 HKT', () => {
+    process.env.TELEGRAM_BOT_TOKEN = 'fake-token';
+    jest.useFakeTimers();
+    // Sunday 18:00 HKT = Sunday 10:00 UTC
+    jest.setSystemTime(new Date('2026-03-29T10:00:00Z'));
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+    const intervalId = startWeeklyDigestScheduler();
+    // Advance one hour to trigger the interval
+    jest.advanceTimersByTime(60 * 60 * 1000);
+    if (intervalId) clearInterval(intervalId as unknown as number);
+    consoleSpy.mockRestore();
+    errorSpy.mockRestore();
+    jest.useRealTimers();
+  });
+
+  it('does not fire on non-Sunday', () => {
+    process.env.TELEGRAM_BOT_TOKEN = 'fake-token';
+    jest.useFakeTimers();
+    // Monday 18:00 HKT = Monday 10:00 UTC
+    jest.setSystemTime(new Date('2026-03-30T10:00:00Z'));
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+    const intervalId = startWeeklyDigestScheduler();
+    jest.advanceTimersByTime(60 * 60 * 1000);
+    // Should only see the "Started" log, not a "Sent" log
+    const sentCalls = consoleSpy.mock.calls.filter(c =>
+      typeof c[0] === 'string' && c[0].includes('Sent')
+    );
+    expect(sentCalls.length).toBe(0);
+    if (intervalId) clearInterval(intervalId as unknown as number);
+    consoleSpy.mockRestore();
+    jest.useRealTimers();
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,55 @@
+services:
+  mongo:
+    image: mongo:7
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo-data:/data/db
+    healthcheck:
+      test: mongosh --eval "db.adminCommand('ping')" --quiet
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  backend:
+    build:
+      context: .
+      target: dev
+    ports:
+      - "${PORT:-3001}:3001"
+    volumes:
+      - ./src:/app/src
+      - ./tsconfig.json:/app/tsconfig.json
+    environment:
+      - PORT=3001
+      - MONGODB_URI=mongodb://mongo:27017/money-flow
+      - JWT_SECRET=${JWT_SECRET:-local-dev-secret-change-me}
+      - FRONTEND_URL=${FRONTEND_URL:-http://localhost:3000}
+      - NODE_ENV=development
+    depends_on:
+      mongo:
+        condition: service_healthy
+    profiles:
+      - dev
+      - test
+
+  backend-prod:
+    build:
+      context: .
+      target: prod
+    ports:
+      - "${PORT:-3001}:3001"
+    environment:
+      - PORT=3001
+      - MONGODB_URI=mongodb://mongo:27017/money-flow
+      - JWT_SECRET=${JWT_SECRET:-local-dev-secret-change-me}
+      - FRONTEND_URL=${FRONTEND_URL:-http://localhost:3000}
+      - NODE_ENV=production
+    depends_on:
+      mongo:
+        condition: service_healthy
+    profiles:
+      - test
+
+volumes:
+  mongo-data:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,26 +1,29 @@
 {
   "name": "money-flow-backend",
-  "version": "1.0.0",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "money-flow-backend",
-      "version": "1.0.0",
+      "version": "1.0.6",
       "license": "MIT",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.80.0",
         "@sentry/node": "^10.45.0",
         "@types/bcryptjs": "^2.4.6",
         "@types/cors": "^2.8.14",
         "@types/express": "^4.17.20",
         "@types/jsonwebtoken": "^9.0.4",
         "@types/node": "^20.8.7",
+        "apple-signin-auth": "^2.0.0",
         "bcryptjs": "^2.4.3",
         "cors": "^2.8.5",
         "csv-parse": "^6.2.1",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "express-validator": "^7.0.1",
+        "google-auth-library": "^10.6.2",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^7.6.3",
         "multer": "^2.1.1",
@@ -38,6 +41,26 @@
         "nodemon": "^3.0.1",
         "supertest": "^7.2.2",
         "ts-jest": "^29.4.6"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.80.0.tgz",
+      "integrity": "sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -499,6 +522,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2739,7 +2771,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -2823,6 +2854,19 @@
       "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
       "license": "MIT"
     },
+    "node_modules/apple-signin-auth": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/apple-signin-auth/-/apple-signin-auth-2.0.0.tgz",
+      "integrity": "sha512-/O5gvAby7OU2K7baYQCzY0e0tCiHzhFkzt9L2v3bMd2I2w0ckCZ/4hdVUOrbolRGMppME+Zo8TAKPVru8aYnzg==",
+      "license": "MIT",
+      "dependencies": {
+        "jsonwebtoken": "^9.0.0",
+        "node-rsa": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -2851,6 +2895,15 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
     },
     "node_modules/async-mutex": {
       "version": "0.5.0",
@@ -3083,6 +3136,26 @@
         "bare-path": "^3.0.0"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.10",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.10.tgz",
@@ -3101,6 +3174,15 @@
       "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
       "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
       "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -3702,6 +3784,15 @@
       "integrity": "sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ==",
       "license": "MIT"
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -4135,6 +4226,12 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
@@ -4164,6 +4261,29 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/fill-range": {
@@ -4325,6 +4445,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/formidable": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
@@ -4395,6 +4527,34 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/gensync": {
@@ -4538,6 +4698,32 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -4660,7 +4846,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -5573,12 +5758,34 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -6260,6 +6467,44 @@
         "node": ">=12.22.0"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -6273,6 +6518,15 @@
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-rsa": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/node-rsa/-/node-rsa-1.1.1.tgz",
+      "integrity": "sha512-Jd4cvbJMryN21r5HgxQOpMEqv+ooke/korixNNK3mGqfGJmy0M77WDDzo/05969+OkMy3XW1UuZsSmW9KQm7Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "asn1": "^0.2.4"
+      }
     },
     "node_modules/nodemon": {
       "version": "3.1.14",
@@ -7662,6 +7916,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
     "node_modules/ts-jest": {
       "version": "29.4.6",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
@@ -8009,6 +8269,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "money-flow-backend",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "money-flow-backend",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.80.0",
@@ -27,6 +27,7 @@
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^7.6.3",
         "multer": "^2.1.1",
+        "pdfkit": "^0.18.0",
         "string-similarity": "^4.0.4",
         "ts-node": "^10.9.1",
         "typescript": "^5.2.2"
@@ -34,6 +35,7 @@
       "devDependencies": {
         "@types/jest": "^30.0.0",
         "@types/multer": "^2.1.0",
+        "@types/pdfkit": "^0.17.5",
         "@types/string-similarity": "^4.0.2",
         "@types/supertest": "^7.2.0",
         "jest": "^30.3.0",
@@ -1166,11 +1168,22 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -1929,6 +1942,15 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -2227,6 +2249,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.25.1"
+      }
+    },
+    "node_modules/@types/pdfkit": {
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/@types/pdfkit/-/pdfkit-0.17.5.tgz",
+      "integrity": "sha512-T3ZHnvF91HsEco5ClhBCOuBwobZfPcI2jaiSHybkkKYq4KhVIIurod94JVKvDIG0JXT6o3KiERC0X0//m8dyrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/pg": {
@@ -3270,6 +3302,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
@@ -3600,6 +3641,15 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -3884,6 +3934,12 @@
         "asap": "^2.0.0",
         "wrappy": "1"
       }
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
     },
     "node_modules/diff": {
       "version": "4.0.4",
@@ -4232,6 +4288,12 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
@@ -4409,6 +4471,23 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
       }
     },
     "node_modules/foreground-child": {
@@ -5724,6 +5803,12 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/js-md5": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
+      "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5860,6 +5945,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/lines-and-columns": {
@@ -6724,6 +6828,12 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -6812,6 +6922,20 @@
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
+    "node_modules/pdfkit": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.18.0.tgz",
+      "integrity": "sha512-NvUwSDZ0eYEzqAiWwVQkRkjYUkZ48kcsHuCO31ykqPPIVkwoSDjDGiwIgHHNtsiwls3z3P/zy4q00hl2chg2Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^1.0.0",
+        "@noble/hashes": "^1.6.0",
+        "fontkit": "^2.0.4",
+        "js-md5": "^0.8.3",
+        "linebreak": "^1.1.0",
+        "png-js": "^1.0.0"
+      }
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -6892,6 +7016,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/png-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
+      "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g=="
     },
     "node_modules/postgres-array": {
       "version": "2.0.0",
@@ -7137,6 +7266,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -7865,6 +8000,12 @@
         "b4a": "^1.6.4"
       }
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -8047,7 +8188,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-detect": {
@@ -8131,6 +8271,26 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
       "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==",
       "license": "MIT"
+    },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,8294 @@
+{
+  "name": "money-flow-backend",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "money-flow-backend",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/node": "^10.45.0",
+        "@types/bcryptjs": "^2.4.6",
+        "@types/cors": "^2.8.14",
+        "@types/express": "^4.17.20",
+        "@types/jsonwebtoken": "^9.0.4",
+        "@types/node": "^20.8.7",
+        "bcryptjs": "^2.4.3",
+        "cors": "^2.8.5",
+        "csv-parse": "^6.2.1",
+        "dotenv": "^16.3.1",
+        "express": "^4.18.2",
+        "express-validator": "^7.0.1",
+        "jsonwebtoken": "^9.0.2",
+        "mongoose": "^7.6.3",
+        "multer": "^2.1.1",
+        "ts-node": "^10.9.1",
+        "typescript": "^5.2.2"
+      },
+      "devDependencies": {
+        "@types/jest": "^30.0.0",
+        "@types/multer": "^2.1.0",
+        "@types/supertest": "^7.2.0",
+        "jest": "^30.3.0",
+        "mongodb-memory-server": "^11.0.1",
+        "nodemon": "^3.0.1",
+        "supertest": "^7.2.2",
+        "ts-jest": "^29.4.6"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+      "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
+      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@fastify/otel": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@fastify/otel/-/otel-0.17.1.tgz",
+      "integrity": "sha512-K4wyxfUZx2ux5o+b6BtTqouYFVILohLZmSbA2tKUueJstNcBnoGPVhllCaOvbQ3ZrXdUxUC/fyrSWSCqHhdOPg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "minimatch": "^10.2.4"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
+    "node_modules/@fastify/otel/node_modules/@opentelemetry/api-logs": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.212.0.tgz",
+      "integrity": "sha512-TEEVrLbNROUkYY51sBJGk7lO/OLjuepch8+hmpM6ffMJQ2z/KVCjdHuCFX6fJj8OkJP2zckPjrJzQtXU3IAsFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@fastify/otel/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.212.0.tgz",
+      "integrity": "sha512-IyXmpNnifNouMOe0I/gX7ENfv2ZCNdYTF0FpCsoBcpbIHzk81Ww9rQTYTnvghszCg7qGrIhNvWC8dhEifgX9Jg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.212.0",
+        "import-in-the-middle": "^2.0.6",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@fastify/otel/node_modules/import-in-the-middle": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
+      "integrity": "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.3.0.tgz",
+      "integrity": "sha512-PAwCvFJ4696XP2qZj+LAn1BWjZaJ6RjG6c7/lkMaUJnkyMS34ucuIsfqYvfskVNvUI27R/u4P1HMYFnlVXG/Ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "jest-message-util": "30.3.0",
+        "jest-util": "30.3.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.3.0.tgz",
+      "integrity": "sha512-U5mVPsBxLSO6xYbf+tgkymLx+iAhvZX43/xI1+ej2ZOPnPdkdO1CzDmFKh2mZBn2s4XZixszHeQnzp1gm/DIxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.3.0",
+        "@jest/pattern": "30.0.1",
+        "@jest/reporters": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "exit-x": "^0.2.2",
+        "graceful-fs": "^4.2.11",
+        "jest-changed-files": "30.3.0",
+        "jest-config": "30.3.0",
+        "jest-haste-map": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-regex-util": "30.0.1",
+        "jest-resolve": "30.3.0",
+        "jest-resolve-dependencies": "30.3.0",
+        "jest-runner": "30.3.0",
+        "jest-runtime": "30.3.0",
+        "jest-snapshot": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0",
+        "jest-watcher": "30.3.0",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz",
+      "integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
+      "integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-mock": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.3.0.tgz",
+      "integrity": "sha512-76Nlh4xJxk2D/9URCn3wFi98d2hb19uWE1idLsTt2ywhvdOldbw3S570hBgn25P4ICUZ/cBjybrBex2g17IDbg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "30.3.0",
+        "jest-snapshot": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.3.0.tgz",
+      "integrity": "sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
+      "integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@sinonjs/fake-timers": "^15.0.0",
+        "@types/node": "*",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.3.0.tgz",
+      "integrity": "sha512-+owLCBBdfpgL3HU+BD5etr1SvbXpSitJK0is1kiYjJxAAJggYMRQz5hSdd5pq1sSggfxPbw2ld71pt4x5wwViA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/expect": "30.3.0",
+        "@jest/types": "30.3.0",
+        "jest-mock": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+      "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.3.0.tgz",
+      "integrity": "sha512-a09z89S+PkQnL055bVj8+pe2Caed2PBOaczHcXCykW5ngxX9EWx/1uAwncxc/HiU0oZqfwseMjyhxgRjS49qPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "collect-v8-coverage": "^1.0.2",
+        "exit-x": "^0.2.2",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^5.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-worker": "30.3.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.2",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/snapshot-utils": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.3.0.tgz",
+      "integrity": "sha512-ORbRN9sf5PP82v3FXNSwmO1OTDR2vzR2YTaR+E3VkSBZ8zadQE6IqYdYEeFH1NIkeB2HIGdF02dapb6K0Mj05g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "natural-compare": "^1.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-30.0.1.tgz",
+      "integrity": "sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "callsites": "^3.1.0",
+        "graceful-fs": "^4.2.11"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.3.0.tgz",
+      "integrity": "sha512-e/52nJGuD74AKTSe0P4y5wFRlaXP0qmrS17rqOMHeSwm278VyNyXE3gFO/4DTGF9w+65ra3lo3VKj0LBrzmgdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "collect-v8-coverage": "^1.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.3.0.tgz",
+      "integrity": "sha512-dgbWy9b8QDlQeRZcv7LNF+/jFiiYHTKho1xirauZ7kVwY7avjFF6uTT0RqlgudB5OuIPagFdVtfFMosjVbk1eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "30.3.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.3.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz",
+      "integrity": "sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@jest/types": "30.3.0",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "babel-plugin-istanbul": "^7.0.1",
+        "chalk": "^4.1.2",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.3.0",
+        "jest-regex-util": "30.0.1",
+        "jest-util": "30.3.0",
+        "pirates": "^4.0.7",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^5.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.6.tgz",
+      "integrity": "sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.213.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.213.0.tgz",
+      "integrity": "sha512-zRM5/Qj6G84Ej3F1yt33xBVY/3tnMxtL1fiDIxYbDWYaZ/eudVw3/PBiZ8G7JwUxXxjW8gU4g6LnOyfGKYHYgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.0.tgz",
+      "integrity": "sha512-L8UyDwqpTcbkIK5cgwDRDYDoEhQoj8wp8BwsO19w3LB1Z41yEQm2VJyNfAi9DrLP/YTqXqWpKHyZfR9/tFYo1Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.0.tgz",
+      "integrity": "sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.213.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.213.0.tgz",
+      "integrity": "sha512-3i9NdkET/KvQomeh7UaR/F4r9P25Rx6ooALlWXPIjypcEOUxksCmVu0zA70NBJWlrMW1rPr/LRidFAflLI+s/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.213.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-amqplib": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.60.0.tgz",
+      "integrity": "sha512-q/B2IvoVXRm1M00MvhnzpMN6rKYOszPXVsALi6u0ss4AYHe+TidZEtLW9N1ZhrobI1dSriHnBqqtAOZVAv07sg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-connect": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.56.0.tgz",
+      "integrity": "sha512-PKp+sSZ7AfzMvGgO3VCyo1inwNu+q7A1k9X88WK4PQ+S6Hp7eFk8pie+sWHDTaARovmqq5V2osav3lQej2B0nw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/connect": "3.4.38"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-connect/node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-connect/node_modules/@types/node": {
+      "version": "20.8.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.6.tgz",
+      "integrity": "sha512-eWO4K2Ji70QzKUqRy6oyJWUeB7+g2cRagT3T/nxYibYcT4y2BDL8lqolRXjTHmkZCdJfIPaY73KbJAZmcryxTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.25.1"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-dataloader": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.30.0.tgz",
+      "integrity": "sha512-MXHP2Q38cd2OhzEBKAIXUi9uBlPEYzF6BNJbyjUXBQ6kLaf93kRC41vNMIz0Nl5mnuwK7fDvKT+/lpx7BXRwdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.213.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-express": {
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.61.0.tgz",
+      "integrity": "sha512-Xdmqo9RZuZlL29Flg8QdwrrX7eW1CZ7wFQPKHyXljNymgKhN1MCsYuqQ/7uxavhSKwAl7WxkTzKhnqpUApLMvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-fs": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.32.0.tgz",
+      "integrity": "sha512-koR6apx0g0wX6RRiPpjA4AFQUQUbXrK16kq4/SZjVp7u5cffJhNkY4TnITxcGA4acGSPYAfx3NHRIv4Khn1axQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.213.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-generic-pool": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.56.0.tgz",
+      "integrity": "sha512-fg+Jffs6fqrf0uQS0hom7qBFKsbtpBiBl8+Vkc63Gx8xh6pVh+FhagmiO6oM0m3vyb683t1lP7yGYq22SiDnqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.213.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-graphql": {
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.61.0.tgz",
+      "integrity": "sha512-pUiVASv6nh2XrerTvlbVHh7vKFzscpgwiQ/xvnZuAIzQ5lRjWVdRPUuXbvZJ/Yq79QsE81TZdJ7z9YsXiss1ew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.213.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-hapi": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.59.0.tgz",
+      "integrity": "sha512-33wa4mEr+9+ztwdgLor1SeBu4Opz4IsmpcLETXAd3VmBrOjez8uQtrsOhPCa5Vhbm5gzDlMYTgFRLQzf8/YHFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http": {
+      "version": "0.213.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.213.0.tgz",
+      "integrity": "sha512-B978Xsm5XEPGhm1P07grDoaOFLHapJPkOG9h016cJsyWWxmiLnPu2M/4Nrm7UCkHSiLnkXgC+zVGUAIahy8EEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.0",
+        "@opentelemetry/instrumentation": "0.213.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0",
+        "forwarded-parse": "2.1.2"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-ioredis": {
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.61.0.tgz",
+      "integrity": "sha512-hsHDadUtAFbws1YSDc1XW0svGFKiUbqv2td1Cby+UAiwvojm1NyBo/taifH0t8CuFZ0x/2SDm0iuTwrM5pnVOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.213.0",
+        "@opentelemetry/redis-common": "^0.38.2",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-kafkajs": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.22.0.tgz",
+      "integrity": "sha512-wJU4IBQMUikdJAcTChLFqK5lo+flo7pahqd8DSLv7uMxsdOdAHj6RzKYAm8pPfUS6ItKYutYyuicwKaFwQKsoA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.213.0",
+        "@opentelemetry/semantic-conventions": "^1.30.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-knex": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.57.0.tgz",
+      "integrity": "sha512-vMCSh8kolEm5rRsc+FZeTZymWmIJwc40hjIKnXH4O0Dv/gAkJJIRXCsPX5cPbe0c0j/34+PsENd0HqKruwhVYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.213.0",
+        "@opentelemetry/semantic-conventions": "^1.33.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-koa": {
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.61.0.tgz",
+      "integrity": "sha512-lvrfWe9ShK/D2X4brmx8ZqqeWPfRl8xekU0FCn7C1dHm5k6+rTOOi36+4fnaHAP8lig9Ux6XQ1D4RNIpPCt1WQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
+        "@opentelemetry/semantic-conventions": "^1.36.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-lru-memoizer": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.57.0.tgz",
+      "integrity": "sha512-cEqpUocSKJfwDtLYTTJehRLWzkZ2eoePCxfVIgGkGkb83fMB71O+y4MvRHJPbeV2bdoWdOVrl8uO0+EynWhTEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.213.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongodb": {
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.66.0.tgz",
+      "integrity": "sha512-d7m9QnAY+4TCWI4q1QRkfrc6fo/92VwssaB1DzQfXNRvu51b78P+HJlWP7Qg6N6nkwdb9faMZNBCZJfftmszkw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.213.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongoose": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.59.0.tgz",
+      "integrity": "sha512-6/jWU+c1NgznkVLDU/2y0bXV2nJo3o9FWZ9mZ9nN6T/JBNRoMnVXZl2FdBmgH+a5MwaWLs5kmRJTP5oUVGIkPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.59.0.tgz",
+      "integrity": "sha512-r+V/Fh0sm7Ga8/zk/TI5H5FQRAjwr0RrpfPf8kNIehlsKf12XnvIaZi8ViZkpX0gyPEpLXqzqWD6QHlgObgzZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.213.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0",
+        "@types/mysql": "2.15.27"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql2": {
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.59.0.tgz",
+      "integrity": "sha512-n9/xrVCRBfG9egVbffnlU1uhr+HX0vF4GgtAB/Bvm48wpFgRidqD8msBMiym1kRYzmpWvJqTxNT47u1MkgBEdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.213.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0",
+        "@opentelemetry/sql-common": "^0.41.2"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-pg": {
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.65.0.tgz",
+      "integrity": "sha512-W0zpHEIEuyZ8zvb3njaX9AAbHgPYOsSWVOoWmv1sjVRSF6ZpBqtlxBWbU+6hhq1TFWBeWJOXZ8nZS/PUFpLJYQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
+        "@opentelemetry/semantic-conventions": "^1.34.0",
+        "@opentelemetry/sql-common": "^0.41.2",
+        "@types/pg": "8.15.6",
+        "@types/pg-pool": "2.0.7"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-redis": {
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.61.0.tgz",
+      "integrity": "sha512-JnPexA034/0UJRsvH96B0erQoNOqKJZjE2ZRSw9hiTSC23LzE0nJE/u6D+xqOhgUhRnhhcPHq4MdYtmUdYTF+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.213.0",
+        "@opentelemetry/redis-common": "^0.38.2",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-tedious": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.32.0.tgz",
+      "integrity": "sha512-BQS6gG8RJ1foEqfEZ+wxoqlwfCAzb1ZVG0ad8Gfe4x8T658HJCLGLd4E4NaoQd8EvPfLqOXgzGaE/2U4ytDSWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.213.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0",
+        "@types/tedious": "^4.0.14"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-undici": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.23.0.tgz",
+      "integrity": "sha512-LL0VySzKVR2cJSFVZaTYpZl1XTpBGnfzoQPe2W7McS2267ldsaEIqtQY6VXs2KCXN0poFjze5110PIpxHDaDGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
+        "@opentelemetry/semantic-conventions": "^1.24.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.7.0"
+      }
+    },
+    "node_modules/@opentelemetry/redis-common": {
+      "version": "0.38.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.38.2.tgz",
+      "integrity": "sha512-1BCcU93iwSRZvDAgwUxC/DV4T/406SkMfxGqu5ojc3AvNI+I9GhV7v0J1HljsczuuhcnFLYqD5VmwVXfCGHzxA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.0.tgz",
+      "integrity": "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.0.tgz",
+      "integrity": "sha512-g/OZVkqlxllgFM7qMKqbPV9c1DUPhQ7d4n3pgZFcrnrNft9eJXZM2TNHTPYREJBrtNdRytYyvwjgL5geDKl3EQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.0",
+        "@opentelemetry/resources": "2.6.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sql-common": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.41.2.tgz",
+      "integrity": "sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
+      "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@prisma/instrumentation": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-7.4.2.tgz",
+      "integrity": "sha512-r9JfchJF1Ae6yAxcaLu/V1TGqBhAuSDe3mRNOssBfx1rMzfZ4fdNvrgUBwyb/TNTGXFxlH9AZix5P257x07nrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.207.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.8"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/api-logs": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.207.0.tgz",
+      "integrity": "sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.207.0.tgz",
+      "integrity": "sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.207.0",
+        "import-in-the-middle": "^2.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/import-in-the-middle": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
+      "integrity": "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.45.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.45.0.tgz",
+      "integrity": "sha512-s69UXxvefeQxuZ5nY7/THtTrIEvJxNVCp3ns4kwoCw1qMpgpvn/296WCKVmM7MiwnaAdzEKnAvLAwaxZc2nM7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "10.45.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.45.0.tgz",
+      "integrity": "sha512-Kpiq9lRGnJc1ex8SwxOBl+FLQNl4Y137BydVooP7AFiAYZ6ftwHsIEF1bcYXaipHMT1YHS2bdhC2UQaaB2jkuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/otel": "0.17.1",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/context-async-hooks": "^2.6.0",
+        "@opentelemetry/core": "^2.6.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
+        "@opentelemetry/instrumentation-amqplib": "0.60.0",
+        "@opentelemetry/instrumentation-connect": "0.56.0",
+        "@opentelemetry/instrumentation-dataloader": "0.30.0",
+        "@opentelemetry/instrumentation-express": "0.61.0",
+        "@opentelemetry/instrumentation-fs": "0.32.0",
+        "@opentelemetry/instrumentation-generic-pool": "0.56.0",
+        "@opentelemetry/instrumentation-graphql": "0.61.0",
+        "@opentelemetry/instrumentation-hapi": "0.59.0",
+        "@opentelemetry/instrumentation-http": "0.213.0",
+        "@opentelemetry/instrumentation-ioredis": "0.61.0",
+        "@opentelemetry/instrumentation-kafkajs": "0.22.0",
+        "@opentelemetry/instrumentation-knex": "0.57.0",
+        "@opentelemetry/instrumentation-koa": "0.61.0",
+        "@opentelemetry/instrumentation-lru-memoizer": "0.57.0",
+        "@opentelemetry/instrumentation-mongodb": "0.66.0",
+        "@opentelemetry/instrumentation-mongoose": "0.59.0",
+        "@opentelemetry/instrumentation-mysql": "0.59.0",
+        "@opentelemetry/instrumentation-mysql2": "0.59.0",
+        "@opentelemetry/instrumentation-pg": "0.65.0",
+        "@opentelemetry/instrumentation-redis": "0.61.0",
+        "@opentelemetry/instrumentation-tedious": "0.32.0",
+        "@opentelemetry/instrumentation-undici": "0.23.0",
+        "@opentelemetry/resources": "^2.6.0",
+        "@opentelemetry/sdk-trace-base": "^2.6.0",
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "@prisma/instrumentation": "7.4.2",
+        "@sentry/core": "10.45.0",
+        "@sentry/node-core": "10.45.0",
+        "@sentry/opentelemetry": "10.45.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node-core": {
+      "version": "10.45.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.45.0.tgz",
+      "integrity": "sha512-KQZEvLKM344+EqXiA9HIzWbW5hzq6/9nnFUQ8niaBPoOgR9AiJhrccfIscfgb8vjkriiEtzE03OW/4h1CTgZ3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.45.0",
+        "@sentry/opentelemetry": "10.45.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
+        "@opentelemetry/resources": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.39.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/context-async-hooks": {
+          "optional": true
+        },
+        "@opentelemetry/core": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation": {
+          "optional": true
+        },
+        "@opentelemetry/resources": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "@opentelemetry/semantic-conventions": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/opentelemetry": {
+      "version": "10.45.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.45.0.tgz",
+      "integrity": "sha512-PmuGO+p/gC3ZQ8ddOeJ5P9ApnTTm35i12Bpuyb13AckCbNSJFvG2ggZda35JQOmiFU0kKYiwkoFAa8Mvj9od3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.45.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.39.0"
+      }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.48",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
+      "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.1.1.tgz",
+      "integrity": "sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.3",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.3.tgz",
+      "integrity": "sha512-oyl4jvAfTGX9Bt6Or4H9ni1Z447/tQuxnZsytsCaExKlmJiU8sFgnIBRzJUpKwB5eWn9HuBYlUlVA74q/yN0eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/body-parser/node_modules/@types/node": {
+      "version": "20.8.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.6.tgz",
+      "integrity": "sha512-eWO4K2Ji70QzKUqRy6oyJWUeB7+g2cRagT3T/nxYibYcT4y2BDL8lqolRXjTHmkZCdJfIPaY73KbJAZmcryxTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.25.1"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.36",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.36.tgz",
+      "integrity": "sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect/node_modules/@types/node": {
+      "version": "20.8.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.6.tgz",
+      "integrity": "sha512-eWO4K2Ji70QzKUqRy6oyJWUeB7+g2cRagT3T/nxYibYcT4y2BDL8lqolRXjTHmkZCdJfIPaY73KbJAZmcryxTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.25.1"
+      }
+    },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors/node_modules/@types/node": {
+      "version": "20.8.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.6.tgz",
+      "integrity": "sha512-eWO4K2Ji70QzKUqRy6oyJWUeB7+g2cRagT3T/nxYibYcT4y2BDL8lqolRXjTHmkZCdJfIPaY73KbJAZmcryxTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.25.1"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.20.tgz",
+      "integrity": "sha512-rOaqlkgEvOW495xErXMsmyX3WKBInbhG5eqojXYi3cGUaLoRDlXa5d52fkfWZT963AZ3v2eZ4MbKE6WpDAGVsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.17.37",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.37.tgz",
+      "integrity": "sha512-ZohaCYTgGFcOP7u6aJOhY9uIZQgZ2vxC2yWoArY+FeDXlqeH66ZVBjgvg+RLVAS/DWNq4Ap9ZXu1+SUQiiWYMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core/node_modules/@types/node": {
+      "version": "20.8.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.6.tgz",
+      "integrity": "sha512-eWO4K2Ji70QzKUqRy6oyJWUeB7+g2cRagT3T/nxYibYcT4y2BDL8lqolRXjTHmkZCdJfIPaY73KbJAZmcryxTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.25.1"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.2.tgz",
+      "integrity": "sha512-lPG6KlZs88gef6aD85z3HNkztpj7w2R7HmR3gygjfXCQmsLloWNARFkMuzKiiY8FGdh1XDpgBdrSf4aKDiA7Kg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
+      }
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/jsonwebtoken/node_modules/@types/node": {
+      "version": "20.8.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.6.tgz",
+      "integrity": "sha512-eWO4K2Ji70QzKUqRy6oyJWUeB7+g2cRagT3T/nxYibYcT4y2BDL8lqolRXjTHmkZCdJfIPaY73KbJAZmcryxTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.25.1"
+      }
+    },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mime": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.2.tgz",
+      "integrity": "sha512-Wj+fqpTLtTbG7c0tH47dkahefpLKEbB+xAZuLq7b4/IDHPl/n6VoXcyUQ2bypFlbSwvCr0y+bD4euTTqTJsPxQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/multer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.1.0.tgz",
+      "integrity": "sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
+    "node_modules/@types/mysql": {
+      "version": "2.15.27",
+      "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.27.tgz",
+      "integrity": "sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/mysql/node_modules/@types/node": {
+      "version": "20.8.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.6.tgz",
+      "integrity": "sha512-eWO4K2Ji70QzKUqRy6oyJWUeB7+g2cRagT3T/nxYibYcT4y2BDL8lqolRXjTHmkZCdJfIPaY73KbJAZmcryxTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.25.1"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.8.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.7.tgz",
+      "integrity": "sha512-21TKHHh3eUHIi2MloeptJWALuCu5H7HQTdTrWIFReA8ad+aggoX+lRes3ex7/FtpC+sVUpFMQ+QTfYr74mruiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.25.1"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.15.6",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.6.tgz",
+      "integrity": "sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/pg-pool": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.7.tgz",
+      "integrity": "sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pg": "*"
+      }
+    },
+    "node_modules/@types/pg-pool/node_modules/@types/node": {
+      "version": "20.8.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.6.tgz",
+      "integrity": "sha512-eWO4K2Ji70QzKUqRy6oyJWUeB7+g2cRagT3T/nxYibYcT4y2BDL8lqolRXjTHmkZCdJfIPaY73KbJAZmcryxTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.25.1"
+      }
+    },
+    "node_modules/@types/pg-pool/node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/pg/node_modules/@types/node": {
+      "version": "20.8.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.6.tgz",
+      "integrity": "sha512-eWO4K2Ji70QzKUqRy6oyJWUeB7+g2cRagT3T/nxYibYcT4y2BDL8lqolRXjTHmkZCdJfIPaY73KbJAZmcryxTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.25.1"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.9.8",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.8.tgz",
+      "integrity": "sha512-u95svzDlTysU5xecFNTgfFG5RUWu1A9P0VzgpcIiGZA9iraHOdSzcxMxQ55DyeRaGCSxQi7LxXDI4rzq/MYfdg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.5.tgz",
+      "integrity": "sha512-xrO9OoVPqFuYyR/loIHjnbvvyRZREYKLjxV4+dY6v3FQR3stQ9ZxIGkaclF7YhI9hfjpuTbu14hZEy94qKLtOA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.2.tgz",
+      "integrity": "sha512-aAG6yRf6r0wQ29bkS+x97BIs64ZLxeE/ARwyS6wrldMm3C1MdKwCcnnEwMC1slI8wuxJOpiUH9MioC0A0i+GJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/send/node_modules/@types/mime": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.3.tgz",
+      "integrity": "sha512-Ys+/St+2VF4+xuY6+kDIXGxbNRO0mesVg0bbxEfB97Od1Vjpjx9KD1qxs64Gcb3CWPirk9Xe+PT4YiiHQ9T+eg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/send/node_modules/@types/node": {
+      "version": "20.8.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.6.tgz",
+      "integrity": "sha512-eWO4K2Ji70QzKUqRy6oyJWUeB7+g2cRagT3T/nxYibYcT4y2BDL8lqolRXjTHmkZCdJfIPaY73KbJAZmcryxTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.25.1"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.3.tgz",
+      "integrity": "sha512-yVRvFsEMrv7s0lGhzrggJjNOSmZCdgCjw9xWrPr/kNNLp6FaDfMC1KaYl3TSJ0c58bECwNBMoQrZJ8hA8E1eFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/mime": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/node": {
+      "version": "20.8.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.6.tgz",
+      "integrity": "sha512-eWO4K2Ji70QzKUqRy6oyJWUeB7+g2cRagT3T/nxYibYcT4y2BDL8lqolRXjTHmkZCdJfIPaY73KbJAZmcryxTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.25.1"
+      }
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-7.2.0.tgz",
+      "integrity": "sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
+      }
+    },
+    "node_modules/@types/tedious": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
+      "integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/tedious/node_modules/@types/node": {
+      "version": "20.8.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.6.tgz",
+      "integrity": "sha512-eWO4K2Ji70QzKUqRy6oyJWUeB7+g2cRagT3T/nxYibYcT4y2BDL8lqolRXjTHmkZCdJfIPaY73KbJAZmcryxTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.25.1"
+      }
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.1.tgz",
+      "integrity": "sha512-8hKOnOan+Uu+NgMaCouhg3cT9x5fFZ92Jwf+uDLXLu/MFRbXxlWwGeQY7KVHkeSft6RvY+tdxklUBuyY9eIEKg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/b4a": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/babel-jest": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz",
+      "integrity": "sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "30.3.0",
+        "@types/babel__core": "^7.20.5",
+        "babel-plugin-istanbul": "^7.0.1",
+        "babel-preset-jest": "30.3.0",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
+      "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "workspaces": [
+        "test/babel-8"
+      ],
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-instrument": "^6.0.2",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.3.0.tgz",
+      "integrity": "sha512-+TRkByhsws6sfPjVaitzadk1I0F5sPvOVUH5tyTSzhePpsGIVrdeunHSw/C36QeocS95OOk8lunc4rlu5Anwsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/babel__core": "^7.20.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.3.0.tgz",
+      "integrity": "sha512-6ZcUbWHC+dMz2vfzdNwi87Z1gQsLNK2uLuK1Q89R11xdvejcivlYYwDlEv0FHX3VwEXpbBQ9uufB/MUNpZGfhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "30.3.0",
+        "babel-preset-current-node-syntax": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.6.tgz",
+      "integrity": "sha512-1QovqDrR80Pmt5HPAsMsXTCFcDYr+NSUKW6nd6WO5v0JBmnItc/irNRzm2KOQ5oZ69P37y+AMujNyNtG+1Rggw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.0.tgz",
+      "integrity": "sha512-Dc9/SlwfxkXIGYhvMQNUtKaXCaGkZYGcd1vuNUUADVqzu4/vQfvnMkYYOUnt2VwQ2AqKr/8qAVFRtwETljgeFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.10.0.tgz",
+      "integrity": "sha512-DOPZF/DDcDruKDA43cOw6e9Quq5daua7ygcAwJE/pKJsRWhgSSemi7qVNGE5kyDIxIeN1533G/zfbvWX7Wcb9w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.0.tgz",
+      "integrity": "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.10",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.10.tgz",
+      "integrity": "sha512-sUoJ3IMxx4AyRqO4MLeHlnGDkyXRoUG0/AI9fjK+vS72ekpV0yWVY7O0BVjmBcRtkNcsAO2QDZ4tdKKGoI6YaQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+      "license": "MIT"
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/bson": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.1.tgz",
+      "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.20.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001781",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz",
+      "integrity": "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/csv-parse": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-6.2.1.tgz",
+      "integrity": "sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.322",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.322.tgz",
+      "integrity": "sha512-vFU34OcrvMcH66T+dYC3G4nURmgfDVewMIu6Q2urXpumAPSMmzvcn04KVVV8Opikq8Vs5nUbO/8laNhNRqSzYw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/exit-x": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
+      "integrity": "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz",
+      "integrity": "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "30.3.0",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-validator": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.3.1.tgz",
+      "integrity": "sha512-IGenaSf+DnWc69lKuqlRE9/i/2t5/16VpH5bXoqdxWz1aCpRvEdrBuu1y95i/iL5QP8ZYVATiwLFhwk3EDl5vg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "validator": "~13.15.23"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bser": "2.1.1"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/forwarded-parse": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
+      "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
+      "license": "MIT"
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.0.tgz",
+      "integrity": "sha512-OnGy+eYT7wVejH2XWgLRgbmzujhhVIATQH0ztIeRilwHBjTeG3pD+XnH3PKX0r9gJ0BuJmJ68q/oh9qgXnNDQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jest": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-30.3.0.tgz",
+      "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "30.3.0",
+        "@jest/types": "30.3.0",
+        "import-local": "^3.2.0",
+        "jest-cli": "30.3.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.3.0.tgz",
+      "integrity": "sha512-B/7Cny6cV5At6M25EWDgf9S617lHivamL8vl6KEpJqkStauzcG4e+WPfDgMMF+H4FVH4A2PLRyvgDJan4441QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.1.1",
+        "jest-util": "30.3.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.3.0.tgz",
+      "integrity": "sha512-PyXq5szeSfR/4f1lYqCmmQjh0vqDkURUYi9N6whnHjlRz4IUQfMcXkGLeEoiJtxtyPqgUaUUfyQlApXWBSN1RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/expect": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "co": "^4.6.0",
+        "dedent": "^1.6.0",
+        "is-generator-fn": "^2.1.0",
+        "jest-each": "30.3.0",
+        "jest-matcher-utils": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-runtime": "30.3.0",
+        "jest-snapshot": "30.3.0",
+        "jest-util": "30.3.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "30.3.0",
+        "pure-rand": "^7.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.3.0.tgz",
+      "integrity": "sha512-l6Tqx+j1fDXJEW5bqYykDQQ7mQg+9mhWXtnj+tQZrTWYHyHoi6Be8HPumDSA+UiX2/2buEgjA58iJzdj146uCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/types": "30.3.0",
+        "chalk": "^4.1.2",
+        "exit-x": "^0.2.2",
+        "import-local": "^3.2.0",
+        "jest-config": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.3.0.tgz",
+      "integrity": "sha512-WPMAkMAtNDY9P/oKObtsRG/6KTrhtgPJoBTmk20uDn4Uy6/3EJnnaZJre/FMT1KVRx8cve1r7/FlMIOfRVWL4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@jest/get-type": "30.1.0",
+        "@jest/pattern": "30.0.1",
+        "@jest/test-sequencer": "30.3.0",
+        "@jest/types": "30.3.0",
+        "babel-jest": "30.3.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "deepmerge": "^4.3.1",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "jest-circus": "30.3.0",
+        "jest-docblock": "30.2.0",
+        "jest-environment-node": "30.3.0",
+        "jest-regex-util": "30.0.1",
+        "jest-resolve": "30.3.0",
+        "jest-runner": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0",
+        "parse-json": "^5.2.0",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "esbuild-register": ">=3.4.0",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "esbuild-register": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
+      "integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.3.0",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.2.0.tgz",
+      "integrity": "sha512-tR/FFgZKS1CXluOQzZvNH3+0z9jXr3ldGSD8bhyuxvlVUwbeLOGynkunvlTMxchC5urrKndYiwCFC0DLVjpOCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.3.0.tgz",
+      "integrity": "sha512-V8eMndg/aZ+3LnCJgSm13IxS5XSBM22QSZc9BtPK8Dek6pm+hfUNfwBdvsB3d342bo1q7wnSkC38zjX259qZNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "@jest/types": "30.3.0",
+        "chalk": "^4.1.2",
+        "jest-util": "30.3.0",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.3.0.tgz",
+      "integrity": "sha512-4i6HItw/JSiJVsC5q0hnKIe/hbYfZLVG9YJ/0pU9Hz2n/9qZe3Rhn5s5CUZA5ORZlcdT/vmAXRMyONXJwPrmYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/fake-timers": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.3.0.tgz",
+      "integrity": "sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "anymatch": "^3.1.3",
+        "fb-watchman": "^2.0.2",
+        "graceful-fs": "^4.2.11",
+        "jest-regex-util": "30.0.1",
+        "jest-util": "30.3.0",
+        "jest-worker": "30.3.0",
+        "picomatch": "^4.0.3",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.3"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.3.0.tgz",
+      "integrity": "sha512-cuKmUUGIjfXZAiGJ7TbEMx0bcqNdPPI6P1V+7aF+m/FUJqFDxkFR4JqkTu8ZOiU5AaX/x0hZ20KaaIPXQzbMGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz",
+      "integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.3.0",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+      "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.3.0",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+      "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.3.0.tgz",
+      "integrity": "sha512-NRtTAHQlpd15F9rUR36jqwelbrDV/dY4vzNte3S2kxCKUJRYNd5/6nTSbYiak1VX5g8IoFF23Uj5TURkUW8O5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.3.0",
+        "jest-pnp-resolver": "^1.2.3",
+        "jest-util": "30.3.0",
+        "jest-validate": "30.3.0",
+        "slash": "^3.0.0",
+        "unrs-resolver": "^1.7.11"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.3.0.tgz",
+      "integrity": "sha512-9ev8s3YN6Hsyz9LV75XUwkCVFlwPbaFn6Wp75qnI0wzAINYWY8Fb3+6y59Rwd3QaS3kKXffHXsZMziMavfz/nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "30.0.1",
+        "jest-snapshot": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.3.0.tgz",
+      "integrity": "sha512-gDv6C9LGKWDPLia9TSzZwf4h3kMQCqyTpq+95PODnTRDO0g9os48XIYYkS6D236vjpBir2fF63YmJFtqkS5Duw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "30.3.0",
+        "@jest/environment": "30.3.0",
+        "@jest/test-result": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "emittery": "^0.13.1",
+        "exit-x": "^0.2.2",
+        "graceful-fs": "^4.2.11",
+        "jest-docblock": "30.2.0",
+        "jest-environment-node": "30.3.0",
+        "jest-haste-map": "30.3.0",
+        "jest-leak-detector": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-resolve": "30.3.0",
+        "jest-runtime": "30.3.0",
+        "jest-util": "30.3.0",
+        "jest-watcher": "30.3.0",
+        "jest-worker": "30.3.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.3.0.tgz",
+      "integrity": "sha512-CgC+hIBJbuh78HEffkhNKcbXAytQViplcl8xupqeIWyKQF50kCQA8J7GeJCkjisC6hpnC9Muf8jV5RdtdFbGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/fake-timers": "30.3.0",
+        "@jest/globals": "30.3.0",
+        "@jest/source-map": "30.0.1",
+        "@jest/test-result": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "cjs-module-lexer": "^2.1.0",
+        "collect-v8-coverage": "^1.0.2",
+        "glob": "^10.5.0",
+        "graceful-fs": "^4.2.11",
+        "jest-haste-map": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-regex-util": "30.0.1",
+        "jest-resolve": "30.3.0",
+        "jest-snapshot": "30.3.0",
+        "jest-util": "30.3.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.3.0.tgz",
+      "integrity": "sha512-f14c7atpb4O2DeNhwcvS810Y63wEn8O1HqK/luJ4F6M4NjvxmAKQwBUWjbExUtMxWJQ0wVgmCKymeJK6NZMnfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.27.4",
+        "@babel/generator": "^7.27.5",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.27.1",
+        "@babel/types": "^7.27.3",
+        "@jest/expect-utils": "30.3.0",
+        "@jest/get-type": "30.1.0",
+        "@jest/snapshot-utils": "30.3.0",
+        "@jest/transform": "30.3.0",
+        "@jest/types": "30.3.0",
+        "babel-preset-current-node-syntax": "^1.2.0",
+        "chalk": "^4.1.2",
+        "expect": "30.3.0",
+        "graceful-fs": "^4.2.11",
+        "jest-diff": "30.3.0",
+        "jest-matcher-utils": "30.3.0",
+        "jest-message-util": "30.3.0",
+        "jest-util": "30.3.0",
+        "pretty-format": "30.3.0",
+        "semver": "^7.7.2",
+        "synckit": "^0.11.8"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.3.0.tgz",
+      "integrity": "sha512-I/xzC8h5G+SHCb2P2gWkJYrNiTbeL47KvKeW5EzplkyxzBRBw1ssSHlI/jXec0ukH2q7x2zAWQm7015iusg62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "@jest/types": "30.3.0",
+        "camelcase": "^6.3.0",
+        "chalk": "^4.1.2",
+        "leven": "^3.1.0",
+        "pretty-format": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.3.0.tgz",
+      "integrity": "sha512-PJ1d9ThtTR8aMiBWUdcownq9mDdLXsQzJayTk4kmaBRHKvwNQn+ANveuhEBUyNI2hR1TVhvQ8D5kHubbzBHR/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "emittery": "^0.13.1",
+        "jest-util": "30.3.0",
+        "string-length": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.3.0.tgz",
+      "integrity": "sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@ungap/structured-clone": "^1.3.0",
+        "jest-util": "30.3.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.1.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/kareem": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
+      "integrity": "sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "license": "ISC"
+    },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
+    "node_modules/mongodb": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz",
+      "integrity": "sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bson": "^5.5.0",
+        "mongodb-connection-string-url": "^2.6.0",
+        "socks": "^2.7.1"
+      },
+      "engines": {
+        "node": ">=14.20.1"
+      },
+      "optionalDependencies": {
+        "@mongodb-js/saslprep": "^1.1.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.0.0",
+        "kerberos": "^1.0.0 || ^2.0.0",
+        "mongodb-client-encryption": ">=2.3.0 <3",
+        "snappy": "^7.2.2"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
+      }
+    },
+    "node_modules/mongodb-memory-server": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-11.0.1.tgz",
+      "integrity": "sha512-nUlKovSJZBh7q5hPsewFRam9H66D08Ne18nyknkNalfXMPtK1Og3kOcuqQhcX88x/pghSZPIJHrLbxNFW3OWiw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "mongodb-memory-server-core": "11.0.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/mongodb-memory-server-core": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-11.0.1.tgz",
+      "integrity": "sha512-IcIb2S9Xf7Lmz43Z1ZujMqNg7PU5Q7yn+4wOnu7l6pfeGPkEmlqzV1hIbroVx8s4vXhPB1oMGC1u8clW7aj3Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-mutex": "^0.5.0",
+        "camelcase": "^6.3.0",
+        "debug": "^4.4.3",
+        "find-cache-dir": "^3.3.2",
+        "follow-redirects": "^1.15.11",
+        "https-proxy-agent": "^7.0.6",
+        "mongodb": "^7.0.0",
+        "new-find-package-json": "^2.0.0",
+        "semver": "^7.7.3",
+        "tar-stream": "^3.1.7",
+        "tslib": "^2.8.1",
+        "yauzl": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/@types/whatwg-url": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
+      "integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/bson": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-7.2.0.tgz",
+      "integrity": "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/mongodb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.1.1.tgz",
+      "integrity": "sha512-067DXiMjcpYQl6bGjWQoTUEE9UoRViTtKFcoqX7z08I+iDZv/emH1g8XEFiO3qiDfXAheT5ozl1VffDTKhIW/w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.3.0",
+        "bson": "^7.1.1",
+        "mongodb-connection-string-url": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.806.0",
+        "@mongodb-js/zstd": "^7.0.0",
+        "gcp-metadata": "^7.0.1",
+        "kerberos": "^7.0.0",
+        "mongodb-client-encryption": ">=7.0.0 <7.1.0",
+        "snappy": "^7.3.2",
+        "socks": "^2.8.6"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/mongodb-connection-string-url": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.1.tgz",
+      "integrity": "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^13.0.0",
+        "whatwg-url": "^14.1.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/mongoose": {
+      "version": "7.8.9",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.8.9.tgz",
+      "integrity": "sha512-V3GBAJbmOAdzEP8murOvlg7q1szlbe4jTBRyW+JBHRduJBe7F9dk5eyqJDTuYrdBcOOWfLbr6AgXrDK7F0/o5A==",
+      "license": "MIT",
+      "dependencies": {
+        "bson": "^5.5.0",
+        "kareem": "2.5.1",
+        "mongodb": "5.9.2",
+        "mpath": "0.9.0",
+        "mquery": "5.0.0",
+        "ms": "2.1.3",
+        "sift": "16.0.1"
+      },
+      "engines": {
+        "node": ">=14.20.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mpath": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+      "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mquery": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
+      "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4.x"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/mquery/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mquery/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/multer": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
+      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/new-find-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/new-find-package-json/-/new-find-package-json-2.0.0.tgz",
+      "integrity": "sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.36",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nodemon": {
+      "version": "3.1.14",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.14.tgz",
+      "integrity": "sha512-jakjZi93UtB3jHMWsXL68FXSAosbLfY0In5gtKq3niLSkrWznrVBzXFNOEMJUfc9+Ke7SHWoAZsiMkNP3vq6Jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "debug": "^4",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^10.2.1",
+        "pstree.remy": "^1.1.8",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5"
+      },
+      "bin": {
+        "nodemon": "bin/nodemon.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/nodemon/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/nodemon/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sift": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-16.0.1.tgz",
+      "integrity": "sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ==",
+      "license": "MIT"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "memory-pager": "^1.0.2"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-length/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-length/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/synckit": {
+      "version": "0.11.12",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
+      "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.2.9"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/touch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "nodetouch": "bin/nodetouch.js"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ts-jest": {
+      "version": "29.4.6",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
+      "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.8",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.7.3",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/acorn": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "5.25.3",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
+      "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==",
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/unrs-resolver": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+      "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+        "@unrs/resolver-binding-android-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-x64": "1.11.1",
+        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "license": "MIT"
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.15.26",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.26.tgz",
+      "integrity": "sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.1.tgz",
+      "integrity": "sha512-k1isifdbpNSFEHFJ1ZY4YDewv0IH9FR61lDetaRMD3j2ae3bIXGV+7c+LHCqtQGofSd8PIyV4X6+dHMAnSr60A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,12 +24,14 @@
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^7.6.3",
         "multer": "^2.1.1",
+        "string-similarity": "^4.0.4",
         "ts-node": "^10.9.1",
         "typescript": "^5.2.2"
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
         "@types/multer": "^2.1.0",
+        "@types/string-similarity": "^4.0.2",
         "@types/supertest": "^7.2.0",
         "jest": "^30.3.0",
         "mongodb-memory-server": "^11.0.1",
@@ -2308,6 +2310,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/string-similarity": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/string-similarity/-/string-similarity-4.0.2.tgz",
+      "integrity": "sha512-LkJQ/jsXtCVMK+sKYAmX/8zEq+/46f1PTQw7YtmQwb74jemS1SlNLmARM2Zml9DgdDTWKAtc5L13WorpHPDjDA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/superagent": {
       "version": "8.1.9",
       "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
@@ -3263,6 +3272,8 @@
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
     },
     "node_modules/busboy": {
@@ -7257,6 +7268,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/string-similarity": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-4.0.4.tgz",
+      "integrity": "sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "ISC"
     },
     "node_modules/string-width": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "dev": "nodemon --exec ts-node ./src/app.ts",
     "build": "tsc",
     "start-server": "ts-node ./src/app.ts",
-    "test": "jest --forceExit"
+    "test": "jest --forceExit",
+    "build:check": "tsc"
   },
   "jest": {
     "preset": "ts-jest",

--- a/package.json
+++ b/package.json
@@ -14,21 +14,39 @@
     "@types/node": "^20.8.7",
     "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
+    "csv-parse": "^6.2.1",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "express-validator": "^7.0.1",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^7.6.3",
+    "multer": "^2.1.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2"
   },
   "devDependencies": {
-    "nodemon": "^3.0.1"
+    "@types/jest": "^30.0.0",
+    "@types/multer": "^2.1.0",
+    "@types/supertest": "^7.2.0",
+    "jest": "^30.3.0",
+    "mongodb-memory-server": "^11.0.1",
+    "nodemon": "^3.0.1",
+    "supertest": "^7.2.2",
+    "ts-jest": "^29.4.6"
   },
   "scripts": {
     "start": "node dist/app.js",
     "dev": "nodemon --exec ts-node ./src/app.ts",
     "build": "tsc",
-    "start-server": "ts-node ./src/app.ts"
+    "start-server": "ts-node ./src/app.ts",
+    "test": "jest --forceExit"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node",
+    "testMatch": [
+      "**/__tests__/**/*.test.ts"
+    ],
+    "forceExit": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "money-flow-backend",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "dist/app.js",
   "repository": "https://github.com/wkliwk/money-flow-backend.git",
   "author": "rickyli <ricky.li@crypto.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "money-flow-backend",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "main": "dist/app.js",
   "repository": "https://github.com/wkliwk/money-flow-backend.git",
   "author": "rickyli <ricky.li@crypto.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "money-flow-backend",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "main": "dist/app.js",
   "repository": "https://github.com/wkliwk/money-flow-backend.git",
   "author": "rickyli <ricky.li@crypto.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "money-flow-backend",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "dist/app.js",
   "repository": "https://github.com/wkliwk/money-flow-backend.git",
   "author": "rickyli <ricky.li@crypto.com>",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^7.6.3",
     "multer": "^2.1.1",
+    "pdfkit": "^0.18.0",
     "string-similarity": "^4.0.4",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2"
@@ -31,6 +32,7 @@
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/multer": "^2.1.0",
+    "@types/pdfkit": "^0.17.5",
     "@types/string-similarity": "^4.0.2",
     "@types/supertest": "^7.2.0",
     "jest": "^30.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "money-flow-backend",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "dist/app.js",
   "repository": "https://github.com/wkliwk/money-flow-backend.git",
   "author": "rickyli <ricky.li@crypto.com>",

--- a/package.json
+++ b/package.json
@@ -21,12 +21,14 @@
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^7.6.3",
     "multer": "^2.1.1",
+    "string-similarity": "^4.0.4",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/multer": "^2.1.0",
+    "@types/string-similarity": "^4.0.2",
     "@types/supertest": "^7.2.0",
     "jest": "^30.3.0",
     "mongodb-memory-server": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,10 @@
     "testMatch": [
       "**/__tests__/**/*.test.ts"
     ],
+    "coveragePathIgnorePatterns": [
+      "/node_modules/",
+      "/scripts/"
+    ],
     "forceExit": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "money-flow-backend",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "dist/app.js",
   "repository": "https://github.com/wkliwk/money-flow-backend.git",
   "author": "rickyli <ricky.li@crypto.com>",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@types/express": "^4.17.20",
     "@types/jsonwebtoken": "^9.0.4",
     "@types/node": "^20.8.7",
+    "apple-signin-auth": "^2.0.0",
     "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
     "csv-parse": "^6.2.1",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "rickyli <ricky.li@crypto.com>",
   "license": "MIT",
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.80.0",
     "@sentry/node": "^10.45.0",
     "@types/bcryptjs": "^2.4.6",
     "@types/cors": "^2.8.14",
@@ -18,6 +19,7 @@
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "express-validator": "^7.0.1",
+    "google-auth-library": "^10.6.2",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^7.6.3",
     "multer": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "rickyli <ricky.li@crypto.com>",
   "license": "MIT",
   "dependencies": {
+    "@sentry/node": "^10.45.0",
     "@types/bcryptjs": "^2.4.6",
     "@types/cors": "^2.8.14",
     "@types/express": "^4.17.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "money-flow-backend",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "dist/app.js",
   "repository": "https://github.com/wkliwk/money-flow-backend.git",
   "author": "rickyli <ricky.li@crypto.com>",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "csv-parse": "^6.2.1",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
+    "express-rate-limit": "^8.3.2",
     "express-validator": "^7.0.1",
     "google-auth-library": "^10.6.2",
     "jsonwebtoken": "^9.0.2",

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,0 +1,56 @@
+import mongoose from 'mongoose';
+import dotenv from 'dotenv';
+import UserModel from '../src/models/User';
+import ExpenseModel from '../src/models/Expense';
+
+dotenv.config();
+
+const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017/money-flow';
+
+const seed = async () => {
+  await mongoose.connect(MONGODB_URI);
+  console.log('Connected to MongoDB');
+
+  // Clear existing data
+  await UserModel.deleteMany({});
+  await ExpenseModel.deleteMany({});
+  console.log('Cleared existing data');
+
+  // Create test user (password: "password123")
+  const user = await UserModel.create({
+    email: 'test@example.com',
+    password: 'password123',
+    budgets: [
+      { category: 'Food', limit: 5000, alert_threshold: 0.9, enable_alerts: true },
+      { category: 'Transport', limit: 2000, alert_threshold: 0.8, enable_alerts: false },
+    ],
+  });
+  console.log(`Created user: ${user.email} (id: ${user._id})`);
+
+  // Create sample expenses
+  const now = new Date();
+  const expenses = [
+    { owner: user._id, description: 'Lunch at Tim Ho Wan', amount: 85, type: 'expense', category: 'Food', date: new Date(now.getFullYear(), now.getMonth(), 1) },
+    { owner: user._id, description: 'MTR monthly pass', amount: 500, type: 'expense', category: 'Transport', date: new Date(now.getFullYear(), now.getMonth(), 2) },
+    { owner: user._id, description: 'Groceries at Wellcome', amount: 320, type: 'expense', category: 'Food', date: new Date(now.getFullYear(), now.getMonth(), 5) },
+    { owner: user._id, description: 'Salary', amount: 35000, type: 'income', category: 'Salary', date: new Date(now.getFullYear(), now.getMonth(), 1) },
+    { owner: user._id, description: 'Electricity bill', amount: 450, type: 'expense', category: 'Utilities', date: new Date(now.getFullYear(), now.getMonth(), 10) },
+    { owner: user._id, description: 'Netflix subscription', amount: 78, type: 'expense', category: 'Entertainment', date: new Date(now.getFullYear(), now.getMonth(), 15) },
+    { owner: user._id, description: 'Coffee at Starbucks', amount: 42, type: 'expense', category: 'Food', date: new Date(now.getFullYear(), now.getMonth(), 18) },
+    { owner: user._id, description: 'Freelance payment', amount: 5000, type: 'income', category: 'Freelance', date: new Date(now.getFullYear(), now.getMonth(), 20) },
+  ];
+
+  await ExpenseModel.insertMany(expenses);
+  console.log(`Created ${expenses.length} sample transactions`);
+
+  console.log('\nSeed complete! Login with:');
+  console.log('  Email: test@example.com');
+  console.log('  Password: password123');
+
+  await mongoose.disconnect();
+};
+
+seed().catch((err) => {
+  console.error('Seed failed:', err);
+  process.exit(1);
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -15,6 +15,7 @@ import reportRoutes from './routes/reports';
 import exchangeRateRoutes from './routes/exchange-rates';
 import userRoutes from './routes/users';
 import receiptRoutes from './routes/receipts';
+import templateRoutes from './routes/templates';
 import { startAlertScheduler } from './jobs/processAlerts';
 import { startRecurringScheduler } from './jobs/processRecurring';
 import { startWeeklyDigestScheduler } from './jobs/weeklyDigest';
@@ -54,6 +55,7 @@ app.use('/api/reports', reportRoutes);
 app.use('/api/exchange-rates', exchangeRateRoutes);
 app.use('/api/users', userRoutes);
 app.use('/api/receipts', receiptRoutes);
+app.use('/api/templates', templateRoutes);
 
 Sentry.setupExpressErrorHandler(app);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -18,6 +18,7 @@ import receiptRoutes from './routes/receipts';
 import templateRoutes from './routes/templates';
 import friendRoutes from './routes/friends';
 import jobRoutes from './routes/jobs';
+import itemPriceRoutes from './routes/item-prices';
 import { startAlertScheduler } from './jobs/processAlerts';
 import { startRecurringScheduler } from './jobs/processRecurring';
 import { startWeeklyDigestScheduler } from './jobs/weeklyDigest';
@@ -61,6 +62,7 @@ app.use('/api/receipts', receiptRoutes);
 app.use('/api/templates', templateRoutes);
 app.use('/api/friends', friendRoutes);
 app.use('/api/jobs', jobRoutes);
+app.use('/api/item-prices', itemPriceRoutes);
 
 Sentry.setupExpressErrorHandler(app);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -20,6 +20,7 @@ import friendRoutes from './routes/friends';
 import jobRoutes from './routes/jobs';
 import itemPriceRoutes from './routes/item-prices';
 import accountRoutes from './routes/accounts';
+import insightRoutes from './routes/insights';
 import { startAlertScheduler } from './jobs/processAlerts';
 import { startRecurringScheduler } from './jobs/processRecurring';
 import { startWeeklyDigestScheduler } from './jobs/weeklyDigest';
@@ -65,6 +66,7 @@ app.use('/api/friends', friendRoutes);
 app.use('/api/jobs', jobRoutes);
 app.use('/api/item-prices', itemPriceRoutes);
 app.use('/api/accounts', accountRoutes);
+app.use('/api/insights', insightRoutes);
 
 Sentry.setupExpressErrorHandler(app);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -7,6 +7,7 @@ import dotenv from 'dotenv';
 import authRoutes from './routes/auth';
 import expenseRoutes from './routes/expenses';
 import budgetRoutes from './routes/budgets';
+import netWorthRoutes from './routes/net-worth';
 
 dotenv.config();
 
@@ -27,6 +28,7 @@ app.get('/health', (_req, res) => {
 app.use('/auth', authRoutes);
 app.use('/api/expenses', expenseRoutes);
 app.use('/api/budgets', budgetRoutes);
+app.use('/api/net-worth', netWorthRoutes);
 
 Sentry.setupExpressErrorHandler(app);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -14,6 +14,7 @@ import recurringRoutes from './routes/recurring';
 import reportRoutes from './routes/reports';
 import exchangeRateRoutes from './routes/exchange-rates';
 import userRoutes from './routes/users';
+import receiptRoutes from './routes/receipts';
 import { startAlertScheduler } from './jobs/processAlerts';
 import { startRecurringScheduler } from './jobs/processRecurring';
 import { startWeeklyDigestScheduler } from './jobs/weeklyDigest';
@@ -52,6 +53,7 @@ app.use('/api/recurring', recurringRoutes);
 app.use('/api/reports', reportRoutes);
 app.use('/api/exchange-rates', exchangeRateRoutes);
 app.use('/api/users', userRoutes);
+app.use('/api/receipts', receiptRoutes);
 
 Sentry.setupExpressErrorHandler(app);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -14,6 +14,7 @@ import recurringRoutes from './routes/recurring';
 import reportRoutes from './routes/reports';
 import { startAlertScheduler } from './jobs/processAlerts';
 import { startRecurringScheduler } from './jobs/processRecurring';
+import { startWeeklyDigestScheduler } from './jobs/weeklyDigest';
 
 dotenv.config();
 
@@ -64,6 +65,7 @@ if (process.env.NODE_ENV !== 'test') {
       console.log('Connected to MongoDB');
       startAlertScheduler();
       startRecurringScheduler();
+      startWeeklyDigestScheduler();
       app.listen(PORT, () => {
         console.log(`Server running on port ${PORT}`);
       });

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,7 @@ import cors from 'cors';
 import dotenv from 'dotenv';
 import authRoutes from './routes/auth';
 import expenseRoutes from './routes/expenses';
+import budgetRoutes from './routes/budgets';
 
 dotenv.config();
 
@@ -25,6 +26,7 @@ app.get('/health', (_req, res) => {
 
 app.use('/auth', authRoutes);
 app.use('/api/expenses', expenseRoutes);
+app.use('/api/budgets', budgetRoutes);
 
 Sentry.setupExpressErrorHandler(app);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,6 +10,7 @@ import budgetRoutes from './routes/budgets';
 import netWorthRoutes from './routes/net-worth';
 import exportRoutes from './routes/export';
 import importRoutes from './routes/import';
+import { startAlertScheduler } from './jobs/processAlerts';
 
 dotenv.config();
 
@@ -49,6 +50,7 @@ if (process.env.NODE_ENV !== 'test') {
     .connect(MONGODB_URI)
     .then(() => {
       console.log('Connected to MongoDB');
+      startAlertScheduler();
       app.listen(PORT, () => {
         console.log(`Server running on port ${PORT}`);
       });

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,3 +1,5 @@
+import './instrument';
+import * as Sentry from '@sentry/node';
 import express, { Request, Response, NextFunction } from 'express';
 import mongoose from 'mongoose';
 import cors from 'cors';
@@ -23,6 +25,8 @@ app.get('/health', (_req, res) => {
 
 app.use('/auth', authRoutes);
 app.use('/api/expenses', expenseRoutes);
+
+Sentry.setupExpressErrorHandler(app);
 
 // Global error handler
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/app.ts
+++ b/src/app.ts
@@ -9,6 +9,7 @@ import expenseRoutes from './routes/expenses';
 import budgetRoutes from './routes/budgets';
 import netWorthRoutes from './routes/net-worth';
 import exportRoutes from './routes/export';
+import importRoutes from './routes/import';
 
 dotenv.config();
 
@@ -31,6 +32,7 @@ app.use('/api/expenses', expenseRoutes);
 app.use('/api/budgets', budgetRoutes);
 app.use('/api/net-worth', netWorthRoutes);
 app.use('/api/export', exportRoutes);
+app.use('/api/import', importRoutes);
 
 Sentry.setupExpressErrorHandler(app);
 
@@ -41,17 +43,20 @@ app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
   res.status(500).json({ error: 'Internal server error' });
 });
 
-mongoose
-  .connect(MONGODB_URI)
-  .then(() => {
-    console.log('Connected to MongoDB');
-    app.listen(PORT, () => {
-      console.log(`Server running on port ${PORT}`);
+// Only connect and start server when not in test environment
+if (process.env.NODE_ENV !== 'test') {
+  mongoose
+    .connect(MONGODB_URI)
+    .then(() => {
+      console.log('Connected to MongoDB');
+      app.listen(PORT, () => {
+        console.log(`Server running on port ${PORT}`);
+      });
+    })
+    .catch((err) => {
+      console.error('MongoDB connection error:', err);
+      process.exit(1);
     });
-  })
-  .catch((err) => {
-    console.error('MongoDB connection error:', err);
-    process.exit(1);
-  });
+}
 
 export default app;

--- a/src/app.ts
+++ b/src/app.ts
@@ -44,6 +44,10 @@ app.get('/health', (_req, res) => {
   res.json({ status: 'ok', version });
 });
 
+app.get('/debug-sentry', (_req, _res) => {
+  throw new Error('Sentry test error — verify capture works');
+});
+
 app.get('/api/health', async (_req, res) => {
   const health = await getHealthStatus();
   const statusCode = health.status === 'healthy' ? 200 : 503;

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,7 +10,9 @@ import budgetRoutes from './routes/budgets';
 import netWorthRoutes from './routes/net-worth';
 import exportRoutes from './routes/export';
 import importRoutes from './routes/import';
+import recurringRoutes from './routes/recurring';
 import { startAlertScheduler } from './jobs/processAlerts';
+import { startRecurringScheduler } from './jobs/processRecurring';
 
 dotenv.config();
 
@@ -34,6 +36,7 @@ app.use('/api/budgets', budgetRoutes);
 app.use('/api/net-worth', netWorthRoutes);
 app.use('/api/export', exportRoutes);
 app.use('/api/import', importRoutes);
+app.use('/api/recurring', recurringRoutes);
 
 Sentry.setupExpressErrorHandler(app);
 
@@ -51,6 +54,7 @@ if (process.env.NODE_ENV !== 'test') {
     .then(() => {
       console.log('Connected to MongoDB');
       startAlertScheduler();
+      startRecurringScheduler();
       app.listen(PORT, () => {
         console.log(`Server running on port ${PORT}`);
       });

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,6 +8,7 @@ import authRoutes from './routes/auth';
 import expenseRoutes from './routes/expenses';
 import budgetRoutes from './routes/budgets';
 import netWorthRoutes from './routes/net-worth';
+import exportRoutes from './routes/export';
 
 dotenv.config();
 
@@ -29,6 +30,7 @@ app.use('/auth', authRoutes);
 app.use('/api/expenses', expenseRoutes);
 app.use('/api/budgets', budgetRoutes);
 app.use('/api/net-worth', netWorthRoutes);
+app.use('/api/export', exportRoutes);
 
 Sentry.setupExpressErrorHandler(app);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,9 +1,9 @@
 import './instrument';
 import * as Sentry from '@sentry/node';
 import express, { Request, Response, NextFunction } from 'express';
-import mongoose from 'mongoose';
 import cors from 'cors';
 import dotenv from 'dotenv';
+import { connectWithRetry, getHealthStatus } from './db';
 import authRoutes from './routes/auth';
 import expenseRoutes from './routes/expenses';
 import budgetRoutes from './routes/budgets';
@@ -31,6 +31,12 @@ app.get('/health', (_req, res) => {
   res.json({ status: 'ok' });
 });
 
+app.get('/api/health', async (_req, res) => {
+  const health = await getHealthStatus();
+  const statusCode = health.status === 'healthy' ? 200 : 503;
+  res.status(statusCode).json(health);
+});
+
 app.use('/auth', authRoutes);
 app.use('/api/expenses', expenseRoutes);
 app.use('/api/budgets', budgetRoutes);
@@ -51,8 +57,7 @@ app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
 
 // Only connect and start server when not in test environment
 if (process.env.NODE_ENV !== 'test') {
-  mongoose
-    .connect(MONGODB_URI)
+  connectWithRetry(MONGODB_URI)
     .then(() => {
       console.log('Connected to MongoDB');
       startAlertScheduler();

--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,7 @@ import importRoutes from './routes/import';
 import recurringRoutes from './routes/recurring';
 import reportRoutes from './routes/reports';
 import exchangeRateRoutes from './routes/exchange-rates';
+import userRoutes from './routes/users';
 import { startAlertScheduler } from './jobs/processAlerts';
 import { startRecurringScheduler } from './jobs/processRecurring';
 import { startWeeklyDigestScheduler } from './jobs/weeklyDigest';
@@ -50,6 +51,7 @@ app.use('/api/import', importRoutes);
 app.use('/api/recurring', recurringRoutes);
 app.use('/api/reports', reportRoutes);
 app.use('/api/exchange-rates', exchangeRateRoutes);
+app.use('/api/users', userRoutes);
 
 Sentry.setupExpressErrorHandler(app);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -21,6 +21,7 @@ import jobRoutes from './routes/jobs';
 import itemPriceRoutes from './routes/item-prices';
 import accountRoutes from './routes/accounts';
 import insightRoutes from './routes/insights';
+import goalRoutes from './routes/goals';
 import { startAlertScheduler } from './jobs/processAlerts';
 import { startRecurringScheduler } from './jobs/processRecurring';
 import { startWeeklyDigestScheduler } from './jobs/weeklyDigest';
@@ -71,6 +72,7 @@ app.use('/api/jobs', jobRoutes);
 app.use('/api/item-prices', itemPriceRoutes);
 app.use('/api/accounts', accountRoutes);
 app.use('/api/insights', insightRoutes);
+app.use('/api/goals', goalRoutes);
 
 Sentry.setupExpressErrorHandler(app);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -19,6 +19,7 @@ import templateRoutes from './routes/templates';
 import friendRoutes from './routes/friends';
 import jobRoutes from './routes/jobs';
 import itemPriceRoutes from './routes/item-prices';
+import accountRoutes from './routes/accounts';
 import { startAlertScheduler } from './jobs/processAlerts';
 import { startRecurringScheduler } from './jobs/processRecurring';
 import { startWeeklyDigestScheduler } from './jobs/weeklyDigest';
@@ -63,6 +64,7 @@ app.use('/api/templates', templateRoutes);
 app.use('/api/friends', friendRoutes);
 app.use('/api/jobs', jobRoutes);
 app.use('/api/item-prices', itemPriceRoutes);
+app.use('/api/accounts', accountRoutes);
 
 Sentry.setupExpressErrorHandler(app);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -11,6 +11,7 @@ import netWorthRoutes from './routes/net-worth';
 import exportRoutes from './routes/export';
 import importRoutes from './routes/import';
 import recurringRoutes from './routes/recurring';
+import reportRoutes from './routes/reports';
 import { startAlertScheduler } from './jobs/processAlerts';
 import { startRecurringScheduler } from './jobs/processRecurring';
 
@@ -37,6 +38,7 @@ app.use('/api/net-worth', netWorthRoutes);
 app.use('/api/export', exportRoutes);
 app.use('/api/import', importRoutes);
 app.use('/api/recurring', recurringRoutes);
+app.use('/api/reports', reportRoutes);
 
 Sentry.setupExpressErrorHandler(app);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,6 +16,7 @@ import exchangeRateRoutes from './routes/exchange-rates';
 import userRoutes from './routes/users';
 import receiptRoutes from './routes/receipts';
 import templateRoutes from './routes/templates';
+import friendRoutes from './routes/friends';
 import { startAlertScheduler } from './jobs/processAlerts';
 import { startRecurringScheduler } from './jobs/processRecurring';
 import { startWeeklyDigestScheduler } from './jobs/weeklyDigest';
@@ -56,6 +57,7 @@ app.use('/api/exchange-rates', exchangeRateRoutes);
 app.use('/api/users', userRoutes);
 app.use('/api/receipts', receiptRoutes);
 app.use('/api/templates', templateRoutes);
+app.use('/api/friends', friendRoutes);
 
 Sentry.setupExpressErrorHandler(app);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -22,6 +22,7 @@ import itemPriceRoutes from './routes/item-prices';
 import accountRoutes from './routes/accounts';
 import insightRoutes from './routes/insights';
 import goalRoutes from './routes/goals';
+import transactionRoutes from './routes/transactions';
 import { startAlertScheduler } from './jobs/processAlerts';
 import { startRecurringScheduler } from './jobs/processRecurring';
 import { startWeeklyDigestScheduler } from './jobs/weeklyDigest';
@@ -73,6 +74,7 @@ app.use('/api/item-prices', itemPriceRoutes);
 app.use('/api/accounts', accountRoutes);
 app.use('/api/insights', insightRoutes);
 app.use('/api/goals', goalRoutes);
+app.use('/api/transactions', transactionRoutes);
 
 Sentry.setupExpressErrorHandler(app);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,9 +16,11 @@ import exchangeRateRoutes from './routes/exchange-rates';
 import userRoutes from './routes/users';
 import receiptRoutes from './routes/receipts';
 import templateRoutes from './routes/templates';
+import jobRoutes from './routes/jobs';
 import { startAlertScheduler } from './jobs/processAlerts';
 import { startRecurringScheduler } from './jobs/processRecurring';
 import { startWeeklyDigestScheduler } from './jobs/weeklyDigest';
+import { startMonthlySummaryScheduler } from './jobs/monthlySummary';
 
 dotenv.config();
 
@@ -56,6 +58,7 @@ app.use('/api/exchange-rates', exchangeRateRoutes);
 app.use('/api/users', userRoutes);
 app.use('/api/receipts', receiptRoutes);
 app.use('/api/templates', templateRoutes);
+app.use('/api/jobs', jobRoutes);
 
 Sentry.setupExpressErrorHandler(app);
 
@@ -74,6 +77,7 @@ if (process.env.NODE_ENV !== 'test') {
       startAlertScheduler();
       startRecurringScheduler();
       startWeeklyDigestScheduler();
+      startMonthlySummaryScheduler();
       app.listen(PORT, () => {
         console.log(`Server running on port ${PORT}`);
       });

--- a/src/app.ts
+++ b/src/app.ts
@@ -12,6 +12,7 @@ import exportRoutes from './routes/export';
 import importRoutes from './routes/import';
 import recurringRoutes from './routes/recurring';
 import reportRoutes from './routes/reports';
+import exchangeRateRoutes from './routes/exchange-rates';
 import { startAlertScheduler } from './jobs/processAlerts';
 import { startRecurringScheduler } from './jobs/processRecurring';
 import { startWeeklyDigestScheduler } from './jobs/weeklyDigest';
@@ -48,6 +49,7 @@ app.use('/api/export', exportRoutes);
 app.use('/api/import', importRoutes);
 app.use('/api/recurring', recurringRoutes);
 app.use('/api/reports', reportRoutes);
+app.use('/api/exchange-rates', exchangeRateRoutes);
 
 Sentry.setupExpressErrorHandler(app);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -27,14 +27,16 @@ app.use(cors({
 }));
 app.use(express.json());
 
+const { version } = require('../package.json') as { version: string };
+
 app.get('/health', (_req, res) => {
-  res.json({ status: 'ok' });
+  res.json({ status: 'ok', version });
 });
 
 app.get('/api/health', async (_req, res) => {
   const health = await getHealthStatus();
   const statusCode = health.status === 'healthy' ? 200 : 503;
-  res.status(statusCode).json(health);
+  res.status(statusCode).json({ ...health, version });
 });
 
 app.use('/auth', authRoutes);

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,95 @@
+import mongoose from 'mongoose';
+
+const CONNECTION_TIMEOUT_MS = 10_000;
+const SOCKET_TIMEOUT_MS = 30_000;
+const MIN_POOL_SIZE = 5;
+const MAX_POOL_SIZE = 10;
+const MAX_RETRIES = 5;
+const BASE_DELAY_MS = 1_000;
+
+function getRetryDelay(attempt: number): number {
+  return BASE_DELAY_MS * Math.pow(2, attempt);
+}
+
+async function connectWithRetry(uri: string, retries = MAX_RETRIES): Promise<typeof mongoose> {
+  const options: mongoose.ConnectOptions = {
+    connectTimeoutMS: CONNECTION_TIMEOUT_MS,
+    socketTimeoutMS: SOCKET_TIMEOUT_MS,
+    minPoolSize: MIN_POOL_SIZE,
+    maxPoolSize: MAX_POOL_SIZE,
+    serverSelectionTimeoutMS: CONNECTION_TIMEOUT_MS,
+  };
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const conn = await mongoose.connect(uri, options);
+      return conn;
+    } catch (err) {
+      if (attempt >= retries) {
+        throw err;
+      }
+      const delay = getRetryDelay(attempt);
+      console.warn(`MongoDB connection attempt ${attempt + 1} failed, retrying in ${delay}ms...`);
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+
+  throw new Error('MongoDB connection failed after all retries');
+}
+
+interface HealthStatus {
+  status: 'healthy' | 'unhealthy';
+  dbState: string;
+  responseTimeMs: number;
+}
+
+const DB_STATE_MAP: Record<number, string> = {
+  0: 'disconnected',
+  1: 'connected',
+  2: 'connecting',
+  3: 'disconnecting',
+};
+
+async function getHealthStatus(): Promise<HealthStatus> {
+  const start = Date.now();
+  const state = mongoose.connection.readyState;
+  const dbState = DB_STATE_MAP[state] || 'unknown';
+
+  if (state !== 1) {
+    return {
+      status: 'unhealthy',
+      dbState,
+      responseTimeMs: Date.now() - start,
+    };
+  }
+
+  try {
+    const admin = mongoose.connection.db?.admin();
+    if (admin) {
+      await admin.ping();
+    }
+    return {
+      status: 'healthy',
+      dbState,
+      responseTimeMs: Date.now() - start,
+    };
+  } catch {
+    return {
+      status: 'unhealthy',
+      dbState: 'ping_failed',
+      responseTimeMs: Date.now() - start,
+    };
+  }
+}
+
+export {
+  connectWithRetry,
+  getHealthStatus,
+  getRetryDelay,
+  HealthStatus,
+  CONNECTION_TIMEOUT_MS,
+  MIN_POOL_SIZE,
+  MAX_POOL_SIZE,
+  MAX_RETRIES,
+  BASE_DELAY_MS,
+};

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -4,5 +4,7 @@ if (process.env.SENTRY_DSN) {
   Sentry.init({
     dsn: process.env.SENTRY_DSN,
     environment: process.env.NODE_ENV || 'production',
+    tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.2 : 1.0,
+    sendDefaultPii: false,
   });
 }

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -1,0 +1,8 @@
+import * as Sentry from '@sentry/node';
+
+if (process.env.SENTRY_DSN) {
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    environment: process.env.NODE_ENV || 'production',
+  });
+}

--- a/src/jobs/monthlySummary.ts
+++ b/src/jobs/monthlySummary.ts
@@ -1,0 +1,55 @@
+import { processMonthlySummaries } from '../utils/monthlySummary';
+
+export async function monthlySummaryJob(): Promise<void> {
+  const start = Date.now();
+  try {
+    const count = await processMonthlySummaries();
+    const duration = Date.now() - start;
+    console.log(`[MonthlySummaryJob] Sent ${count} summaries in ${duration}ms`);
+  } catch (error) {
+    console.error('[MonthlySummaryJob] Error:', error);
+  }
+}
+
+/**
+ * Start monthly summary scheduler.
+ * Checks every hour; only sends on the 1st of the month at or after 09:00 HKT (UTC+8).
+ * Cron equivalent: 0 9 1 * * (Railway cron schedule)
+ */
+export function startMonthlySummaryScheduler(): NodeJS.Timer | null {
+  if (!process.env.TELEGRAM_BOT_TOKEN) {
+    console.log('[MonthlySummaryScheduler] Telegram not configured, skipping');
+    return null;
+  }
+
+  let lastSentMonth = '';
+
+  const intervalId = setInterval(
+    () => {
+      const now = new Date();
+      // HKT = UTC+8
+      const hktOffset = now.getUTCHours() + 8;
+      const hktHour = hktOffset % 24;
+      const crossedMidnight = hktOffset >= 24;
+
+      const utcDate = new Date(now);
+      if (crossedMidnight) utcDate.setUTCDate(utcDate.getUTCDate() + 1);
+      const hktDay = utcDate.getUTCDate();
+
+      // 1st of month at or after 09:00 HKT
+      if (hktDay === 1 && hktHour >= 9) {
+        const monthKey = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+        if (monthKey !== lastSentMonth) {
+          lastSentMonth = monthKey;
+          monthlySummaryJob().catch((error) => {
+            console.error('[MonthlySummaryScheduler] Run failed:', error);
+          });
+        }
+      }
+    },
+    60 * 60 * 1000 // Check every hour
+  );
+
+  console.log('[MonthlySummaryScheduler] Started (checks hourly, sends 1st of month 09:00 HKT)');
+  return intervalId;
+}

--- a/src/jobs/processAlerts.ts
+++ b/src/jobs/processAlerts.ts
@@ -1,0 +1,44 @@
+import { processPendingAlerts } from '../utils/alerts';
+
+/**
+ * Background job to process pending alert queue
+ * Should be called every 30 minutes
+ */
+export async function processAlertsJob(): Promise<void> {
+  const start = Date.now();
+  try {
+    await processPendingAlerts();
+    const duration = Date.now() - start;
+    console.log(`[AlertJob] Processed pending alerts in ${duration}ms`);
+  } catch (error) {
+    console.error('[AlertJob] Error processing alerts:', error);
+  }
+}
+
+/**
+ * Start the background job scheduler
+ */
+export function startAlertScheduler(): NodeJS.Timer | null {
+  // Only start if Telegram is configured
+  if (!process.env.TELEGRAM_BOT_TOKEN || !process.env.TELEGRAM_CHAT_ID) {
+    console.log('[AlertScheduler] Telegram not configured, skipping alert job');
+    return null;
+  }
+
+  // Run immediately on startup, then every 30 minutes (1800000 ms)
+  processAlertsJob().catch((error) => {
+    console.error('[AlertJob] Initial run failed:', error);
+  });
+
+  const intervalId = setInterval(
+    () => {
+      processAlertsJob().catch((error) => {
+        console.error('[AlertJob] Scheduled run failed:', error);
+      });
+    },
+    30 * 60 * 1000
+  );
+
+  console.log('[AlertScheduler] Started alert processing job (every 30 minutes)');
+  return intervalId;
+}

--- a/src/jobs/processRecurring.ts
+++ b/src/jobs/processRecurring.ts
@@ -1,0 +1,40 @@
+import { processRecurringExpenses } from '../utils/recurring';
+
+/**
+ * Background job to process recurring expenses and generate transactions
+ * Should be called daily
+ */
+export async function processRecurringJob(): Promise<void> {
+  const start = Date.now();
+  try {
+    await processRecurringExpenses();
+    const duration = Date.now() - start;
+    console.log(`[RecurringJob] Processed recurring expenses in ${duration}ms`);
+  } catch (error) {
+    console.error('[RecurringJob] Error processing recurring expenses:', error);
+  }
+}
+
+/**
+ * Start the background job scheduler for recurring expenses
+ * Runs daily at midnight
+ */
+export function startRecurringScheduler(): NodeJS.Timer | null {
+  // Run immediately on startup
+  processRecurringJob().catch((error) => {
+    console.error('[RecurringScheduler] Initial run failed:', error);
+  });
+
+  // Schedule to run daily at midnight (24 hours = 86400000 ms)
+  const intervalId = setInterval(
+    () => {
+      processRecurringJob().catch((error) => {
+        console.error('[RecurringScheduler] Scheduled run failed:', error);
+      });
+    },
+    24 * 60 * 60 * 1000
+  );
+
+  console.log('[RecurringScheduler] Started recurring expense processing job (daily)');
+  return intervalId;
+}

--- a/src/jobs/processRecurring.ts
+++ b/src/jobs/processRecurring.ts
@@ -1,17 +1,23 @@
-import { processRecurringExpenses } from '../utils/recurring';
+import { processRecurringExpenses, ProcessingResult } from '../utils/recurring';
 
 /**
- * Background job to process recurring expenses and generate transactions
- * Should be called daily
+ * Background job to process recurring expenses and generate transactions.
+ * Returns the processing result for use by the manual trigger endpoint.
  */
-export async function processRecurringJob(): Promise<void> {
+export async function processRecurringJob(): Promise<ProcessingResult> {
   const start = Date.now();
   try {
-    await processRecurringExpenses();
+    const result = await processRecurringExpenses();
     const duration = Date.now() - start;
-    console.log(`[RecurringJob] Processed recurring expenses in ${duration}ms`);
+    console.log(
+      `[RecurringJob] Processed ${result.processed} recurring expense(s), ` +
+      `created ${result.expensesCreated} expense(s), ` +
+      `${result.errors} error(s) in ${duration}ms`
+    );
+    return result;
   } catch (error) {
     console.error('[RecurringJob] Error processing recurring expenses:', error);
+    throw error;
   }
 }
 

--- a/src/jobs/weeklyDigest.ts
+++ b/src/jobs/weeklyDigest.ts
@@ -1,0 +1,59 @@
+import { processWeeklyDigests } from '../utils/weeklyDigest';
+
+export async function weeklyDigestJob(): Promise<void> {
+  const start = Date.now();
+  try {
+    const count = await processWeeklyDigests();
+    const duration = Date.now() - start;
+    console.log(`[WeeklyDigestJob] Sent ${count} digests in ${duration}ms`);
+  } catch (error) {
+    console.error('[WeeklyDigestJob] Error:', error);
+  }
+}
+
+/**
+ * Start weekly digest scheduler
+ * Checks every hour; only sends on Sunday after 18:00 HKT (UTC+8)
+ */
+export function startWeeklyDigestScheduler(): NodeJS.Timer | null {
+  if (!process.env.TELEGRAM_BOT_TOKEN) {
+    console.log('[WeeklyDigestScheduler] Telegram not configured, skipping');
+    return null;
+  }
+
+  let lastSentWeek = '';
+
+  const intervalId = setInterval(
+    () => {
+      const now = new Date();
+      // HKT = UTC+8
+      const hktHour = (now.getUTCHours() + 8) % 24;
+      const hktDay = now.getUTCDay();
+      // Adjust day if HKT offset crosses midnight
+      const adjustedDay = now.getUTCHours() + 8 >= 24 ? (hktDay + 1) % 7 : hktDay;
+
+      // Sunday (0) at or after 18:00 HKT
+      if (adjustedDay === 0 && hktHour >= 18) {
+        const weekKey = `${now.getFullYear()}-W${getISOWeek(now)}`;
+        if (weekKey !== lastSentWeek) {
+          lastSentWeek = weekKey;
+          weeklyDigestJob().catch((error) => {
+            console.error('[WeeklyDigestScheduler] Run failed:', error);
+          });
+        }
+      }
+    },
+    60 * 60 * 1000 // Check every hour
+  );
+
+  console.log('[WeeklyDigestScheduler] Started (checks hourly, sends Sunday 18:00 HKT)');
+  return intervalId;
+}
+
+function getISOWeek(date: Date): number {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  d.setDate(d.getDate() + 3 - ((d.getDay() + 6) % 7));
+  const yearStart = new Date(d.getFullYear(), 0, 1);
+  return Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+}

--- a/src/models/Account.ts
+++ b/src/models/Account.ts
@@ -1,0 +1,42 @@
+import mongoose, { Document } from 'mongoose';
+
+const ACCOUNT_TYPES = [
+  'checking',
+  'savings',
+  'credit_card',
+  'cash',
+  'investment',
+  'other',
+] as const;
+
+type AccountType = typeof ACCOUNT_TYPES[number];
+
+interface IAccount extends Document {
+  userId: string;
+  name: string;
+  type: AccountType;
+  startingBalance: number;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+const AccountSchema = new mongoose.Schema(
+  {
+    userId: { type: String, required: true },
+    name: { type: String, required: true },
+    type: {
+      type: String,
+      enum: ACCOUNT_TYPES,
+      required: true,
+    },
+    startingBalance: { type: Number, default: 0 },
+  },
+  { timestamps: true }
+);
+
+AccountSchema.index({ userId: 1, createdAt: -1 });
+
+export { ACCOUNT_TYPES };
+export type { AccountType };
+export const AccountModel = mongoose.model<IAccount>('Account', AccountSchema);
+export default AccountModel;

--- a/src/models/Alert.ts
+++ b/src/models/Alert.ts
@@ -1,0 +1,30 @@
+import mongoose, { Document } from 'mongoose';
+
+export interface IAlert extends Document {
+  userId: string;
+  category: string;
+  amount: number;
+  limit: number;
+  percentUsed: number;
+  message: string;
+  sent: boolean;
+  sentAt?: Date;
+  createdAt: Date;
+}
+
+const AlertSchema = new mongoose.Schema(
+  {
+    userId: { type: String, required: true, index: true },
+    category: { type: String, required: true },
+    amount: { type: Number, required: true },
+    limit: { type: Number, required: true },
+    percentUsed: { type: Number, required: true },
+    message: { type: String, required: true },
+    sent: { type: Boolean, default: false, index: true },
+    sentAt: { type: Date },
+  },
+  { timestamps: true }
+);
+
+export const AlertModel = mongoose.model<IAlert>('Alert', AlertSchema);
+export default AlertModel;

--- a/src/models/Expense.ts
+++ b/src/models/Expense.ts
@@ -41,7 +41,7 @@ interface IExpense extends Document {
   originalAmount?: number | null;
   exchangeRate?: number | null;
   paymentMethod?: PaymentMethod | null;
-  splitBill?: boolean;
+  splitBill?: boolean | string;
   createdAt?: Date;
   updatedAt?: Date;
 }
@@ -75,7 +75,7 @@ const ExpenseSchema = new mongoose.Schema(
       enum: [...PAYMENT_METHODS, null],
       default: null,
     },
-    splitBill: { type: Boolean, default: false },
+    splitBill: { type: mongoose.Schema.Types.Mixed, default: false },
   },
   { timestamps: true }
 );

--- a/src/models/Expense.ts
+++ b/src/models/Expense.ts
@@ -14,6 +14,12 @@ const PAYMENT_METHODS = [
 
 type PaymentMethod = typeof PAYMENT_METHODS[number];
 
+const SUPPORTED_CURRENCIES = [
+  'HKD', 'CNY', 'JPY', 'USD', 'EUR', 'GBP', 'TWD', 'THB', 'KRW',
+] as const;
+
+type SupportedCurrency = typeof SUPPORTED_CURRENCIES[number];
+
 interface IExpense extends Document {
   owner: string;
   description?: string;
@@ -30,6 +36,9 @@ interface IExpense extends Document {
   endDate?: Date | null;
   date?: Date;
   amount: number;
+  currency?: SupportedCurrency;
+  originalAmount?: number | null;
+  exchangeRate?: number | null;
   paymentMethod?: PaymentMethod | null;
   createdAt?: Date;
   updatedAt?: Date;
@@ -52,6 +61,13 @@ const ExpenseSchema = new mongoose.Schema(
     item: String,
     participants: [String],
     amount: { type: Number, required: true },
+    currency: {
+      type: String,
+      enum: SUPPORTED_CURRENCIES,
+      default: 'HKD',
+    },
+    originalAmount: { type: Number, default: null },
+    exchangeRate: { type: Number, default: null },
     paymentMethod: {
       type: String,
       enum: [...PAYMENT_METHODS, null],
@@ -64,6 +80,7 @@ const ExpenseSchema = new mongoose.Schema(
 ExpenseSchema.index({ owner: 1, date: -1 });
 ExpenseSchema.index({ owner: 1, _id: 1 });
 
-export { PAYMENT_METHODS };
+export { PAYMENT_METHODS, SUPPORTED_CURRENCIES };
+export type { SupportedCurrency };
 export const ExpenseModel = mongoose.model<IExpense>('Expense', ExpenseSchema);
 export default ExpenseModel;

--- a/src/models/Expense.ts
+++ b/src/models/Expense.ts
@@ -33,7 +33,7 @@ const ExpenseSchema = new mongoose.Schema(
     date: { type: Date, default: Date.now },
     category: String,
     item: String,
-    participants: { type: [String], default: [] },
+    participants: [String],
     amount: { type: Number, required: true },
   },
   { timestamps: true }

--- a/src/models/Expense.ts
+++ b/src/models/Expense.ts
@@ -6,11 +6,13 @@ interface IExpense extends Document {
   purpose?: string;
   currentLocation?: string;
   type?: string;
+  category?: string;
   parent?: string;
   status?: string;
   profit?: number;
   startDate?: Date | null;
   endDate?: Date | null;
+  date?: Date;
   amount: number;
 }
 
@@ -26,6 +28,8 @@ const ExpenseSchema = new mongoose.Schema(
     profit: Number,
     startDate: Date,
     endDate: Date,
+    date: { type: Date, default: Date.now },
+    category: String,
     amount: { type: Number, required: true },
   },
   { timestamps: true }

--- a/src/models/Expense.ts
+++ b/src/models/Expense.ts
@@ -1,5 +1,19 @@
 import mongoose, { Document } from 'mongoose';
 
+const PAYMENT_METHODS = [
+  'cash',
+  'credit_card',
+  'debit_card',
+  'octopus',
+  'payme',
+  'fps',
+  'alipay_hk',
+  'wechat_pay',
+  'other',
+] as const;
+
+type PaymentMethod = typeof PAYMENT_METHODS[number];
+
 interface IExpense extends Document {
   owner: string;
   description?: string;
@@ -16,6 +30,7 @@ interface IExpense extends Document {
   endDate?: Date | null;
   date?: Date;
   amount: number;
+  paymentMethod?: PaymentMethod | null;
   createdAt?: Date;
   updatedAt?: Date;
 }
@@ -37,6 +52,11 @@ const ExpenseSchema = new mongoose.Schema(
     item: String,
     participants: [String],
     amount: { type: Number, required: true },
+    paymentMethod: {
+      type: String,
+      enum: [...PAYMENT_METHODS, null],
+      default: null,
+    },
   },
   { timestamps: true }
 );
@@ -44,5 +64,6 @@ const ExpenseSchema = new mongoose.Schema(
 ExpenseSchema.index({ owner: 1, date: -1 });
 ExpenseSchema.index({ owner: 1, _id: 1 });
 
+export { PAYMENT_METHODS };
 export const ExpenseModel = mongoose.model<IExpense>('Expense', ExpenseSchema);
 export default ExpenseModel;

--- a/src/models/Expense.ts
+++ b/src/models/Expense.ts
@@ -7,6 +7,7 @@ interface IExpense extends Document {
   currentLocation?: string;
   type?: string;
   category?: string;
+  item?: string;
   participants?: string[];
   parent?: string;
   status?: string;
@@ -31,6 +32,7 @@ const ExpenseSchema = new mongoose.Schema(
     endDate: Date,
     date: { type: Date, default: Date.now },
     category: String,
+    item: String,
     participants: { type: [String], default: [] },
     amount: { type: Number, required: true },
   },

--- a/src/models/Expense.ts
+++ b/src/models/Expense.ts
@@ -40,6 +40,7 @@ interface IExpense extends Document {
   originalAmount?: number | null;
   exchangeRate?: number | null;
   paymentMethod?: PaymentMethod | null;
+  splitBill?: boolean;
   createdAt?: Date;
   updatedAt?: Date;
 }
@@ -73,6 +74,7 @@ const ExpenseSchema = new mongoose.Schema(
       enum: [...PAYMENT_METHODS, null],
       default: null,
     },
+    splitBill: { type: Boolean, default: false },
   },
   { timestamps: true }
 );

--- a/src/models/Expense.ts
+++ b/src/models/Expense.ts
@@ -41,5 +41,8 @@ const ExpenseSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
+ExpenseSchema.index({ owner: 1, date: -1 });
+ExpenseSchema.index({ owner: 1, _id: 1 });
+
 export const ExpenseModel = mongoose.model<IExpense>('Expense', ExpenseSchema);
 export default ExpenseModel;

--- a/src/models/Expense.ts
+++ b/src/models/Expense.ts
@@ -82,6 +82,7 @@ const ExpenseSchema = new mongoose.Schema(
 
 ExpenseSchema.index({ owner: 1, date: -1 });
 ExpenseSchema.index({ owner: 1, _id: 1 });
+ExpenseSchema.index({ owner: 1, category: 1, date: -1 }); // budget + report queries filtered by category
 
 export { PAYMENT_METHODS, SUPPORTED_CURRENCIES };
 export type { SupportedCurrency };

--- a/src/models/Expense.ts
+++ b/src/models/Expense.ts
@@ -7,6 +7,7 @@ interface IExpense extends Document {
   currentLocation?: string;
   type?: string;
   category?: string;
+  participants?: string[];
   parent?: string;
   status?: string;
   profit?: number;
@@ -30,6 +31,7 @@ const ExpenseSchema = new mongoose.Schema(
     endDate: Date,
     date: { type: Date, default: Date.now },
     category: String,
+    participants: { type: [String], default: [] },
     amount: { type: Number, required: true },
   },
   { timestamps: true }

--- a/src/models/Expense.ts
+++ b/src/models/Expense.ts
@@ -7,6 +7,7 @@ const PAYMENT_METHODS = [
   'octopus',
   'payme',
   'fps',
+  'bank_transfer',
   'alipay_hk',
   'wechat_pay',
   'other',

--- a/src/models/Expense.ts
+++ b/src/models/Expense.ts
@@ -16,6 +16,8 @@ interface IExpense extends Document {
   endDate?: Date | null;
   date?: Date;
   amount: number;
+  createdAt?: Date;
+  updatedAt?: Date;
 }
 
 const ExpenseSchema = new mongoose.Schema(

--- a/src/models/Friendship.ts
+++ b/src/models/Friendship.ts
@@ -1,0 +1,26 @@
+import mongoose, { Document } from 'mongoose';
+
+export type FriendshipStatus = 'pending' | 'accepted' | 'rejected';
+
+export interface IFriendship extends Document {
+  requester: string;
+  recipient: string;
+  status: FriendshipStatus;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const FriendshipSchema = new mongoose.Schema(
+  {
+    requester: { type: String, required: true },
+    recipient: { type: String, required: true },
+    status: { type: String, enum: ['pending', 'accepted', 'rejected'], default: 'pending' },
+  },
+  { timestamps: true }
+);
+
+FriendshipSchema.index({ requester: 1, recipient: 1 }, { unique: true });
+FriendshipSchema.index({ recipient: 1, status: 1 });
+
+export const FriendshipModel = mongoose.model<IFriendship>('Friendship', FriendshipSchema);
+export default FriendshipModel;

--- a/src/models/Goal.ts
+++ b/src/models/Goal.ts
@@ -1,0 +1,29 @@
+import mongoose, { Document } from 'mongoose';
+
+interface IGoal extends Document {
+  userId: string;
+  name: string;
+  targetAmount: number;
+  currentAmount: number;
+  deadline?: Date;
+  category?: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+const GoalSchema = new mongoose.Schema(
+  {
+    userId: { type: String, required: true },
+    name: { type: String, required: true },
+    targetAmount: { type: Number, required: true },
+    currentAmount: { type: Number, default: 0 },
+    deadline: { type: Date },
+    category: { type: String },
+  },
+  { timestamps: true }
+);
+
+GoalSchema.index({ userId: 1, createdAt: -1 });
+
+export const GoalModel = mongoose.model<IGoal>('Goal', GoalSchema);
+export default GoalModel;

--- a/src/models/ItemPrice.ts
+++ b/src/models/ItemPrice.ts
@@ -1,0 +1,47 @@
+import mongoose, { Document } from 'mongoose';
+
+interface IPriceHistoryEntry {
+  price: number;
+  date: Date;
+}
+
+export interface IItemPrice extends Document {
+  userId: string;
+  merchant: string;
+  itemName: string;
+  price: number;
+  currency: string;
+  lastSeen: Date;
+  priceHistory: IPriceHistoryEntry[];
+  occurrences: number;
+}
+
+const PriceHistoryEntrySchema = new mongoose.Schema<IPriceHistoryEntry>(
+  {
+    price: { type: Number, required: true },
+    date: { type: Date, required: true },
+  },
+  { _id: false }
+);
+
+const ItemPriceSchema = new mongoose.Schema<IItemPrice>(
+  {
+    userId: { type: String, required: true },
+    merchant: { type: String, required: true },
+    itemName: { type: String, required: true },
+    price: { type: Number, required: true },
+    currency: { type: String, required: true, default: 'HKD' },
+    lastSeen: { type: Date, required: true },
+    priceHistory: { type: [PriceHistoryEntrySchema], default: [] },
+    occurrences: { type: Number, required: true, default: 1 },
+  },
+  { timestamps: true }
+);
+
+// Compound index for fast lookup by user + merchant + item
+ItemPriceSchema.index({ userId: 1, merchant: 1, itemName: 1 }, { unique: true });
+// Index for suggest endpoint (user + merchant)
+ItemPriceSchema.index({ userId: 1, merchant: 1 });
+
+export const ItemPriceModel = mongoose.model<IItemPrice>('ItemPrice', ItemPriceSchema);
+export default ItemPriceModel;

--- a/src/models/NetWorth.ts
+++ b/src/models/NetWorth.ts
@@ -1,0 +1,56 @@
+import mongoose from 'mongoose';
+
+interface INetWorthSnapshot {
+  userId: string;
+  date: Date;
+  assets: {
+    cash?: number;
+    investments?: number;
+    property?: number;
+    other?: number;
+  };
+  liabilities: {
+    loans?: number;
+    creditCardDebt?: number;
+    other?: number;
+  };
+  netWorth?: number; // calculated: sum(assets) - sum(liabilities)
+}
+
+const NetWorthSchema = new mongoose.Schema(
+  {
+    userId: { type: String, required: true, index: true },
+    date: { type: Date, required: true, index: true },
+    assets: {
+      cash: { type: Number, default: 0 },
+      investments: { type: Number, default: 0 },
+      property: { type: Number, default: 0 },
+      other: { type: Number, default: 0 },
+    },
+    liabilities: {
+      loans: { type: Number, default: 0 },
+      creditCardDebt: { type: Number, default: 0 },
+      other: { type: Number, default: 0 },
+    },
+  },
+  { timestamps: true }
+);
+
+// Calculate netWorth before saving
+NetWorthSchema.pre('save', function () {
+  const totalAssets =
+    (this.assets?.cash || 0) +
+    (this.assets?.investments || 0) +
+    (this.assets?.property || 0) +
+    (this.assets?.other || 0);
+
+  const totalLiabilities =
+    (this.liabilities?.loans || 0) +
+    (this.liabilities?.creditCardDebt || 0) +
+    (this.liabilities?.other || 0);
+
+  (this as any).netWorth = totalAssets - totalLiabilities;
+});
+
+export const NetWorthModel = mongoose.model<INetWorthSnapshot>('NetWorth', NetWorthSchema);
+export default NetWorthModel;

--- a/src/models/RecurringExpense.ts
+++ b/src/models/RecurringExpense.ts
@@ -11,6 +11,10 @@ export interface IRecurringExpense extends Document {
   end_date?: Date;
   frequency: RecurringFrequency;
   description?: string;
+  nextDueDate: Date;
+  lastProcessedDate?: Date;
+  processedUntil?: Date;
+  active: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -29,17 +33,25 @@ const RecurringExpenseSchema = new mongoose.Schema(
       required: true,
     },
     description: { type: String },
+    nextDueDate: { type: Date, index: true },
+    lastProcessedDate: { type: Date },
+    processedUntil: { type: Date },
+    active: { type: Boolean, default: true },
   },
   { timestamps: true }
 );
 
-// Validate that end_date (if set) is after start_date
+// Validate that end_date (if set) is after start_date, and set nextDueDate on creation
 RecurringExpenseSchema.pre('save', function (next) {
   if (this.end_date && this.start_date > this.end_date) {
     next(new Error('end_date must be after start_date'));
-  } else {
-    next();
+    return;
   }
+  // Set nextDueDate to start_date if not already set
+  if (!this.nextDueDate) {
+    this.nextDueDate = this.start_date;
+  }
+  next();
 });
 
 export const RecurringExpenseModel = mongoose.model<IRecurringExpense>(

--- a/src/models/RecurringExpense.ts
+++ b/src/models/RecurringExpense.ts
@@ -1,0 +1,49 @@
+import mongoose, { Document } from 'mongoose';
+
+export type RecurringFrequency = 'DAILY' | 'WEEKLY' | 'MONTHLY' | 'QUARTERLY' | 'YEARLY';
+
+export interface IRecurringExpense extends Document {
+  userId: string;
+  name: string;
+  amount: number;
+  category?: string;
+  start_date: Date;
+  end_date?: Date;
+  frequency: RecurringFrequency;
+  description?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const RecurringExpenseSchema = new mongoose.Schema(
+  {
+    userId: { type: String, required: true, index: true },
+    name: { type: String, required: true },
+    amount: { type: Number, required: true, min: 0.01 },
+    category: { type: String },
+    start_date: { type: Date, required: true },
+    end_date: { type: Date },
+    frequency: {
+      type: String,
+      enum: ['DAILY', 'WEEKLY', 'MONTHLY', 'QUARTERLY', 'YEARLY'],
+      required: true,
+    },
+    description: { type: String },
+  },
+  { timestamps: true }
+);
+
+// Validate that end_date (if set) is after start_date
+RecurringExpenseSchema.pre('save', function (next) {
+  if (this.end_date && this.start_date > this.end_date) {
+    next(new Error('end_date must be after start_date'));
+  } else {
+    next();
+  }
+});
+
+export const RecurringExpenseModel = mongoose.model<IRecurringExpense>(
+  'RecurringExpense',
+  RecurringExpenseSchema
+);
+export default RecurringExpenseModel;

--- a/src/models/TransactionTemplate.ts
+++ b/src/models/TransactionTemplate.ts
@@ -1,0 +1,38 @@
+import mongoose, { Document } from 'mongoose';
+
+export type TemplateFrequency = 'weekly' | 'biweekly' | 'monthly';
+
+export interface ITransactionTemplate extends Document {
+  owner: string;
+  name: string;
+  amount: number;
+  category?: string;
+  description?: string;
+  frequency: TemplateFrequency;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const TransactionTemplateSchema = new mongoose.Schema(
+  {
+    owner: { type: String, required: true, index: true },
+    name: { type: String, required: true },
+    amount: { type: Number, required: true, min: 0.01 },
+    category: { type: String },
+    description: { type: String },
+    frequency: {
+      type: String,
+      enum: ['weekly', 'biweekly', 'monthly'],
+      required: true,
+    },
+  },
+  { timestamps: true }
+);
+
+TransactionTemplateSchema.index({ owner: 1, createdAt: -1 });
+
+export const TransactionTemplateModel = mongoose.model<ITransactionTemplate>(
+  'TransactionTemplate',
+  TransactionTemplateSchema
+);
+export default TransactionTemplateModel;

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -8,12 +8,15 @@ export interface IBudget {
   enable_alerts?: boolean;
 }
 
+export type ThemePreference = 'light' | 'dark' | 'system';
+
 export interface IUser extends Document {
   email: string;
   password: string;
   budgets: IBudget[];
   telegramChatId?: string;
   weeklyDigestEnabled: boolean;
+  themePreference: ThemePreference;
   createdAt: Date;
   comparePassword(candidate: string): Promise<boolean>;
 }
@@ -35,6 +38,7 @@ const UserSchema = new mongoose.Schema(
     },
     telegramChatId: { type: String, default: undefined },
     weeklyDigestEnabled: { type: Boolean, default: false },
+    themePreference: { type: String, enum: ['light', 'dark', 'system'], default: 'system' },
   },
   { timestamps: true }
 );

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -4,6 +4,8 @@ import bcrypt from 'bcryptjs';
 export interface IBudget {
   category: string;
   limit: number;
+  alert_threshold?: number;
+  enable_alerts?: boolean;
 }
 
 export interface IUser extends Document {
@@ -18,7 +20,17 @@ const UserSchema = new mongoose.Schema(
   {
     email: { type: String, required: true, unique: true, lowercase: true, trim: true },
     password: { type: String, required: true, minlength: 6 },
-    budgets: { type: [{ category: String, limit: Number }], default: [] },
+    budgets: {
+      type: [
+        {
+          category: String,
+          limit: Number,
+          alert_threshold: { type: Number, default: 0.9 },
+          enable_alerts: { type: Boolean, default: false },
+        },
+      ],
+      default: [],
+    },
   },
   { timestamps: true }
 );

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -12,7 +12,8 @@ export type ThemePreference = 'light' | 'dark' | 'system';
 
 export interface IUser extends Document {
   email: string;
-  password: string;
+  password?: string;
+  googleId?: string;
   budgets: IBudget[];
   telegramChatId?: string;
   weeklyDigestEnabled: boolean;
@@ -24,7 +25,8 @@ export interface IUser extends Document {
 const UserSchema = new mongoose.Schema(
   {
     email: { type: String, required: true, unique: true, lowercase: true, trim: true },
-    password: { type: String, required: true, minlength: 6 },
+    password: { type: String, minlength: 6 },
+    googleId: { type: String, sparse: true },
     budgets: {
       type: [
         {
@@ -44,7 +46,7 @@ const UserSchema = new mongoose.Schema(
 );
 
 UserSchema.pre('save', async function (next) {
-  if (!this.isModified('password')) return next();
+  if (!this.isModified('password') || !this.password) return next();
   this.password = await bcrypt.hash(this.password, 12);
   next();
 });

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -1,9 +1,15 @@
 import mongoose, { Document } from 'mongoose';
 import bcrypt from 'bcryptjs';
 
+export interface IBudget {
+  category: string;
+  limit: number;
+}
+
 export interface IUser extends Document {
   email: string;
   password: string;
+  budgets: IBudget[];
   createdAt: Date;
   comparePassword(candidate: string): Promise<boolean>;
 }
@@ -12,6 +18,7 @@ const UserSchema = new mongoose.Schema(
   {
     email: { type: String, required: true, unique: true, lowercase: true, trim: true },
     password: { type: String, required: true, minlength: 6 },
+    budgets: { type: [{ category: String, limit: Number }], default: [] },
   },
   { timestamps: true }
 );

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -12,6 +12,8 @@ export interface IUser extends Document {
   email: string;
   password: string;
   budgets: IBudget[];
+  telegramChatId?: string;
+  weeklyDigestEnabled: boolean;
   createdAt: Date;
   comparePassword(candidate: string): Promise<boolean>;
 }
@@ -31,6 +33,8 @@ const UserSchema = new mongoose.Schema(
       ],
       default: [],
     },
+    telegramChatId: { type: String, default: undefined },
+    weeklyDigestEnabled: { type: Boolean, default: false },
   },
   { timestamps: true }
 );

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -14,6 +14,7 @@ export interface IUser extends Document {
   email: string;
   password?: string;
   googleId?: string;
+  appleId?: string;
   budgets: IBudget[];
   telegramChatId?: string;
   weeklyDigestEnabled: boolean;
@@ -27,6 +28,7 @@ const UserSchema = new mongoose.Schema(
     email: { type: String, required: true, unique: true, lowercase: true, trim: true },
     password: { type: String, minlength: 6 },
     googleId: { type: String, sparse: true },
+    appleId: { type: String, sparse: true },
     budgets: {
       type: [
         {

--- a/src/models/WeeklyPulse.ts
+++ b/src/models/WeeklyPulse.ts
@@ -1,0 +1,34 @@
+import mongoose, { Document } from 'mongoose';
+
+export interface IWeeklyPulseStats {
+  totalSpend: number;
+  fourWeekAverage: number;
+  deltaPercent: number;
+  topCategory: string;
+  highestSpendDay: string;
+  largestTransaction: { description: string; amount: number; category: string } | null;
+  transactionCount: number;
+}
+
+interface IWeeklyPulse extends Document {
+  userId: string;
+  weekStart: string; // YYYY-MM-DD (Monday)
+  narrative: string;
+  stats: IWeeklyPulseStats;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+const WeeklyPulseSchema = new mongoose.Schema(
+  {
+    userId: { type: String, required: true },
+    weekStart: { type: String, required: true },
+    narrative: { type: String, required: true },
+    stats: { type: mongoose.Schema.Types.Mixed, required: true },
+  },
+  { timestamps: true }
+);
+
+WeeklyPulseSchema.index({ userId: 1, weekStart: -1 });
+
+export const WeeklyPulseModel = mongoose.model<IWeeklyPulse>('WeeklyPulse', WeeklyPulseSchema);

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -15,8 +15,9 @@ router.get('/', async (req: AuthRequest, res: Response) => {
       .sort({ createdAt: -1 })
       .lean();
     res.json({ accounts });
-  } catch {
-    res.status(500).json({ error: 'Failed to fetch accounts' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to fetch accounts';
+    res.status(500).json({ error: message });
   }
 });
 
@@ -52,8 +53,9 @@ router.post(
         startingBalance: startingBalance ?? 0,
       });
       res.status(201).json({ account });
-    } catch {
-      res.status(500).json({ error: 'Failed to create account' });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to create account';
+      res.status(500).json({ error: message });
     }
   }
 );
@@ -89,8 +91,9 @@ router.put(
         return;
       }
       res.json({ account });
-    } catch {
-      res.status(500).json({ error: 'Failed to update account' });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to update account';
+      res.status(500).json({ error: message });
     }
   }
 );
@@ -116,8 +119,9 @@ router.delete('/:id', async (req: AuthRequest, res: Response) => {
     await AccountModel.deleteOne({ _id: req.params.id });
 
     res.json({ deleted: true, unlinkedTransactions: linkedCount });
-  } catch {
-    res.status(500).json({ error: 'Failed to delete account' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to delete account';
+    res.status(500).json({ error: message });
   }
 });
 

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -1,0 +1,124 @@
+import { Router, Response } from 'express';
+import { body, validationResult } from 'express-validator';
+import { protect, AuthRequest } from '../middleware/auth';
+import AccountModel, { ACCOUNT_TYPES } from '../models/Account';
+import ExpenseModel from '../models/Expense';
+
+const router = Router();
+
+router.use(protect);
+
+// GET /api/accounts
+router.get('/', async (req: AuthRequest, res: Response) => {
+  try {
+    const accounts = await AccountModel.find({ userId: req.userId })
+      .sort({ createdAt: -1 })
+      .lean();
+    res.json({ accounts });
+  } catch {
+    res.status(500).json({ error: 'Failed to fetch accounts' });
+  }
+});
+
+// POST /api/accounts
+router.post(
+  '/',
+  [
+    body('name').notEmpty().withMessage('name is required'),
+    body('type')
+      .isIn(ACCOUNT_TYPES)
+      .withMessage(`type must be one of: ${ACCOUNT_TYPES.join(', ')}`),
+    body('startingBalance')
+      .optional()
+      .isNumeric()
+      .withMessage('startingBalance must be a number'),
+  ],
+  async (req: AuthRequest, res: Response) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({ error: errors.array()[0].msg });
+      return;
+    }
+    try {
+      const { name, type, startingBalance } = req.body as {
+        name: string;
+        type: string;
+        startingBalance?: number;
+      };
+      const account = await AccountModel.create({
+        userId: req.userId,
+        name,
+        type,
+        startingBalance: startingBalance ?? 0,
+      });
+      res.status(201).json({ account });
+    } catch {
+      res.status(500).json({ error: 'Failed to create account' });
+    }
+  }
+);
+
+// PUT /api/accounts/:id
+router.put(
+  '/:id',
+  [
+    body('name').optional().notEmpty().withMessage('name cannot be empty'),
+    body('type')
+      .optional()
+      .isIn(ACCOUNT_TYPES)
+      .withMessage(`type must be one of: ${ACCOUNT_TYPES.join(', ')}`),
+    body('startingBalance')
+      .optional()
+      .isNumeric()
+      .withMessage('startingBalance must be a number'),
+  ],
+  async (req: AuthRequest, res: Response) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({ error: errors.array()[0].msg });
+      return;
+    }
+    try {
+      const account = await AccountModel.findOneAndUpdate(
+        { _id: req.params.id, userId: req.userId },
+        { $set: req.body },
+        { new: true }
+      );
+      if (!account) {
+        res.status(404).json({ error: 'Account not found' });
+        return;
+      }
+      res.json({ account });
+    } catch {
+      res.status(500).json({ error: 'Failed to update account' });
+    }
+  }
+);
+
+// DELETE /api/accounts/:id
+router.delete('/:id', async (req: AuthRequest, res: Response) => {
+  try {
+    const account = await AccountModel.findOne({
+      _id: req.params.id,
+      userId: req.userId,
+    });
+    if (!account) {
+      res.status(404).json({ error: 'Account not found' });
+      return;
+    }
+
+    // Count transactions linked to this account
+    const linkedCount = await ExpenseModel.countDocuments({
+      owner: req.userId,
+      accountId: req.params.id,
+    });
+
+    await AccountModel.deleteOne({ _id: req.params.id });
+
+    res.json({ deleted: true, unlinkedTransactions: linkedCount });
+  } catch {
+    res.status(500).json({ error: 'Failed to delete account' });
+  }
+});
+
+export default router;

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,11 +1,44 @@
 import { Router, Request, Response } from 'express';
 import jwt from 'jsonwebtoken';
 import { body, validationResult } from 'express-validator';
+import rateLimit from 'express-rate-limit';
 import { OAuth2Client } from 'google-auth-library';
 import appleSignin from 'apple-signin-auth';
 import UserModel from '../models/User';
 
 const router = Router();
+
+const rateLimitMessage = { error: 'Too many requests, please try again later' };
+
+const isTestWithoutRateLimit = (): boolean =>
+  process.env.NODE_ENV === 'test' && process.env.ENABLE_RATE_LIMIT !== 'true';
+
+export const loginLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: rateLimitMessage,
+  skip: isTestWithoutRateLimit,
+});
+
+export const registerLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  limit: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: rateLimitMessage,
+  skip: isTestWithoutRateLimit,
+});
+
+export const socialAuthLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 20,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: rateLimitMessage,
+  skip: isTestWithoutRateLimit,
+});
 
 const signToken = (userId: string): string =>
   jwt.sign({ userId }, process.env.JWT_SECRET as string, { expiresIn: '7d' });
@@ -13,6 +46,7 @@ const signToken = (userId: string): string =>
 // POST /auth/register
 router.post(
   '/register',
+  registerLimiter,
   [
     body('email').isEmail().normalizeEmail(),
     body('password').isLength({ min: 6 }),
@@ -43,6 +77,7 @@ router.post(
 // POST /auth/login
 router.post(
   '/login',
+  loginLimiter,
   [
     body('email').isEmail().normalizeEmail(),
     body('password').notEmpty(),
@@ -72,6 +107,7 @@ router.post(
 // POST /auth/google
 router.post(
   '/google',
+  socialAuthLimiter,
   [body('idToken').notEmpty()],
   async (req: Request, res: Response) => {
     const errors = validationResult(req);
@@ -131,6 +167,7 @@ router.post(
 // POST /auth/apple
 router.post(
   '/apple',
+  socialAuthLimiter,
   [body('idToken').notEmpty()],
   async (req: Request, res: Response) => {
     const errors = validationResult(req);

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from 'express';
 import jwt from 'jsonwebtoken';
 import { body, validationResult } from 'express-validator';
+import { OAuth2Client } from 'google-auth-library';
 import UserModel from '../models/User';
 
 const router = Router();
@@ -63,6 +64,65 @@ router.post(
       res.json({ token });
     } catch {
       res.status(500).json({ error: 'Login failed' });
+    }
+  }
+);
+
+// POST /auth/google
+router.post(
+  '/google',
+  [body('idToken').notEmpty()],
+  async (req: Request, res: Response) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({ error: 'idToken is required' });
+      return;
+    }
+
+    try {
+      const { idToken } = req.body as { idToken: string };
+      const clientId = process.env.GOOGLE_CLIENT_ID;
+      if (!clientId) {
+        res.status(500).json({ error: 'Google OAuth not configured' });
+        return;
+      }
+
+      const client = new OAuth2Client(clientId);
+      const ticket = await client.verifyIdToken({
+        idToken,
+        audience: clientId,
+      });
+      const payload = ticket.getPayload();
+      if (!payload || !payload.email) {
+        res.status(401).json({ error: 'Invalid Google token' });
+        return;
+      }
+
+      const { email, sub: googleId } = payload;
+
+      // Check if user exists by googleId or email
+      let user = await UserModel.findOne({
+        $or: [{ googleId }, { email: email.toLowerCase() }],
+      });
+
+      if (user) {
+        // Link Google account if not already linked
+        if (!user.googleId) {
+          user.googleId = googleId;
+          await user.save();
+        }
+      } else {
+        // Create new OAuth-only user
+        user = await UserModel.create({
+          email: email.toLowerCase(),
+          googleId,
+        });
+      }
+
+      const token = signToken(user.id as string);
+      res.json({ token });
+    } catch {
+      res.status(401).json({ error: 'Google authentication failed' });
     }
   }
 );

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -5,6 +5,17 @@ import rateLimit from 'express-rate-limit';
 import { OAuth2Client } from 'google-auth-library';
 import appleSignin from 'apple-signin-auth';
 import UserModel from '../models/User';
+import ExpenseModel from '../models/Expense';
+import TransactionTemplateModel from '../models/TransactionTemplate';
+import RecurringExpenseModel from '../models/RecurringExpense';
+import GoalModel from '../models/Goal';
+import AccountModel from '../models/Account';
+import NetWorthModel from '../models/NetWorth';
+import { WeeklyPulseModel } from '../models/WeeklyPulse';
+import AlertModel from '../models/Alert';
+import ItemPriceModel from '../models/ItemPrice';
+import FriendshipModel from '../models/Friendship';
+import { protect, AuthRequest } from '../middleware/auth';
 
 const router = Router();
 
@@ -214,6 +225,70 @@ router.post(
       res.json({ token });
     } catch {
       res.status(401).json({ error: 'Apple authentication failed' });
+    }
+  }
+);
+
+export const deleteAccountLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  limit: 3,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: rateLimitMessage,
+  skip: isTestWithoutRateLimit,
+});
+
+// DELETE /auth/account
+router.delete(
+  '/account',
+  deleteAccountLimiter,
+  protect,
+  [body('password').notEmpty().withMessage('Password is required')],
+  async (req: AuthRequest, res: Response) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({ error: errors.array()[0].msg });
+      return;
+    }
+
+    try {
+      const userId = req.userId as string;
+      const { password } = req.body as { password: string };
+
+      const user = await UserModel.findById(userId);
+      if (!user) {
+        res.status(401).json({ error: 'User not found' });
+        return;
+      }
+
+      if (!user.password) {
+        res.status(400).json({ error: 'OAuth-only accounts cannot be deleted with password confirmation' });
+        return;
+      }
+
+      const isMatch = await user.comparePassword(password);
+      if (!isMatch) {
+        res.status(401).json({ error: 'Incorrect password' });
+        return;
+      }
+
+      await Promise.all([
+        ExpenseModel.deleteMany({ owner: userId }),
+        TransactionTemplateModel.deleteMany({ owner: userId }),
+        RecurringExpenseModel.deleteMany({ userId }),
+        GoalModel.deleteMany({ userId }),
+        AccountModel.deleteMany({ userId }),
+        NetWorthModel.deleteMany({ userId }),
+        WeeklyPulseModel.deleteMany({ userId }),
+        AlertModel.deleteMany({ userId }),
+        ItemPriceModel.deleteMany({ userId }),
+        FriendshipModel.deleteMany({ $or: [{ requester: userId }, { recipient: userId }] }),
+        UserModel.findByIdAndDelete(userId),
+      ]);
+
+      res.json({ message: 'Account and all data deleted' });
+    } catch {
+      res.status(500).json({ error: 'Account deletion failed' });
     }
   }
 );

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express';
 import jwt from 'jsonwebtoken';
 import { body, validationResult } from 'express-validator';
 import { OAuth2Client } from 'google-auth-library';
+import appleSignin from 'apple-signin-auth';
 import UserModel from '../models/User';
 
 const router = Router();
@@ -123,6 +124,59 @@ router.post(
       res.json({ token });
     } catch {
       res.status(401).json({ error: 'Google authentication failed' });
+    }
+  }
+);
+
+// POST /auth/apple
+router.post(
+  '/apple',
+  [body('idToken').notEmpty()],
+  async (req: Request, res: Response) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({ error: 'idToken is required' });
+      return;
+    }
+
+    try {
+      const { idToken } = req.body as { idToken: string };
+      const clientId = process.env.APPLE_CLIENT_ID;
+      if (!clientId) {
+        res.status(500).json({ error: 'Apple Sign-In not configured' });
+        return;
+      }
+
+      const payload = await appleSignin.verifyIdToken(idToken, {
+        audience: clientId,
+      });
+
+      const { email, sub: appleId } = payload;
+      if (!email) {
+        res.status(401).json({ error: 'Invalid Apple token' });
+        return;
+      }
+
+      let user = await UserModel.findOne({
+        $or: [{ appleId }, { email: email.toLowerCase() }],
+      });
+
+      if (user) {
+        if (!user.appleId) {
+          user.appleId = appleId;
+          await user.save();
+        }
+      } else {
+        user = await UserModel.create({
+          email: email.toLowerCase(),
+          appleId,
+        });
+      }
+
+      const token = signToken(user.id as string);
+      res.json({ token });
+    } catch {
+      res.status(401).json({ error: 'Apple authentication failed' });
     }
   }
 );

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -79,8 +79,9 @@ router.post(
       const user = await UserModel.create({ email, password });
       const token = signToken(user.id as string);
       res.status(201).json({ token });
-    } catch {
-      res.status(500).json({ error: 'Registration failed' });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Registration failed';
+      res.status(500).json({ error: message });
     }
   }
 );
@@ -109,8 +110,9 @@ router.post(
       }
       const token = signToken(user.id as string);
       res.json({ token });
-    } catch {
-      res.status(500).json({ error: 'Login failed' });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Login failed';
+      res.status(500).json({ error: message });
     }
   }
 );
@@ -169,8 +171,9 @@ router.post(
 
       const token = signToken(user.id as string);
       res.json({ token });
-    } catch {
-      res.status(401).json({ error: 'Google authentication failed' });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Google authentication failed';
+      res.status(401).json({ error: message });
     }
   }
 );
@@ -223,8 +226,9 @@ router.post(
 
       const token = signToken(user.id as string);
       res.json({ token });
-    } catch {
-      res.status(401).json({ error: 'Apple authentication failed' });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Apple authentication failed';
+      res.status(401).json({ error: message });
     }
   }
 );
@@ -287,8 +291,9 @@ router.delete(
       ]);
 
       res.json({ message: 'Account and all data deleted' });
-    } catch {
-      res.status(500).json({ error: 'Account deletion failed' });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Account deletion failed';
+      res.status(500).json({ error: message });
     }
   }
 );

--- a/src/routes/budgets.ts
+++ b/src/routes/budgets.ts
@@ -17,8 +17,9 @@ router.get('/', async (req: AuthRequest, res: Response) => {
       return;
     }
     res.json({ budgets: user.budgets || [] });
-  } catch {
-    res.status(500).json({ error: 'Failed to fetch budgets' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to fetch budgets';
+    res.status(500).json({ error: message });
   }
 });
 
@@ -78,8 +79,9 @@ router.get('/summary', async (req: AuthRequest, res: Response) => {
     });
 
     res.json({ summary });
-  } catch {
-    res.status(500).json({ error: 'Failed to fetch budget summary' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to fetch budget summary';
+    res.status(500).json({ error: message });
   }
 });
 
@@ -113,8 +115,9 @@ router.post('/:category/alerts', [
     await user.save();
 
     res.json({ message: `Alerts ${enable_alerts ? 'enabled' : 'disabled'} for ${category}` });
-  } catch {
-    res.status(500).json({ error: 'Failed to update alert settings' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to update alert settings';
+    res.status(500).json({ error: message });
   }
 });
 
@@ -144,8 +147,9 @@ router.put(
 
       await UserModel.findByIdAndUpdate(req.userId, { $set: { budgets } });
       res.json({ budgets });
-    } catch {
-      res.status(500).json({ error: 'Failed to update budgets' });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to update budgets';
+      res.status(500).json({ error: message });
     }
   }
 );

--- a/src/routes/budgets.ts
+++ b/src/routes/budgets.ts
@@ -83,6 +83,41 @@ router.get('/summary', async (req: AuthRequest, res: Response) => {
   }
 });
 
+// POST /api/budgets/:category/alerts - enable/disable alerts for category
+router.post('/:category/alerts', [
+  body('enable_alerts').isBoolean().withMessage('enable_alerts must be a boolean'),
+], async (req: AuthRequest, res: Response) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    res.status(400).json({ error: errors.array()[0].msg });
+    return;
+  }
+  try {
+    const { category } = req.params;
+    const { enable_alerts } = req.body;
+
+    const user = await UserModel.findById(req.userId);
+    if (!user) {
+      res.status(404).json({ error: 'User not found' });
+      return;
+    }
+
+    // Find or create budget entry for this category
+    let budget = user.budgets.find((b) => b.category === category);
+    if (!budget) {
+      res.status(404).json({ error: 'Budget not found for this category' });
+      return;
+    }
+
+    budget.enable_alerts = enable_alerts;
+    await user.save();
+
+    res.json({ message: `Alerts ${enable_alerts ? 'enabled' : 'disabled'} for ${category}` });
+  } catch {
+    res.status(500).json({ error: 'Failed to update alert settings' });
+  }
+});
+
 // PUT /api/budgets
 router.put(
   '/',

--- a/src/routes/budgets.ts
+++ b/src/routes/budgets.ts
@@ -1,6 +1,7 @@
 import { Router, Response } from 'express';
 import { body, validationResult } from 'express-validator';
 import UserModel from '../models/User';
+import ExpenseModel from '../models/Expense';
 import { protect, AuthRequest } from '../middleware/auth';
 
 const router = Router();
@@ -21,6 +22,67 @@ router.get('/', async (req: AuthRequest, res: Response) => {
   }
 });
 
+// GET /api/budgets/summary - returns current spend vs limits
+router.get('/summary', async (req: AuthRequest, res: Response) => {
+  try {
+    const user = await UserModel.findById(req.userId).lean();
+    if (!user) {
+      res.status(404).json({ error: 'User not found' });
+      return;
+    }
+
+    const budgets = user.budgets || [];
+    if (budgets.length === 0) {
+      res.json({ summary: [] });
+      return;
+    }
+
+    // Get current month start and end
+    const now = new Date();
+    const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+    const monthEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0);
+
+    // Get expenses for current month grouped by category
+    const expenses = await ExpenseModel.find(
+      {
+        userId: req.userId,
+        type: 'expense',
+        date: { $gte: monthStart, $lte: monthEnd },
+      },
+      { category: 1, amount: 1 }
+    ).lean();
+
+    const categorySpend: { [key: string]: number } = {};
+    expenses.forEach((exp) => {
+      const cat = exp.category || 'Uncategorized';
+      categorySpend[cat] = (categorySpend[cat] || 0) + exp.amount;
+    });
+
+    const summary = budgets.map((b) => {
+      const spend = categorySpend[b.category] || 0;
+      const threshold = b.alert_threshold || 0.9;
+      const remaining = Math.max(0, b.limit - spend);
+      const exceeds = spend > b.limit;
+      const percentUsed = b.limit > 0 ? (spend / b.limit) * 100 : 0;
+
+      return {
+        category: b.category,
+        limit: b.limit,
+        spend,
+        remaining,
+        percentUsed: Math.round(percentUsed),
+        exceeds,
+        alertTriggered: exceeds && b.enable_alerts,
+        thresholdPercentage: threshold * 100,
+      };
+    });
+
+    res.json({ summary });
+  } catch {
+    res.status(500).json({ error: 'Failed to fetch budget summary' });
+  }
+});
+
 // PUT /api/budgets
 router.put(
   '/',
@@ -36,9 +98,15 @@ router.put(
       return;
     }
     try {
-      const budgets = (req.body.budgets as { category: string; limit: number }[]).filter(
-        (b) => b.limit > 0
-      );
+      const budgets = (
+        req.body.budgets as {
+          category: string;
+          limit: number;
+          alert_threshold?: number;
+          enable_alerts?: boolean;
+        }[]
+      ).filter((b) => b.limit > 0);
+
       await UserModel.findByIdAndUpdate(req.userId, { $set: { budgets } });
       res.json({ budgets });
     } catch {

--- a/src/routes/budgets.ts
+++ b/src/routes/budgets.ts
@@ -45,7 +45,7 @@ router.get('/summary', async (req: AuthRequest, res: Response) => {
     // Get expenses for current month grouped by category
     const expenses = await ExpenseModel.find(
       {
-        userId: req.userId,
+        owner: req.userId,
         type: 'expense',
         date: { $gte: monthStart, $lte: monthEnd },
       },

--- a/src/routes/budgets.ts
+++ b/src/routes/budgets.ts
@@ -1,0 +1,50 @@
+import { Router, Response } from 'express';
+import { body, validationResult } from 'express-validator';
+import UserModel from '../models/User';
+import { protect, AuthRequest } from '../middleware/auth';
+
+const router = Router();
+
+router.use(protect);
+
+// GET /api/budgets
+router.get('/', async (req: AuthRequest, res: Response) => {
+  try {
+    const user = await UserModel.findById(req.userId).lean();
+    if (!user) {
+      res.status(404).json({ error: 'User not found' });
+      return;
+    }
+    res.json({ budgets: user.budgets || [] });
+  } catch {
+    res.status(500).json({ error: 'Failed to fetch budgets' });
+  }
+});
+
+// PUT /api/budgets
+router.put(
+  '/',
+  [
+    body('budgets').isArray().withMessage('budgets must be an array'),
+    body('budgets.*.category').notEmpty().withMessage('category is required'),
+    body('budgets.*.limit').isNumeric().withMessage('limit must be a number'),
+  ],
+  async (req: AuthRequest, res: Response) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({ error: errors.array()[0].msg });
+      return;
+    }
+    try {
+      const budgets = (req.body.budgets as { category: string; limit: number }[]).filter(
+        (b) => b.limit > 0
+      );
+      await UserModel.findByIdAndUpdate(req.userId, { $set: { budgets } });
+      res.json({ budgets });
+    } catch {
+      res.status(500).json({ error: 'Failed to update budgets' });
+    }
+  }
+);
+
+export default router;

--- a/src/routes/exchange-rates.ts
+++ b/src/routes/exchange-rates.ts
@@ -1,0 +1,19 @@
+import { Router, Response } from 'express';
+import { protect, AuthRequest } from '../middleware/auth';
+import { getExchangeRates } from '../utils/exchangeRates';
+
+const router = Router();
+
+router.use(protect);
+
+// GET /api/exchange-rates
+router.get('/', async (_req: AuthRequest, res: Response) => {
+  try {
+    const data = await getExchangeRates();
+    res.json(data);
+  } catch {
+    res.status(500).json({ error: 'Failed to fetch exchange rates' });
+  }
+});
+
+export default router;

--- a/src/routes/exchange-rates.ts
+++ b/src/routes/exchange-rates.ts
@@ -11,8 +11,9 @@ router.get('/', async (_req: AuthRequest, res: Response) => {
   try {
     const data = await getExchangeRates();
     res.json(data);
-  } catch {
-    res.status(500).json({ error: 'Failed to fetch exchange rates' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to fetch exchange rates';
+    res.status(500).json({ error: message });
   }
 });
 

--- a/src/routes/expenses.ts
+++ b/src/routes/expenses.ts
@@ -44,7 +44,9 @@ router.post('/', expenseValidation, async (req: AuthRequest, res: Response) => {
     return;
   }
   try {
-    const expense = new ExpenseModel(req.body);
+    // Ensure participants is always an array (empty if not provided)
+    const { participants = [] } = req.body;
+    const expense = new ExpenseModel({ ...req.body, participants });
     const saved = await expense.save();
     res.status(201).json(saved.toObject());
   } catch {

--- a/src/routes/expenses.ts
+++ b/src/routes/expenses.ts
@@ -57,8 +57,8 @@ const currencyValidation = body('currency')
 
 const originalAmountValidation = body('originalAmount')
   .optional({ values: 'null' })
-  .isNumeric()
-  .withMessage('originalAmount must be a number');
+  .isFloat({ gt: 0 })
+  .withMessage('originalAmount must be a positive number');
 
 const exchangeRateValidation = body('exchangeRate')
   .optional({ values: 'null' })
@@ -66,7 +66,7 @@ const exchangeRateValidation = body('exchangeRate')
   .withMessage('exchangeRate must be a number');
 
 const expenseValidation = [
-  body('amount').isNumeric().withMessage('Amount must be a number'),
+  body('amount').isFloat({ gt: 0 }).withMessage('Amount must be a positive number'),
   currencyValidation,
   originalAmountValidation,
   exchangeRateValidation,

--- a/src/routes/expenses.ts
+++ b/src/routes/expenses.ts
@@ -74,11 +74,107 @@ const expenseValidation = [
   paymentMethodValidation,
 ];
 
-// GET /api/expenses with pagination
+// GET /api/expenses/analytics
+router.get('/analytics', async (req: AuthRequest, res: Response) => {
+  try {
+    const monthParam = req.query.month as string | undefined;
+    let year: number;
+    let month: number;
+
+    if (monthParam) {
+      if (!/^\d{4}-(0[1-9]|1[0-2])$/.test(monthParam)) {
+        res.status(400).json({ error: 'month must be in YYYY-MM format' });
+        return;
+      }
+      [year, month] = monthParam.split('-').map(Number);
+    } else {
+      const now = new Date();
+      year = now.getFullYear();
+      month = now.getMonth() + 1;
+    }
+
+    const startDate = new Date(year, month - 1, 1);
+    const endDate = new Date(year, month, 1);
+
+    const matchStage = {
+      $match: {
+        owner: req.userId,
+        date: { $gte: startDate, $lt: endDate },
+      },
+    };
+
+    const [summaryResult, categoryResult, dailyResult] = await Promise.all([
+      ExpenseModel.aggregate([
+        matchStage,
+        {
+          $group: {
+            _id: '$type',
+            total: { $sum: '$amount' },
+          },
+        },
+      ]),
+      ExpenseModel.aggregate([
+        matchStage,
+        { $match: { type: 'expense' } },
+        {
+          $group: {
+            _id: '$category',
+            total: { $sum: '$amount' },
+            count: { $sum: 1 },
+          },
+        },
+        { $sort: { total: -1 } },
+      ]),
+      ExpenseModel.aggregate([
+        matchStage,
+        {
+          $group: {
+            _id: {
+              date: { $dateToString: { format: '%Y-%m-%d', date: '$date' } },
+              type: '$type',
+            },
+            total: { $sum: '$amount' },
+          },
+        },
+        { $sort: { '_id.date': 1 } },
+      ]),
+    ]);
+
+    const totalIncome = summaryResult.find((r) => r._id === 'income')?.total ?? 0;
+    const totalExpense = summaryResult.find((r) => r._id === 'expense')?.total ?? 0;
+    const netBalance = totalIncome - totalExpense;
+
+    const grandExpenseTotal = categoryResult.reduce((sum: number, c: { total: number }) => sum + c.total, 0);
+    const categoryBreakdown = categoryResult.map((c: { _id: string | null; total: number; count: number }) => ({
+      category: c._id ?? 'Uncategorised',
+      total: c.total,
+      count: c.count,
+      percentage: grandExpenseTotal > 0 ? Math.round((c.total / grandExpenseTotal) * 10000) / 100 : 0,
+    }));
+
+    const dailyMap = new Map<string, { income: number; expense: number }>();
+    for (const row of dailyResult) {
+      const date: string = row._id.date;
+      if (!dailyMap.has(date)) dailyMap.set(date, { income: 0, expense: 0 });
+      const entry = dailyMap.get(date)!;
+      if (row._id.type === 'income') entry.income += row.total;
+      else if (row._id.type === 'expense') entry.expense += row.total;
+    }
+    const dailyTotals = Array.from(dailyMap.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([date, totals]) => ({ date, ...totals }));
+
+    res.json({ totalIncome, totalExpense, netBalance, categoryBreakdown, dailyTotals });
+  } catch {
+    res.status(500).json({ error: 'Failed to fetch analytics' });
+  }
+});
+
+// GET /api/expenses with pagination and sorting
 router.get('/', async (req: AuthRequest, res: Response) => {
   try {
     const page = Math.max(1, parseInt(req.query.page as string) || 1);
-    const limit = Math.min(100, Math.max(1, parseInt(req.query.limit as string) || 20));
+    const limit = Math.min(200, Math.max(1, parseInt(req.query.limit as string) || 50));
     const skip = (page - 1) * limit;
 
     const filter: Record<string, unknown> = { owner: req.userId };
@@ -91,17 +187,30 @@ router.get('/', async (req: AuthRequest, res: Response) => {
       filter.paymentMethod = paymentMethodQuery;
     }
 
+    const allowedSortFields = ['createdAt', 'amount', 'date'];
+    const sortField = allowedSortFields.includes(req.query.sort as string)
+      ? (req.query.sort as string)
+      : 'createdAt';
+    const sortOrder = req.query.order === 'asc' ? 1 : -1;
+    const sortObj: Record<string, 1 | -1> = { [sortField]: sortOrder };
+    if (sortField !== 'createdAt') sortObj.createdAt = -1;
+
     const [expenses, total] = await Promise.all([
       ExpenseModel.find(filter)
-        .sort({ date: -1, createdAt: -1 })
+        .sort(sortObj)
         .skip(skip)
         .limit(limit)
         .lean(),
       ExpenseModel.countDocuments(filter),
     ]);
 
-    const pages = Math.ceil(total / limit);
-    res.json({ data: expenses, total, page, pages });
+    const totalPages = Math.ceil(total / limit);
+    res.json({
+      data: expenses,
+      pagination: { page, limit, total, totalPages },
+      // Backward compat
+      total, page, pages: totalPages,
+    });
   } catch {
     res.status(500).json({ error: 'Failed to fetch expenses' });
   }

--- a/src/routes/expenses.ts
+++ b/src/routes/expenses.ts
@@ -1,7 +1,7 @@
 import { Router, Response } from 'express';
 import { body, validationResult } from 'express-validator';
 import { compareTwoStrings } from 'string-similarity';
-import ExpenseModel, { PAYMENT_METHODS } from '../models/Expense';
+import ExpenseModel, { PAYMENT_METHODS, SUPPORTED_CURRENCIES } from '../models/Expense';
 import { protect, AuthRequest } from '../middleware/auth';
 import { checkAndQueueBudgetAlerts } from '../utils/alerts';
 
@@ -50,8 +50,26 @@ const paymentMethodValidation = body('paymentMethod')
   .isIn([...PAYMENT_METHODS])
   .withMessage(`paymentMethod must be one of: ${PAYMENT_METHODS.join(', ')}`);
 
+const currencyValidation = body('currency')
+  .optional()
+  .isIn([...SUPPORTED_CURRENCIES])
+  .withMessage(`currency must be one of: ${SUPPORTED_CURRENCIES.join(', ')}`);
+
+const originalAmountValidation = body('originalAmount')
+  .optional({ values: 'null' })
+  .isNumeric()
+  .withMessage('originalAmount must be a number');
+
+const exchangeRateValidation = body('exchangeRate')
+  .optional({ values: 'null' })
+  .isNumeric()
+  .withMessage('exchangeRate must be a number');
+
 const expenseValidation = [
   body('amount').isNumeric().withMessage('Amount must be a number'),
+  currencyValidation,
+  originalAmountValidation,
+  exchangeRateValidation,
   participantsValidation,
   paymentMethodValidation,
 ];
@@ -111,7 +129,7 @@ router.post('/', expenseValidation, async (req: AuthRequest, res: Response) => {
     return;
   }
   try {
-    const { description, amount, type, category, date, notes, participants, isRecurring, recurringFrequency, paymentMethod } = req.body;
+    const { description, amount, type, category, date, notes, participants, isRecurring, recurringFrequency, paymentMethod, currency, originalAmount, exchangeRate } = req.body;
 
     // Check for potential duplicates
     if (req.userId && typeof description === 'string' && typeof amount === 'number') {
@@ -130,6 +148,9 @@ router.post('/', expenseValidation, async (req: AuthRequest, res: Response) => {
       ...(isRecurring !== undefined && { isRecurring }),
       ...(recurringFrequency !== undefined && { recurringFrequency }),
       ...(paymentMethod !== undefined && { paymentMethod }),
+      ...(currency !== undefined && { currency }),
+      ...(originalAmount !== undefined && { originalAmount }),
+      ...(exchangeRate !== undefined && { exchangeRate }),
     });
     const saved = await expense.save();
     const result = saved.toObject();
@@ -154,12 +175,15 @@ router.put('/:id', expenseValidation, async (req: AuthRequest, res: Response) =>
     return;
   }
   try {
-    const { description, amount, type, category, date, notes, participants, isRecurring, recurringFrequency, paymentMethod } = req.body;
+    const { description, amount, type, category, date, notes, participants, isRecurring, recurringFrequency, paymentMethod, currency, originalAmount, exchangeRate } = req.body;
     const updateData: Record<string, unknown> = { description, amount, type, category, date, notes };
     if (Array.isArray(participants)) updateData.participants = participants; else updateData.participants = [];
     if (isRecurring !== undefined) updateData.isRecurring = isRecurring;
     if (recurringFrequency !== undefined) updateData.recurringFrequency = recurringFrequency;
     if (paymentMethod !== undefined) updateData.paymentMethod = paymentMethod;
+    if (currency !== undefined) updateData.currency = currency;
+    if (originalAmount !== undefined) updateData.originalAmount = originalAmount;
+    if (exchangeRate !== undefined) updateData.exchangeRate = exchangeRate;
     const updated = await ExpenseModel.findOneAndUpdate(
       { _id: req.params.id, owner: req.userId },
       { $set: updateData },

--- a/src/routes/expenses.ts
+++ b/src/routes/expenses.ts
@@ -1,7 +1,7 @@
 import { Router, Response } from 'express';
 import { body, validationResult } from 'express-validator';
 import { compareTwoStrings } from 'string-similarity';
-import ExpenseModel from '../models/Expense';
+import ExpenseModel, { PAYMENT_METHODS } from '../models/Expense';
 import { protect, AuthRequest } from '../middleware/auth';
 import { checkAndQueueBudgetAlerts } from '../utils/alerts';
 
@@ -45,9 +45,15 @@ const participantsValidation = body('participants')
     return true;
   });
 
+const paymentMethodValidation = body('paymentMethod')
+  .optional({ values: 'null' })
+  .isIn([...PAYMENT_METHODS])
+  .withMessage(`paymentMethod must be one of: ${PAYMENT_METHODS.join(', ')}`);
+
 const expenseValidation = [
   body('amount').isNumeric().withMessage('Amount must be a number'),
   participantsValidation,
+  paymentMethodValidation,
 ];
 
 // GET /api/expenses with pagination
@@ -57,13 +63,23 @@ router.get('/', async (req: AuthRequest, res: Response) => {
     const limit = Math.min(100, Math.max(1, parseInt(req.query.limit as string) || 20));
     const skip = (page - 1) * limit;
 
+    const filter: Record<string, unknown> = { owner: req.userId };
+    const paymentMethodQuery = req.query.paymentMethod as string | undefined;
+    if (paymentMethodQuery) {
+      if (!PAYMENT_METHODS.includes(paymentMethodQuery as typeof PAYMENT_METHODS[number])) {
+        res.status(400).json({ error: `Invalid paymentMethod filter. Must be one of: ${PAYMENT_METHODS.join(', ')}` });
+        return;
+      }
+      filter.paymentMethod = paymentMethodQuery;
+    }
+
     const [expenses, total] = await Promise.all([
-      ExpenseModel.find({ owner: req.userId })
+      ExpenseModel.find(filter)
         .sort({ date: -1, createdAt: -1 })
         .skip(skip)
         .limit(limit)
         .lean(),
-      ExpenseModel.countDocuments({ owner: req.userId }),
+      ExpenseModel.countDocuments(filter),
     ]);
 
     const pages = Math.ceil(total / limit);
@@ -95,7 +111,7 @@ router.post('/', expenseValidation, async (req: AuthRequest, res: Response) => {
     return;
   }
   try {
-    const { description, amount, type, category, date, notes, participants, isRecurring, recurringFrequency } = req.body;
+    const { description, amount, type, category, date, notes, participants, isRecurring, recurringFrequency, paymentMethod } = req.body;
 
     // Check for potential duplicates
     if (req.userId && typeof description === 'string' && typeof amount === 'number') {
@@ -113,6 +129,7 @@ router.post('/', expenseValidation, async (req: AuthRequest, res: Response) => {
       participants: Array.isArray(participants) ? participants : [],
       ...(isRecurring !== undefined && { isRecurring }),
       ...(recurringFrequency !== undefined && { recurringFrequency }),
+      ...(paymentMethod !== undefined && { paymentMethod }),
     });
     const saved = await expense.save();
     const result = saved.toObject();
@@ -137,11 +154,12 @@ router.put('/:id', expenseValidation, async (req: AuthRequest, res: Response) =>
     return;
   }
   try {
-    const { description, amount, type, category, date, notes, participants, isRecurring, recurringFrequency } = req.body;
+    const { description, amount, type, category, date, notes, participants, isRecurring, recurringFrequency, paymentMethod } = req.body;
     const updateData: Record<string, unknown> = { description, amount, type, category, date, notes };
     if (Array.isArray(participants)) updateData.participants = participants; else updateData.participants = [];
     if (isRecurring !== undefined) updateData.isRecurring = isRecurring;
     if (recurringFrequency !== undefined) updateData.recurringFrequency = recurringFrequency;
+    if (paymentMethod !== undefined) updateData.paymentMethod = paymentMethod;
     const updated = await ExpenseModel.findOneAndUpdate(
       { _id: req.params.id, owner: req.userId },
       { $set: updateData },

--- a/src/routes/expenses.ts
+++ b/src/routes/expenses.ts
@@ -129,7 +129,7 @@ router.post('/', expenseValidation, async (req: AuthRequest, res: Response) => {
     return;
   }
   try {
-    const { description, amount, type, category, date, notes, participants, isRecurring, recurringFrequency, paymentMethod, currency, originalAmount, exchangeRate } = req.body;
+    const { description, amount, type, category, date, notes, participants, isRecurring, recurringFrequency, paymentMethod, currency, originalAmount, exchangeRate, splitBill } = req.body;
 
     // Check for potential duplicates
     if (req.userId && typeof description === 'string' && typeof amount === 'number') {
@@ -151,6 +151,7 @@ router.post('/', expenseValidation, async (req: AuthRequest, res: Response) => {
       ...(currency !== undefined && { currency }),
       ...(originalAmount !== undefined && { originalAmount }),
       ...(exchangeRate !== undefined && { exchangeRate }),
+      ...(splitBill !== undefined && { splitBill }),
     });
     const saved = await expense.save();
     const result = saved.toObject();
@@ -180,7 +181,7 @@ router.put('/:id', expenseValidation, async (req: AuthRequest, res: Response) =>
       res.status(404).json({ error: 'Expense not found' });
       return;
     }
-    const { description, amount, type, category, date, participants, paymentMethod, currency, originalAmount, exchangeRate } = req.body;
+    const { description, amount, type, category, date, participants, paymentMethod, currency, originalAmount, exchangeRate, splitBill } = req.body;
     expense.description = description;
     expense.amount = amount;
     expense.type = type;
@@ -191,6 +192,7 @@ router.put('/:id', expenseValidation, async (req: AuthRequest, res: Response) =>
     if (currency !== undefined) expense.currency = currency;
     if (originalAmount !== undefined) expense.originalAmount = originalAmount;
     if (exchangeRate !== undefined) expense.exchangeRate = exchangeRate;
+    expense.splitBill = splitBill !== undefined ? splitBill : false;
     await expense.save();
     res.json(expense.toObject());
   } catch {

--- a/src/routes/expenses.ts
+++ b/src/routes/expenses.ts
@@ -12,11 +12,24 @@ const expenseValidation = [
   body('amount').isNumeric().withMessage('Amount must be a number'),
 ];
 
-// GET /api/expenses
+// GET /api/expenses with pagination
 router.get('/', async (req: AuthRequest, res: Response) => {
   try {
-    const expenses = await ExpenseModel.find({ owner: req.userId }).sort({ date: -1, createdAt: -1 }).lean();
-    res.json(expenses);
+    const page = Math.max(1, parseInt(req.query.page as string) || 1);
+    const limit = Math.min(100, Math.max(1, parseInt(req.query.limit as string) || 20));
+    const skip = (page - 1) * limit;
+
+    const [expenses, total] = await Promise.all([
+      ExpenseModel.find({ owner: req.userId })
+        .sort({ date: -1, createdAt: -1 })
+        .skip(skip)
+        .limit(limit)
+        .lean(),
+      ExpenseModel.countDocuments({ owner: req.userId }),
+    ]);
+
+    const pages = Math.ceil(total / limit);
+    res.json({ data: expenses, total, page, pages });
   } catch {
     res.status(500).json({ error: 'Failed to fetch expenses' });
   }

--- a/src/routes/expenses.ts
+++ b/src/routes/expenses.ts
@@ -15,7 +15,7 @@ const expenseValidation = [
 // GET /api/expenses
 router.get('/', async (req: AuthRequest, res: Response) => {
   try {
-    const expenses = await ExpenseModel.find({ owner: req.userId }).sort({ date: -1, createdAt: -1 });
+    const expenses = await ExpenseModel.find({ owner: req.userId }).sort({ date: -1, createdAt: -1 }).lean();
     res.json(expenses);
   } catch {
     res.status(500).json({ error: 'Failed to fetch expenses' });
@@ -25,7 +25,7 @@ router.get('/', async (req: AuthRequest, res: Response) => {
 // GET /api/expenses/:id
 router.get('/:id', async (req: AuthRequest, res: Response) => {
   try {
-    const expense = await ExpenseModel.findOne({ _id: req.params.id, owner: req.userId });
+    const expense = await ExpenseModel.findOne({ _id: req.params.id, owner: req.userId }).lean();
     if (!expense) {
       res.status(404).json({ error: 'Expense not found' });
       return;
@@ -46,7 +46,7 @@ router.post('/', expenseValidation, async (req: AuthRequest, res: Response) => {
   try {
     const expense = new ExpenseModel(req.body);
     const saved = await expense.save();
-    res.status(201).json(saved);
+    res.status(201).json(saved.toObject());
   } catch {
     res.status(400).json({ error: 'Failed to create expense' });
   }
@@ -62,15 +62,17 @@ router.put('/:id', expenseValidation, async (req: AuthRequest, res: Response) =>
   try {
     // Explicitly $set to ensure array fields (like participants) are saved correctly
     const { _id, __v, createdAt, updatedAt, ...fields } = req.body;
-    const updated = await ExpenseModel.findOneAndUpdate(
+    const result = await ExpenseModel.findOneAndUpdate(
       { _id: req.params.id, owner: req.userId },
       { $set: fields },
-      { new: true, runValidators: false }
+      { runValidators: false, strict: false }
     );
-    if (!updated) {
+    if (!result) {
       res.status(404).json({ error: 'Expense not found' });
       return;
     }
+    // Re-fetch with lean() to get the actual stored document including all array fields
+    const updated = await ExpenseModel.findOne({ _id: req.params.id, owner: req.userId }).lean();
     res.json(updated);
   } catch {
     res.status(400).json({ error: 'Failed to update expense' });

--- a/src/routes/expenses.ts
+++ b/src/routes/expenses.ts
@@ -93,8 +93,8 @@ router.get('/analytics', async (req: AuthRequest, res: Response) => {
       month = now.getMonth() + 1;
     }
 
-    const startDate = new Date(year, month - 1, 1);
-    const endDate = new Date(year, month, 1);
+    const startDate = new Date(Date.UTC(year, month - 1, 1));
+    const endDate = new Date(Date.UTC(year, month, 1));
 
     const matchStage = {
       $match: {

--- a/src/routes/expenses.ts
+++ b/src/routes/expenses.ts
@@ -1,11 +1,31 @@
 import { Router, Response } from 'express';
 import { body, validationResult } from 'express-validator';
+import { compareTwoStrings } from 'string-similarity';
 import ExpenseModel from '../models/Expense';
 import { protect, AuthRequest } from '../middleware/auth';
+import { checkAndQueueBudgetAlerts } from '../utils/alerts';
 
 const router = Router();
 
 router.use(protect);
+
+// Helper: check for potential duplicates in the last 24 hours
+async function checkDuplicates(userId: string, description: string, amount: number) {
+  const last24h = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  const recentExpenses = await ExpenseModel.find({
+    owner: userId,
+    amount: amount,
+    createdAt: { $gte: last24h },
+  }).lean();
+
+  const potential = recentExpenses.filter((exp) => {
+    if (!exp.description) return false;
+    const similarity = compareTwoStrings(description.toLowerCase(), exp.description.toLowerCase());
+    return similarity >= 0.9;
+  });
+
+  return potential.length > 0 ? potential[0] : null;
+}
 
 const participantsValidation = body('participants')
   .optional()
@@ -76,6 +96,17 @@ router.post('/', expenseValidation, async (req: AuthRequest, res: Response) => {
   }
   try {
     const { description, amount, type, category, date, notes, participants, isRecurring, recurringFrequency } = req.body;
+
+    // Check for potential duplicates
+    if (req.userId && typeof description === 'string' && typeof amount === 'number') {
+      const duplicate = await checkDuplicates(req.userId, description, amount);
+      if (duplicate) {
+        const minutesAgo = Math.round((Date.now() - new Date(duplicate.createdAt || '').getTime()) / 60000);
+        res.status(409).json({ error: `Potential duplicate detected. Similar transaction created ${minutesAgo} minutes ago.` });
+        return;
+      }
+    }
+
     const expense = new ExpenseModel({
       owner: req.userId,
       description, amount, type, category, date, notes,
@@ -86,6 +117,13 @@ router.post('/', expenseValidation, async (req: AuthRequest, res: Response) => {
     const saved = await expense.save();
     const result = saved.toObject();
     res.status(201).json(result);
+
+    // Check budget alerts asynchronously (don't block response)
+    if (req.userId) {
+      checkAndQueueBudgetAlerts(req.userId).catch((error) => {
+        console.error('Error queuing budget alerts:', error);
+      });
+    }
   } catch {
     res.status(400).json({ error: 'Failed to create expense' });
   }

--- a/src/routes/expenses.ts
+++ b/src/routes/expenses.ts
@@ -74,6 +74,63 @@ const expenseValidation = [
   paymentMethodValidation,
 ];
 
+// GET /api/expenses/last-amounts — map of item/description → most recent amount
+router.get('/last-amounts', async (req: AuthRequest, res: Response) => {
+  try {
+    const results = await ExpenseModel.aggregate([
+      { $match: { owner: req.userId } },
+      { $sort: { date: -1, createdAt: -1 } },
+      {
+        $group: {
+          _id: { $toLower: { $ifNull: ['$item', '$description'] } },
+          amount: { $first: '$amount' },
+          date: { $first: '$date' },
+        },
+      },
+    ]);
+    const map: Record<string, number> = {};
+    for (const r of results) {
+      if (r._id) map[r._id] = r.amount;
+    }
+    res.json(map);
+  } catch {
+    res.status(500).json({ error: 'Failed to fetch last amounts' });
+  }
+});
+
+// GET /api/expenses/price-history/:item — price history for a specific item
+router.get('/price-history/:item', async (req: AuthRequest, res: Response) => {
+  try {
+    const itemName = req.params.item;
+    const limit = Math.min(100, Math.max(1, parseInt(req.query.limit as string) || 20));
+
+    const results = await ExpenseModel.find({
+      owner: req.userId,
+      $or: [
+        { item: { $regex: new RegExp(`^${itemName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, 'i') } },
+        { description: { $regex: new RegExp(`^${itemName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, 'i') } },
+      ],
+    })
+      .sort({ date: -1, createdAt: -1 })
+      .limit(limit)
+      .select('amount date description item category currency')
+      .lean();
+
+    const amounts = results.map((r) => r.amount);
+    const stats = amounts.length > 0 ? {
+      count: amounts.length,
+      latest: amounts[0],
+      min: Math.min(...amounts),
+      max: Math.max(...amounts),
+      avg: Math.round((amounts.reduce((s, a) => s + a, 0) / amounts.length) * 100) / 100,
+    } : null;
+
+    res.json({ item: itemName, history: results, stats });
+  } catch {
+    res.status(500).json({ error: 'Failed to fetch price history' });
+  }
+});
+
 // GET /api/expenses/analytics
 router.get('/analytics', async (req: AuthRequest, res: Response) => {
   try {

--- a/src/routes/expenses.ts
+++ b/src/routes/expenses.ts
@@ -64,9 +64,12 @@ router.put('/:id', expenseValidation, async (req: AuthRequest, res: Response) =>
   try {
     // Explicitly $set to ensure array fields (like participants) are saved correctly
     const { _id, __v, createdAt, updatedAt, ...fields } = req.body;
+    // Ensure participants is always an array (empty if not provided)
+    const { participants = [] } = fields;
+    const updateFields = { ...fields, participants };
     const result = await ExpenseModel.findOneAndUpdate(
       { _id: req.params.id, owner: req.userId },
-      { $set: fields },
+      { $set: updateFields },
       { runValidators: false, strict: false }
     );
     if (!result) {

--- a/src/routes/expenses.ts
+++ b/src/routes/expenses.ts
@@ -142,18 +142,16 @@ router.put('/:id', expenseValidation, async (req: AuthRequest, res: Response) =>
     if (Array.isArray(participants)) updateData.participants = participants; else updateData.participants = [];
     if (isRecurring !== undefined) updateData.isRecurring = isRecurring;
     if (recurringFrequency !== undefined) updateData.recurringFrequency = recurringFrequency;
-    const result = await ExpenseModel.findOneAndUpdate(
+    const updated = await ExpenseModel.findOneAndUpdate(
       { _id: req.params.id, owner: req.userId },
       { $set: updateData },
-      { new: false, runValidators: true, strict: true }
+      { new: true, runValidators: true }
     );
-    if (!result) {
+    if (!updated) {
       res.status(404).json({ error: 'Expense not found' });
       return;
     }
-    // Re-fetch to get the actual stored document including all fields
-    const updated = await ExpenseModel.findOne({ _id: req.params.id, owner: req.userId }).lean();
-    res.json(updated);
+    res.json(updated.toObject());
   } catch {
     res.status(400).json({ error: 'Failed to update expense' });
   }

--- a/src/routes/expenses.ts
+++ b/src/routes/expenses.ts
@@ -44,11 +44,15 @@ router.post('/', expenseValidation, async (req: AuthRequest, res: Response) => {
     return;
   }
   try {
-    // Ensure participants is always an array (empty if not provided)
-    const { participants = [] } = req.body;
-    const expense = new ExpenseModel({ ...req.body, participants });
+    const expenseData = req.body;
+    // Explicitly set participants if not provided
+    if (!expenseData.participants || !Array.isArray(expenseData.participants)) {
+      expenseData.participants = [];
+    }
+    const expense = new ExpenseModel(expenseData);
     const saved = await expense.save();
-    res.status(201).json(saved.toObject());
+    const result = saved.toObject();
+    res.status(201).json(result);
   } catch {
     res.status(400).json({ error: 'Failed to create expense' });
   }
@@ -62,21 +66,22 @@ router.put('/:id', expenseValidation, async (req: AuthRequest, res: Response) =>
     return;
   }
   try {
-    // Explicitly $set to ensure array fields (like participants) are saved correctly
-    const { _id, __v, createdAt, updatedAt, ...fields } = req.body;
+    // Extract fields excluding system fields
+    const { _id, __v, createdAt, updatedAt, ...updateData } = req.body;
     // Ensure participants is always an array (empty if not provided)
-    const { participants = [] } = fields;
-    const updateFields = { ...fields, participants };
+    if (!updateData.participants || !Array.isArray(updateData.participants)) {
+      updateData.participants = [];
+    }
     const result = await ExpenseModel.findOneAndUpdate(
       { _id: req.params.id, owner: req.userId },
-      { $set: updateFields },
+      { $set: updateData },
       { runValidators: false, strict: false }
     );
     if (!result) {
       res.status(404).json({ error: 'Expense not found' });
       return;
     }
-    // Re-fetch with lean() to get the actual stored document including all array fields
+    // Re-fetch to get the actual stored document including all fields
     const updated = await ExpenseModel.findOne({ _id: req.params.id, owner: req.userId }).lean();
     res.json(updated);
   } catch {

--- a/src/routes/expenses.ts
+++ b/src/routes/expenses.ts
@@ -13,9 +13,9 @@ const expenseValidation = [
 ];
 
 // GET /api/expenses
-router.get('/', async (_req: AuthRequest, res: Response) => {
+router.get('/', async (req: AuthRequest, res: Response) => {
   try {
-    const expenses = await ExpenseModel.find().sort({ createdAt: -1 });
+    const expenses = await ExpenseModel.find({ owner: req.userId }).sort({ date: -1, createdAt: -1 });
     res.json(expenses);
   } catch {
     res.status(500).json({ error: 'Failed to fetch expenses' });
@@ -25,7 +25,7 @@ router.get('/', async (_req: AuthRequest, res: Response) => {
 // GET /api/expenses/:id
 router.get('/:id', async (req: AuthRequest, res: Response) => {
   try {
-    const expense = await ExpenseModel.findById(req.params.id);
+    const expense = await ExpenseModel.findOne({ _id: req.params.id, owner: req.userId });
     if (!expense) {
       res.status(404).json({ error: 'Expense not found' });
       return;
@@ -60,8 +60,8 @@ router.put('/:id', expenseValidation, async (req: AuthRequest, res: Response) =>
     return;
   }
   try {
-    const updated = await ExpenseModel.findByIdAndUpdate(
-      req.params.id,
+    const updated = await ExpenseModel.findOneAndUpdate(
+      { _id: req.params.id, owner: req.userId },
       req.body,
       { new: true, runValidators: true }
     );
@@ -78,7 +78,7 @@ router.put('/:id', expenseValidation, async (req: AuthRequest, res: Response) =>
 // DELETE /api/expenses/:id
 router.delete('/:id', async (req: AuthRequest, res: Response) => {
   try {
-    const deleted = await ExpenseModel.findByIdAndDelete(req.params.id);
+    const deleted = await ExpenseModel.findOneAndDelete({ _id: req.params.id, owner: req.userId });
     if (!deleted) {
       res.status(404).json({ error: 'Expense not found' });
       return;

--- a/src/routes/expenses.ts
+++ b/src/routes/expenses.ts
@@ -175,25 +175,24 @@ router.put('/:id', expenseValidation, async (req: AuthRequest, res: Response) =>
     return;
   }
   try {
-    const { description, amount, type, category, date, notes, participants, isRecurring, recurringFrequency, paymentMethod, currency, originalAmount, exchangeRate } = req.body;
-    const updateData: Record<string, unknown> = { description, amount, type, category, date, notes };
-    if (Array.isArray(participants)) updateData.participants = participants; else updateData.participants = [];
-    if (isRecurring !== undefined) updateData.isRecurring = isRecurring;
-    if (recurringFrequency !== undefined) updateData.recurringFrequency = recurringFrequency;
-    if (paymentMethod !== undefined) updateData.paymentMethod = paymentMethod;
-    if (currency !== undefined) updateData.currency = currency;
-    if (originalAmount !== undefined) updateData.originalAmount = originalAmount;
-    if (exchangeRate !== undefined) updateData.exchangeRate = exchangeRate;
-    const updated = await ExpenseModel.findOneAndUpdate(
-      { _id: req.params.id, owner: req.userId },
-      { $set: updateData },
-      { new: true, runValidators: true }
-    );
-    if (!updated) {
+    const expense = await ExpenseModel.findOne({ _id: req.params.id, owner: req.userId });
+    if (!expense) {
       res.status(404).json({ error: 'Expense not found' });
       return;
     }
-    res.json(updated.toObject());
+    const { description, amount, type, category, date, participants, paymentMethod, currency, originalAmount, exchangeRate } = req.body;
+    expense.description = description;
+    expense.amount = amount;
+    expense.type = type;
+    expense.category = category;
+    expense.date = date;
+    expense.participants = Array.isArray(participants) ? participants : [];
+    if (paymentMethod !== undefined) expense.paymentMethod = paymentMethod;
+    if (currency !== undefined) expense.currency = currency;
+    if (originalAmount !== undefined) expense.originalAmount = originalAmount;
+    if (exchangeRate !== undefined) expense.exchangeRate = exchangeRate;
+    await expense.save();
+    res.json(expense.toObject());
   } catch {
     res.status(400).json({ error: 'Failed to update expense' });
   }

--- a/src/routes/expenses.ts
+++ b/src/routes/expenses.ts
@@ -60,10 +60,12 @@ router.put('/:id', expenseValidation, async (req: AuthRequest, res: Response) =>
     return;
   }
   try {
+    // Explicitly $set to ensure array fields (like participants) are saved correctly
+    const { _id, __v, createdAt, updatedAt, ...fields } = req.body;
     const updated = await ExpenseModel.findOneAndUpdate(
       { _id: req.params.id, owner: req.userId },
-      req.body,
-      { new: true, runValidators: true }
+      { $set: fields },
+      { new: true, runValidators: false }
     );
     if (!updated) {
       res.status(404).json({ error: 'Expense not found' });

--- a/src/routes/expenses.ts
+++ b/src/routes/expenses.ts
@@ -93,8 +93,9 @@ router.get('/last-amounts', async (req: AuthRequest, res: Response) => {
       if (r._id) map[r._id] = r.amount;
     }
     res.json(map);
-  } catch {
-    res.status(500).json({ error: 'Failed to fetch last amounts' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to fetch last amounts';
+    res.status(500).json({ error: message });
   }
 });
 
@@ -126,8 +127,9 @@ router.get('/price-history/:item', async (req: AuthRequest, res: Response) => {
     } : null;
 
     res.json({ item: itemName, history: results, stats });
-  } catch {
-    res.status(500).json({ error: 'Failed to fetch price history' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to fetch price history';
+    res.status(500).json({ error: message });
   }
 });
 
@@ -222,8 +224,9 @@ router.get('/analytics', async (req: AuthRequest, res: Response) => {
       .map(([date, totals]) => ({ date, ...totals }));
 
     res.json({ totalIncome, totalExpense, netBalance, categoryBreakdown, dailyTotals });
-  } catch {
-    res.status(500).json({ error: 'Failed to fetch analytics' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to fetch analytics';
+    res.status(500).json({ error: message });
   }
 });
 
@@ -268,8 +271,9 @@ router.get('/', async (req: AuthRequest, res: Response) => {
       // Backward compat
       total, page, pages: totalPages,
     });
-  } catch {
-    res.status(500).json({ error: 'Failed to fetch expenses' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to fetch expenses';
+    res.status(500).json({ error: message });
   }
 });
 
@@ -282,8 +286,9 @@ router.get('/:id', async (req: AuthRequest, res: Response) => {
       return;
     }
     res.json(expense);
-  } catch {
-    res.status(500).json({ error: 'Failed to fetch expense' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to fetch expense';
+    res.status(500).json({ error: message });
   }
 });
 
@@ -329,8 +334,9 @@ router.post('/', expenseValidation, async (req: AuthRequest, res: Response) => {
         console.error('Error queuing budget alerts:', error);
       });
     }
-  } catch {
-    res.status(400).json({ error: 'Failed to create expense' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to create expense';
+    res.status(400).json({ error: message });
   }
 });
 
@@ -362,8 +368,9 @@ router.put('/:id', expenseValidation, async (req: AuthRequest, res: Response) =>
     expense.splitBill = splitBill !== undefined ? splitBill : false;
     await expense.save();
     res.json(expense.toObject());
-  } catch {
-    res.status(400).json({ error: 'Failed to update expense' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to update expense';
+    res.status(400).json({ error: message });
   }
 });
 
@@ -376,8 +383,9 @@ router.delete('/:id', async (req: AuthRequest, res: Response) => {
       return;
     }
     res.json({ message: 'Deleted' });
-  } catch {
-    res.status(500).json({ error: 'Failed to delete expense' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to delete expense';
+    res.status(500).json({ error: message });
   }
 });
 

--- a/src/routes/expenses.ts
+++ b/src/routes/expenses.ts
@@ -7,9 +7,27 @@ const router = Router();
 
 router.use(protect);
 
+const participantsValidation = body('participants')
+  .optional()
+  .custom((value) => {
+    if (value === undefined || value === null) return true;
+    if (!Array.isArray(value)) throw new Error('participants must be an array');
+    if (value.length > 20) throw new Error('participants cannot exceed 20 items');
+    const seen = new Set<string>();
+    for (const item of value) {
+      if (typeof item !== 'string') throw new Error('each participant must be a string');
+      if (item.trim() === '') throw new Error('participant names cannot be empty');
+      if (item.length > 100) throw new Error('participant names cannot exceed 100 characters');
+      const lower = item.toLowerCase();
+      if (seen.has(lower)) throw new Error(`duplicate participant: "${item}"`);
+      seen.add(lower);
+    }
+    return true;
+  });
+
 const expenseValidation = [
-  body('owner').notEmpty().withMessage('Owner is required'),
   body('amount').isNumeric().withMessage('Amount must be a number'),
+  participantsValidation,
 ];
 
 // GET /api/expenses with pagination
@@ -57,12 +75,14 @@ router.post('/', expenseValidation, async (req: AuthRequest, res: Response) => {
     return;
   }
   try {
-    const expenseData = req.body;
-    // Explicitly set participants if not provided
-    if (!expenseData.participants || !Array.isArray(expenseData.participants)) {
-      expenseData.participants = [];
-    }
-    const expense = new ExpenseModel(expenseData);
+    const { description, amount, type, category, date, notes, participants, isRecurring, recurringFrequency } = req.body;
+    const expense = new ExpenseModel({
+      owner: req.userId,
+      description, amount, type, category, date, notes,
+      participants: Array.isArray(participants) ? participants : [],
+      ...(isRecurring !== undefined && { isRecurring }),
+      ...(recurringFrequency !== undefined && { recurringFrequency }),
+    });
     const saved = await expense.save();
     const result = saved.toObject();
     res.status(201).json(result);
@@ -79,16 +99,15 @@ router.put('/:id', expenseValidation, async (req: AuthRequest, res: Response) =>
     return;
   }
   try {
-    // Extract fields excluding system fields
-    const { _id, __v, createdAt, updatedAt, ...updateData } = req.body;
-    // Ensure participants is always an array (empty if not provided)
-    if (!updateData.participants || !Array.isArray(updateData.participants)) {
-      updateData.participants = [];
-    }
+    const { description, amount, type, category, date, notes, participants, isRecurring, recurringFrequency } = req.body;
+    const updateData: Record<string, unknown> = { description, amount, type, category, date, notes };
+    if (Array.isArray(participants)) updateData.participants = participants; else updateData.participants = [];
+    if (isRecurring !== undefined) updateData.isRecurring = isRecurring;
+    if (recurringFrequency !== undefined) updateData.recurringFrequency = recurringFrequency;
     const result = await ExpenseModel.findOneAndUpdate(
       { _id: req.params.id, owner: req.userId },
       { $set: updateData },
-      { runValidators: false, strict: false }
+      { new: false, runValidators: true, strict: true }
     );
     if (!result) {
       res.status(404).json({ error: 'Expense not found' });

--- a/src/routes/expenses.ts
+++ b/src/routes/expenses.ts
@@ -238,7 +238,7 @@ router.post('/', expenseValidation, async (req: AuthRequest, res: Response) => {
     return;
   }
   try {
-    const { description, amount, type, category, date, notes, participants, isRecurring, recurringFrequency, paymentMethod, currency, originalAmount, exchangeRate, splitBill } = req.body;
+    const { description, amount, type, category, item, date, notes, participants, isRecurring, recurringFrequency, paymentMethod, currency, originalAmount, exchangeRate, splitBill } = req.body;
 
     // Check for potential duplicates
     if (req.userId && typeof description === 'string' && typeof amount === 'number') {
@@ -252,7 +252,7 @@ router.post('/', expenseValidation, async (req: AuthRequest, res: Response) => {
 
     const expense = new ExpenseModel({
       owner: req.userId,
-      description, amount, type, category, date, notes,
+      description, amount, type, category, item, date, notes,
       participants: Array.isArray(participants) ? participants : [],
       ...(isRecurring !== undefined && { isRecurring }),
       ...(recurringFrequency !== undefined && { recurringFrequency }),
@@ -290,11 +290,12 @@ router.put('/:id', expenseValidation, async (req: AuthRequest, res: Response) =>
       res.status(404).json({ error: 'Expense not found' });
       return;
     }
-    const { description, amount, type, category, date, participants, paymentMethod, currency, originalAmount, exchangeRate, splitBill } = req.body;
+    const { description, amount, type, category, item, date, participants, paymentMethod, currency, originalAmount, exchangeRate, splitBill } = req.body;
     expense.description = description;
     expense.amount = amount;
     expense.type = type;
     expense.category = category;
+    expense.item = item;
     expense.date = date;
     expense.participants = Array.isArray(participants) ? participants : [];
     if (paymentMethod !== undefined) expense.paymentMethod = paymentMethod;

--- a/src/routes/export.ts
+++ b/src/routes/export.ts
@@ -1,72 +1,291 @@
 import { Router } from 'express';
+import PDFDocument from 'pdfkit';
 import ExpenseModel from '../models/Expense';
+import { PAYMENT_METHODS } from '../models/Expense';
 import { protect, AuthRequest } from '../middleware/auth';
 
 const router = Router();
 
 router.use(protect);
 
+interface ExpenseRecord {
+  date?: string | Date;
+  createdAt?: string | Date;
+  description?: string;
+  category?: string;
+  type?: string;
+  amount?: number;
+  currency?: string;
+  originalAmount?: number;
+  exchangeRate?: number;
+  paymentMethod?: string;
+  participants?: string[];
+  item?: string;
+}
+
+/**
+ * Build a Mongoose filter from shared query params.
+ * Supports: from, to, type, category, q, paymentMethod, minAmount, maxAmount
+ */
+function buildExportFilter(
+  userId: string,
+  query: Record<string, string | undefined>
+): Record<string, unknown> {
+  const filter: Record<string, unknown> = { owner: userId };
+
+  const { from, to, type, category, q, paymentMethod, minAmount, maxAmount } = query;
+
+  // Date range
+  if (from || to) {
+    const dateFilter: Record<string, Date> = {};
+    if (from) dateFilter.$gte = new Date(from);
+    if (to) {
+      const toDate = new Date(to);
+      toDate.setHours(23, 59, 59, 999);
+      dateFilter.$lte = toDate;
+    }
+    filter.date = dateFilter;
+  }
+
+  // Type filter
+  if (type) filter.type = type;
+
+  // Category filter (exact match)
+  if (category) filter.category = category;
+
+  // Payment method filter
+  if (paymentMethod) {
+    if (PAYMENT_METHODS.includes(paymentMethod as typeof PAYMENT_METHODS[number])) {
+      filter.paymentMethod = paymentMethod;
+    }
+  }
+
+  // Amount range
+  const minAmt = parseFloat(minAmount || '');
+  const maxAmt = parseFloat(maxAmount || '');
+  if (!isNaN(minAmt) || !isNaN(maxAmt)) {
+    const amountFilter: Record<string, number> = {};
+    if (!isNaN(minAmt)) amountFilter.$gte = minAmt;
+    if (!isNaN(maxAmt)) amountFilter.$lte = maxAmt;
+    filter.amount = amountFilter;
+  }
+
+  // Text search
+  if (q) {
+    const escaped = q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const regex = { $regex: escaped, $options: 'i' };
+    filter.$or = [
+      { description: regex },
+      { category: regex },
+      { item: regex },
+      { participants: regex },
+    ];
+  }
+
+  return filter;
+}
+
+function formatDate(raw: string | Date | undefined): string {
+  if (!raw) return '';
+  return new Date(raw).toISOString().split('T')[0];
+}
+
+function escapeCSVCell(value: string): string {
+  if (value.includes(',') || value.includes('\n') || value.includes('"')) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
 // GET /api/export/csv
 router.get('/csv', async (req: AuthRequest, res) => {
   try {
-    const { from, to, type } = req.query;
+    const query = req.query as Record<string, string | undefined>;
+    const filter = buildExportFilter(req.userId || '', query);
 
-    // Build filter
-    const filter: any = { owner: req.userId };
-    if (from || to) {
-      filter.date = {};
-      if (from) filter.date.$gte = new Date(from as string);
-      if (to) {
-        const toDate = new Date(to as string);
-        toDate.setHours(23, 59, 59, 999);
-        filter.date.$lte = toDate;
-      }
-    }
-    if (type) filter.type = type;
-
-    // Fetch expenses with lean() for performance
     const expenses = await ExpenseModel.find(filter)
       .sort({ date: -1 })
       .lean();
 
-    // Build CSV
-    const headers = ['Date', 'Description', 'Category', 'Type', 'Amount (HKD)', 'Currency', 'Original Amount', 'Exchange Rate', 'Payment Method', 'Participants'];
-    const rows = expenses.map((e: Record<string, unknown>) => [
-      new Date((e.date || e.createdAt) as string).toISOString().split('T')[0],
-      (e.description as string) || '',
-      (e.category as string) || '',
-      (e.type as string) || '',
-      (e.amount as number) || 0,
-      (e.currency as string) || 'HKD',
-      (e.originalAmount as number) ?? '',
-      (e.exchangeRate as number) ?? '',
-      (e.paymentMethod as string) || '',
-      (e.participants as string[])?.join(';') || '',
+    const headers = [
+      'Date', 'Description', 'Category', 'Type',
+      'Amount (HKD)', 'Currency', 'Original Amount', 'Exchange Rate',
+      'Payment Method', 'Participants',
+    ];
+
+    const rows = (expenses as ExpenseRecord[]).map((e) => [
+      formatDate(e.date || e.createdAt),
+      e.description || '',
+      e.category || '',
+      e.type || '',
+      String(e.amount || 0),
+      e.currency || 'HKD',
+      e.originalAmount != null ? String(e.originalAmount) : '',
+      e.exchangeRate != null ? String(e.exchangeRate) : '',
+      e.paymentMethod || '',
+      e.participants?.join(';') || '',
     ]);
 
-    // Build CSV content
     const csv = [headers, ...rows]
-      .map((row) =>
-        row
-          .map((cell) => {
-            // Escape quotes and wrap in quotes if contains comma/newline
-            const str = String(cell);
-            if (str.includes(',') || str.includes('\n') || str.includes('"')) {
-              return `"${str.replace(/"/g, '""')}"`;
-            }
-            return str;
-          })
-          .join(',')
-      )
+      .map((row) => row.map((cell) => escapeCSVCell(String(cell))).join(','))
       .join('\n');
 
-    // Return CSV file
-    const filename = `money-flow-${new Date().toISOString().split('T')[0]}.csv`;
+    const filename = `money-flow-export-${new Date().toISOString().split('T')[0]}.csv`;
     res.setHeader('Content-Type', 'text/csv');
     res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
     res.send(csv);
   } catch {
     res.status(500).json({ error: 'Failed to export CSV' });
+  }
+});
+
+// GET /api/export/pdf
+router.get('/pdf', async (req: AuthRequest, res) => {
+  try {
+    const query = req.query as Record<string, string | undefined>;
+    const filter = buildExportFilter(req.userId || '', query);
+
+    const expenses = await ExpenseModel.find(filter)
+      .sort({ date: -1 })
+      .lean() as ExpenseRecord[];
+
+    const doc = new PDFDocument({ size: 'A4', margin: 40, bufferPages: true });
+
+    const filename = `money-flow-export-${new Date().toISOString().split('T')[0]}.pdf`;
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    doc.pipe(res);
+
+    // Header
+    doc.fontSize(18).text('Money Flow - Transaction Report', { align: 'center' });
+    doc.moveDown(0.3);
+
+    // Date range subtitle
+    const fromDate = query.from || '';
+    const toDate = query.to || '';
+    if (fromDate || toDate) {
+      const rangeText = fromDate && toDate
+        ? `${fromDate} to ${toDate}`
+        : fromDate
+          ? `From ${fromDate}`
+          : `Up to ${toDate}`;
+      doc.fontSize(10).text(rangeText, { align: 'center' });
+    }
+    doc.fontSize(10).text(`Generated: ${new Date().toISOString().split('T')[0]}`, { align: 'center' });
+    doc.moveDown(1);
+
+    if (expenses.length === 0) {
+      doc.fontSize(12).text('No transactions found for the selected filters.', { align: 'center' });
+      doc.end();
+      return;
+    }
+
+    // Transaction table
+    const colWidths = [65, 140, 75, 60, 70, 55, 50];
+    const colHeaders = ['Date', 'Description', 'Category', 'Type', 'Amount', 'Currency', 'Method'];
+    const tableLeft = 40;
+    const rowHeight = 18;
+
+    function drawTableHeader(yPos: number): number {
+      doc.fontSize(8).font('Helvetica-Bold');
+      let x = tableLeft;
+      for (let i = 0; i < colHeaders.length; i++) {
+        doc.text(colHeaders[i], x, yPos, { width: colWidths[i], align: 'left' });
+        x += colWidths[i];
+      }
+      const lineY = yPos + rowHeight - 4;
+      doc.moveTo(tableLeft, lineY)
+        .lineTo(tableLeft + colWidths.reduce((a, b) => a + b, 0), lineY)
+        .stroke();
+      return lineY + 4;
+    }
+
+    let y = drawTableHeader(doc.y);
+    doc.font('Helvetica').fontSize(7);
+
+    for (const expense of expenses) {
+      if (y > 750) {
+        doc.addPage();
+        y = drawTableHeader(40);
+        doc.font('Helvetica').fontSize(7);
+      }
+
+      const cells = [
+        formatDate(expense.date || expense.createdAt),
+        (expense.description || '').substring(0, 30),
+        (expense.category || '').substring(0, 15),
+        expense.type || '',
+        String(expense.amount || 0),
+        expense.currency || 'HKD',
+        expense.paymentMethod || '',
+      ];
+
+      let x = tableLeft;
+      for (let i = 0; i < cells.length; i++) {
+        doc.text(cells[i], x, y, { width: colWidths[i], align: 'left' });
+        x += colWidths[i];
+      }
+      y += rowHeight;
+    }
+
+    // Category summary section
+    doc.addPage();
+    doc.fontSize(14).font('Helvetica-Bold').text('Category Summary', { align: 'center' });
+    doc.moveDown(1);
+
+    const categoryTotals = new Map<string, { total: number; count: number }>();
+    let grandTotal = 0;
+
+    for (const expense of expenses) {
+      const cat = expense.category || 'Uncategorised';
+      const amt = expense.amount || 0;
+      const existing = categoryTotals.get(cat) || { total: 0, count: 0 };
+      existing.total += amt;
+      existing.count += 1;
+      categoryTotals.set(cat, existing);
+      grandTotal += amt;
+    }
+
+    const sortedCategories = Array.from(categoryTotals.entries())
+      .sort(([, a], [, b]) => b.total - a.total);
+
+    doc.font('Helvetica-Bold').fontSize(9);
+    const summaryColWidths = [180, 100, 80, 80];
+    let sx = tableLeft;
+    const summaryHeaders = ['Category', 'Total', 'Transactions', '% of Total'];
+    for (let i = 0; i < summaryHeaders.length; i++) {
+      doc.text(summaryHeaders[i], sx, doc.y, { width: summaryColWidths[i], align: 'left', continued: i < summaryHeaders.length - 1 });
+      sx += summaryColWidths[i];
+    }
+    doc.text('');
+    const summaryLineY = doc.y + 2;
+    doc.moveTo(tableLeft, summaryLineY)
+      .lineTo(tableLeft + summaryColWidths.reduce((a, b) => a + b, 0), summaryLineY)
+      .stroke();
+    doc.moveDown(0.3);
+
+    doc.font('Helvetica').fontSize(8);
+    for (const [category, data] of sortedCategories) {
+      const pct = grandTotal > 0 ? ((data.total / grandTotal) * 100).toFixed(1) : '0.0';
+      sx = tableLeft;
+      const vals = [category, data.total.toFixed(2), String(data.count), `${pct}%`];
+      for (let i = 0; i < vals.length; i++) {
+        doc.text(vals[i], sx, doc.y, { width: summaryColWidths[i], align: 'left', continued: i < vals.length - 1 });
+        sx += summaryColWidths[i];
+      }
+      doc.text('');
+    }
+
+    doc.moveDown(0.5);
+    doc.font('Helvetica-Bold').fontSize(9);
+    doc.text(`Total: ${grandTotal.toFixed(2)}    |    ${expenses.length} transactions`);
+
+    doc.end();
+  } catch {
+    // If headers already sent, we can't send JSON error
+    if (!res.headersSent) {
+      res.status(500).json({ error: 'Failed to export PDF' });
+    }
   }
 });
 

--- a/src/routes/export.ts
+++ b/src/routes/export.ts
@@ -30,14 +30,15 @@ router.get('/csv', async (req: AuthRequest, res) => {
       .lean();
 
     // Build CSV
-    const headers = ['Date', 'Description', 'Category', 'Type', 'Amount', 'Participants'];
-    const rows = expenses.map((e: any) => [
-      new Date(e.date || e.createdAt).toISOString().split('T')[0],
-      e.description || '',
-      e.category || '',
-      e.type || '',
-      e.amount || 0,
-      e.participants?.join(';') || '',
+    const headers = ['Date', 'Description', 'Category', 'Type', 'Amount', 'Payment Method', 'Participants'];
+    const rows = expenses.map((e: Record<string, unknown>) => [
+      new Date((e.date || e.createdAt) as string).toISOString().split('T')[0],
+      (e.description as string) || '',
+      (e.category as string) || '',
+      (e.type as string) || '',
+      (e.amount as number) || 0,
+      (e.paymentMethod as string) || '',
+      (e.participants as string[])?.join(';') || '',
     ]);
 
     // Build CSV content

--- a/src/routes/export.ts
+++ b/src/routes/export.ts
@@ -134,8 +134,9 @@ router.get('/csv', async (req: AuthRequest, res) => {
     res.setHeader('Content-Type', 'text/csv');
     res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
     res.send(csv);
-  } catch {
-    res.status(500).json({ error: 'Failed to export CSV' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to export CSV';
+    res.status(500).json({ error: message });
   }
 });
 

--- a/src/routes/export.ts
+++ b/src/routes/export.ts
@@ -30,13 +30,16 @@ router.get('/csv', async (req: AuthRequest, res) => {
       .lean();
 
     // Build CSV
-    const headers = ['Date', 'Description', 'Category', 'Type', 'Amount', 'Payment Method', 'Participants'];
+    const headers = ['Date', 'Description', 'Category', 'Type', 'Amount (HKD)', 'Currency', 'Original Amount', 'Exchange Rate', 'Payment Method', 'Participants'];
     const rows = expenses.map((e: Record<string, unknown>) => [
       new Date((e.date || e.createdAt) as string).toISOString().split('T')[0],
       (e.description as string) || '',
       (e.category as string) || '',
       (e.type as string) || '',
       (e.amount as number) || 0,
+      (e.currency as string) || 'HKD',
+      (e.originalAmount as number) ?? '',
+      (e.exchangeRate as number) ?? '',
       (e.paymentMethod as string) || '',
       (e.participants as string[])?.join(';') || '',
     ]);

--- a/src/routes/export.ts
+++ b/src/routes/export.ts
@@ -1,0 +1,69 @@
+import { Router } from 'express';
+import ExpenseModel from '../models/Expense';
+import { protect, AuthRequest } from '../middleware/auth';
+
+const router = Router();
+
+router.use(protect);
+
+// GET /api/export/csv
+router.get('/csv', async (req: AuthRequest, res) => {
+  try {
+    const { from, to, type } = req.query;
+
+    // Build filter
+    const filter: any = { owner: req.userId };
+    if (from || to) {
+      filter.date = {};
+      if (from) filter.date.$gte = new Date(from as string);
+      if (to) {
+        const toDate = new Date(to as string);
+        toDate.setHours(23, 59, 59, 999);
+        filter.date.$lte = toDate;
+      }
+    }
+    if (type) filter.type = type;
+
+    // Fetch expenses with lean() for performance
+    const expenses = await ExpenseModel.find(filter)
+      .sort({ date: -1 })
+      .lean();
+
+    // Build CSV
+    const headers = ['Date', 'Description', 'Category', 'Type', 'Amount', 'Participants'];
+    const rows = expenses.map((e: any) => [
+      new Date(e.date || e.createdAt).toISOString().split('T')[0],
+      e.description || '',
+      e.category || '',
+      e.type || '',
+      e.amount || 0,
+      e.participants?.join(';') || '',
+    ]);
+
+    // Build CSV content
+    const csv = [headers, ...rows]
+      .map((row) =>
+        row
+          .map((cell) => {
+            // Escape quotes and wrap in quotes if contains comma/newline
+            const str = String(cell);
+            if (str.includes(',') || str.includes('\n') || str.includes('"')) {
+              return `"${str.replace(/"/g, '""')}"`;
+            }
+            return str;
+          })
+          .join(',')
+      )
+      .join('\n');
+
+    // Return CSV file
+    const filename = `money-flow-${new Date().toISOString().split('T')[0]}.csv`;
+    res.setHeader('Content-Type', 'text/csv');
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    res.send(csv);
+  } catch {
+    res.status(500).json({ error: 'Failed to export CSV' });
+  }
+});
+
+export default router;

--- a/src/routes/friends.ts
+++ b/src/routes/friends.ts
@@ -1,0 +1,193 @@
+import { Router, Response } from 'express';
+import { body, validationResult } from 'express-validator';
+import { protect, AuthRequest } from '../middleware/auth';
+import FriendshipModel from '../models/Friendship';
+import UserModel from '../models/User';
+
+const router = Router();
+router.use(protect);
+
+// POST /api/friends/request — send friend request by email
+router.post(
+  '/request',
+  body('email').isEmail().withMessage('Valid email required'),
+  async (req: AuthRequest, res: Response) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({ error: errors.array()[0].msg });
+      return;
+    }
+    try {
+      const email = (req.body.email as string).toLowerCase().trim();
+
+      // Find recipient user
+      const recipient = await UserModel.findOne({ email }).lean();
+      if (!recipient) {
+        res.status(404).json({ error: 'User not found' });
+        return;
+      }
+
+      const recipientId = String(recipient._id);
+
+      // Cannot friend yourself
+      if (recipientId === req.userId) {
+        res.status(400).json({ error: 'Cannot send friend request to yourself' });
+        return;
+      }
+
+      // Check for existing friendship in either direction
+      const existing = await FriendshipModel.findOne({
+        $or: [
+          { requester: req.userId, recipient: recipientId },
+          { requester: recipientId, recipient: req.userId },
+        ],
+      });
+
+      if (existing) {
+        if (existing.status === 'accepted') {
+          res.status(409).json({ error: 'Already friends' });
+          return;
+        }
+        if (existing.status === 'pending') {
+          res.status(409).json({ error: 'Friend request already pending' });
+          return;
+        }
+        // If rejected, allow re-request by updating
+        existing.status = 'pending';
+        existing.requester = req.userId!;
+        existing.recipient = recipientId;
+        await existing.save();
+        res.status(201).json({ id: existing._id, status: 'pending', email });
+        return;
+      }
+
+      const friendship = await FriendshipModel.create({
+        requester: req.userId,
+        recipient: recipientId,
+        status: 'pending',
+      });
+
+      res.status(201).json({ id: friendship._id, status: 'pending', email });
+    } catch {
+      res.status(500).json({ error: 'Failed to send friend request' });
+    }
+  }
+);
+
+// GET /api/friends — list accepted friends
+router.get('/', async (req: AuthRequest, res: Response) => {
+  try {
+    const friendships = await FriendshipModel.find({
+      $or: [{ requester: req.userId }, { recipient: req.userId }],
+      status: 'accepted',
+    }).lean();
+
+    const friendIds = friendships.map((f) =>
+      f.requester === req.userId ? f.recipient : f.requester
+    );
+
+    const users = await UserModel.find({ _id: { $in: friendIds } })
+      .select('email')
+      .lean();
+
+    const friends = friendships.map((f) => {
+      const friendId = f.requester === req.userId ? f.recipient : f.requester;
+      const user = users.find((u) => String(u._id) === friendId);
+      return { id: String(f._id), email: user?.email || 'unknown', since: f.createdAt };
+    });
+
+    res.json({ friends });
+  } catch {
+    res.status(500).json({ error: 'Failed to fetch friends' });
+  }
+});
+
+// GET /api/friends/pending — list incoming pending requests
+router.get('/pending', async (req: AuthRequest, res: Response) => {
+  try {
+    const pending = await FriendshipModel.find({
+      recipient: req.userId,
+      status: 'pending',
+    }).lean();
+
+    const requesterIds = pending.map((p) => p.requester);
+    const users = await UserModel.find({ _id: { $in: requesterIds } })
+      .select('email')
+      .lean();
+
+    const requests = pending.map((p) => {
+      const user = users.find((u) => String(u._id) === p.requester);
+      return { id: String(p._id), email: user?.email || 'unknown', createdAt: p.createdAt };
+    });
+
+    res.json({ requests });
+  } catch {
+    res.status(500).json({ error: 'Failed to fetch pending requests' });
+  }
+});
+
+// POST /api/friends/:id/accept
+router.post('/:id/accept', async (req: AuthRequest, res: Response) => {
+  try {
+    const friendship = await FriendshipModel.findOne({
+      _id: req.params.id,
+      recipient: req.userId,
+      status: 'pending',
+    });
+
+    if (!friendship) {
+      res.status(404).json({ error: 'Pending request not found' });
+      return;
+    }
+
+    friendship.status = 'accepted';
+    await friendship.save();
+    res.json({ status: 'accepted' });
+  } catch {
+    res.status(500).json({ error: 'Failed to accept request' });
+  }
+});
+
+// POST /api/friends/:id/reject
+router.post('/:id/reject', async (req: AuthRequest, res: Response) => {
+  try {
+    const friendship = await FriendshipModel.findOne({
+      _id: req.params.id,
+      recipient: req.userId,
+      status: 'pending',
+    });
+
+    if (!friendship) {
+      res.status(404).json({ error: 'Pending request not found' });
+      return;
+    }
+
+    await friendship.deleteOne();
+    res.json({ status: 'removed' });
+  } catch {
+    res.status(500).json({ error: 'Failed to reject request' });
+  }
+});
+
+// DELETE /api/friends/:id — unfriend
+router.delete('/:id', async (req: AuthRequest, res: Response) => {
+  try {
+    const friendship = await FriendshipModel.findOne({
+      _id: req.params.id,
+      $or: [{ requester: req.userId }, { recipient: req.userId }],
+      status: 'accepted',
+    });
+
+    if (!friendship) {
+      res.status(404).json({ error: 'Friendship not found' });
+      return;
+    }
+
+    await friendship.deleteOne();
+    res.json({ status: 'removed' });
+  } catch {
+    res.status(500).json({ error: 'Failed to remove friend' });
+  }
+});
+
+export default router;

--- a/src/routes/friends.ts
+++ b/src/routes/friends.ts
@@ -68,8 +68,9 @@ router.post(
       });
 
       res.status(201).json({ id: friendship._id, status: 'pending', email });
-    } catch {
-      res.status(500).json({ error: 'Failed to send friend request' });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to send friend request';
+      res.status(500).json({ error: message });
     }
   }
 );
@@ -97,8 +98,9 @@ router.get('/', async (req: AuthRequest, res: Response) => {
     });
 
     res.json({ friends });
-  } catch {
-    res.status(500).json({ error: 'Failed to fetch friends' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to fetch friends';
+    res.status(500).json({ error: message });
   }
 });
 
@@ -121,8 +123,9 @@ router.get('/pending', async (req: AuthRequest, res: Response) => {
     });
 
     res.json({ requests });
-  } catch {
-    res.status(500).json({ error: 'Failed to fetch pending requests' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to fetch pending requests';
+    res.status(500).json({ error: message });
   }
 });
 
@@ -143,8 +146,9 @@ router.post('/:id/accept', async (req: AuthRequest, res: Response) => {
     friendship.status = 'accepted';
     await friendship.save();
     res.json({ status: 'accepted' });
-  } catch {
-    res.status(500).json({ error: 'Failed to accept request' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to accept request';
+    res.status(500).json({ error: message });
   }
 });
 
@@ -164,8 +168,9 @@ router.post('/:id/reject', async (req: AuthRequest, res: Response) => {
 
     await friendship.deleteOne();
     res.json({ status: 'removed' });
-  } catch {
-    res.status(500).json({ error: 'Failed to reject request' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to reject request';
+    res.status(500).json({ error: message });
   }
 });
 
@@ -185,8 +190,9 @@ router.delete('/:id', async (req: AuthRequest, res: Response) => {
 
     await friendship.deleteOne();
     res.json({ status: 'removed' });
-  } catch {
-    res.status(500).json({ error: 'Failed to remove friend' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to remove friend';
+    res.status(500).json({ error: message });
   }
 });
 

--- a/src/routes/goals.ts
+++ b/src/routes/goals.ts
@@ -14,8 +14,9 @@ router.get('/', async (req: AuthRequest, res: Response) => {
       .sort({ createdAt: -1 })
       .lean();
     res.json({ goals });
-  } catch {
-    res.status(500).json({ error: 'Failed to fetch goals' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to fetch goals';
+    res.status(500).json({ error: message });
   }
 });
 
@@ -64,8 +65,9 @@ router.post(
         category,
       });
       res.status(201).json({ goal });
-    } catch {
-      res.status(500).json({ error: 'Failed to create goal' });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to create goal';
+      res.status(500).json({ error: message });
     }
   }
 );
@@ -109,8 +111,9 @@ router.put(
         return;
       }
       res.json({ goal });
-    } catch {
-      res.status(500).json({ error: 'Failed to update goal' });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to update goal';
+      res.status(500).json({ error: message });
     }
   }
 );
@@ -127,8 +130,9 @@ router.delete('/:id', async (req: AuthRequest, res: Response) => {
       return;
     }
     res.json({ deleted: true });
-  } catch {
-    res.status(500).json({ error: 'Failed to delete goal' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to delete goal';
+    res.status(500).json({ error: message });
   }
 });
 

--- a/src/routes/goals.ts
+++ b/src/routes/goals.ts
@@ -1,0 +1,135 @@
+import { Router, Response } from 'express';
+import { body, validationResult } from 'express-validator';
+import { protect, AuthRequest } from '../middleware/auth';
+import GoalModel from '../models/Goal';
+
+const router = Router();
+
+router.use(protect);
+
+// GET /api/goals
+router.get('/', async (req: AuthRequest, res: Response) => {
+  try {
+    const goals = await GoalModel.find({ userId: req.userId })
+      .sort({ createdAt: -1 })
+      .lean();
+    res.json({ goals });
+  } catch {
+    res.status(500).json({ error: 'Failed to fetch goals' });
+  }
+});
+
+// POST /api/goals
+router.post(
+  '/',
+  [
+    body('name').notEmpty().withMessage('name is required'),
+    body('targetAmount')
+      .isNumeric()
+      .withMessage('targetAmount must be a number'),
+    body('currentAmount')
+      .optional()
+      .isNumeric()
+      .withMessage('currentAmount must be a number'),
+    body('deadline')
+      .optional()
+      .isISO8601()
+      .withMessage('deadline must be a valid ISO date'),
+    body('category')
+      .optional()
+      .isString()
+      .withMessage('category must be a string'),
+  ],
+  async (req: AuthRequest, res: Response) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({ error: errors.array()[0].msg });
+      return;
+    }
+    try {
+      const { name, targetAmount, currentAmount, deadline, category } =
+        req.body as {
+          name: string;
+          targetAmount: number;
+          currentAmount?: number;
+          deadline?: string;
+          category?: string;
+        };
+      const goal = await GoalModel.create({
+        userId: req.userId,
+        name,
+        targetAmount,
+        currentAmount: currentAmount ?? 0,
+        deadline: deadline ? new Date(deadline) : undefined,
+        category,
+      });
+      res.status(201).json({ goal });
+    } catch {
+      res.status(500).json({ error: 'Failed to create goal' });
+    }
+  }
+);
+
+// PUT /api/goals/:id
+router.put(
+  '/:id',
+  [
+    body('name').optional().notEmpty().withMessage('name cannot be empty'),
+    body('targetAmount')
+      .optional()
+      .isNumeric()
+      .withMessage('targetAmount must be a number'),
+    body('currentAmount')
+      .optional()
+      .isNumeric()
+      .withMessage('currentAmount must be a number'),
+    body('deadline')
+      .optional()
+      .isISO8601()
+      .withMessage('deadline must be a valid ISO date'),
+    body('category')
+      .optional()
+      .isString()
+      .withMessage('category must be a string'),
+  ],
+  async (req: AuthRequest, res: Response) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({ error: errors.array()[0].msg });
+      return;
+    }
+    try {
+      const goal = await GoalModel.findOneAndUpdate(
+        { _id: req.params.id, userId: req.userId },
+        { $set: req.body },
+        { new: true }
+      );
+      if (!goal) {
+        res.status(404).json({ error: 'Goal not found' });
+        return;
+      }
+      res.json({ goal });
+    } catch {
+      res.status(500).json({ error: 'Failed to update goal' });
+    }
+  }
+);
+
+// DELETE /api/goals/:id
+router.delete('/:id', async (req: AuthRequest, res: Response) => {
+  try {
+    const goal = await GoalModel.findOneAndDelete({
+      _id: req.params.id,
+      userId: req.userId,
+    });
+    if (!goal) {
+      res.status(404).json({ error: 'Goal not found' });
+      return;
+    }
+    res.json({ deleted: true });
+  } catch {
+    res.status(500).json({ error: 'Failed to delete goal' });
+  }
+});
+
+export default router;

--- a/src/routes/import.ts
+++ b/src/routes/import.ts
@@ -1,6 +1,7 @@
 import { Router, Response } from 'express';
 import multer from 'multer';
 import { parse } from 'csv-parse/sync';
+import Anthropic from '@anthropic-ai/sdk';
 import ExpenseModel from '../models/Expense';
 import { protect, AuthRequest } from '../middleware/auth';
 
@@ -134,6 +135,248 @@ router.post('/expenses', upload.single('file'), async (req: AuthRequest, res: Re
   }
 
   res.json({ imported, skipped, errors });
+});
+
+// Statement scanning
+
+export interface StatementTxn {
+  date: string;        // YYYY-MM-DD
+  description: string;
+  amount: number;
+  type: 'income' | 'expense';
+}
+
+interface MatchedPair {
+  extracted: StatementTxn;
+  existingId: string;
+  existingDescription: string;
+}
+
+interface Discrepancy {
+  extracted: StatementTxn;
+  existingId: string;
+  existingDescription: string;
+  existingAmount: number;
+  reason: string;
+}
+
+const STATEMENT_MIME_TYPES = [
+  'application/pdf',
+  'image/jpeg',
+  'image/png',
+  'image/heic',
+  'image/heif',
+  'image/webp',
+];
+
+const statementUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 10 * 1024 * 1024 },
+  fileFilter: (_req, file, cb) => {
+    const ok = STATEMENT_MIME_TYPES.some((m) => file.mimetype === m) ||
+      file.originalname.match(/\.(pdf|jpg|jpeg|png|heic|heif|webp)$/i);
+    if (ok) cb(null, true);
+    else cb(new Error('Only PDF and image files are accepted'));
+  },
+});
+
+async function extractTransactionsFromFile(
+  buffer: Buffer,
+  mimeType: string
+): Promise<StatementTxn[]> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) throw new Error('ANTHROPIC_API_KEY not configured');
+
+  const client = new Anthropic({ apiKey });
+  const data = buffer.toString('base64');
+
+  const prompt = `You are extracting transactions from a bank or credit card statement.
+
+Return ONLY a valid JSON array. Each element must have these fields:
+- date: string in YYYY-MM-DD format
+- description: string (merchant or payee name, cleaned up)
+- amount: number (always positive)
+- type: "expense" for debits/withdrawals/purchases, "income" for credits/deposits
+
+Rules:
+- Ignore balance rows, total rows, fee rows labelled as "interest" or "minimum payment"
+- If a row has parentheses around the amount or is labelled as a debit, it is an expense
+- If a row is a credit, deposit, or refund, it is income
+- Do NOT include any text outside the JSON array
+- Do NOT include markdown code blocks
+
+Example output: [{"date":"2026-03-01","description":"Starbucks","amount":45.50,"type":"expense"},{"date":"2026-03-05","description":"Salary","amount":25000,"type":"income"}]`;
+
+  let contentBlock: Anthropic.MessageParam['content'];
+
+  if (mimeType === 'application/pdf') {
+    contentBlock = [
+      {
+        type: 'document' as const,
+        source: { type: 'base64' as const, media_type: 'application/pdf' as const, data },
+      },
+      { type: 'text' as const, text: prompt },
+    ];
+  } else {
+    const imageType = mimeType as 'image/jpeg' | 'image/png' | 'image/webp' | 'image/gif';
+    contentBlock = [
+      {
+        type: 'image' as const,
+        source: { type: 'base64' as const, media_type: imageType, data },
+      },
+      { type: 'text' as const, text: prompt },
+    ];
+  }
+
+  const message = await client.messages.create({
+    model: 'claude-sonnet-4-6',
+    max_tokens: 4096,
+    messages: [{ role: 'user', content: contentBlock }],
+  });
+
+  const block = message.content[0];
+  if (block.type !== 'text') throw new Error('Unexpected response from Claude');
+
+  const text = block.text.trim();
+  const jsonStart = text.indexOf('[');
+  const jsonEnd = text.lastIndexOf(']');
+  if (jsonStart === -1 || jsonEnd === -1) throw new Error('No JSON array found in response');
+
+  const parsed = JSON.parse(text.slice(jsonStart, jsonEnd + 1)) as unknown[];
+  const result: StatementTxn[] = [];
+  for (const item of parsed) {
+    if (typeof item !== 'object' || item === null) continue;
+    const t = item as Record<string, unknown>;
+    if (typeof t.date !== 'string' || typeof t.description !== 'string' || typeof t.amount !== 'number') continue;
+    result.push({
+      date: t.date,
+      description: t.description,
+      amount: Math.abs(t.amount),
+      type: t.type === 'income' ? 'income' : 'expense',
+    });
+  }
+  return result;
+}
+
+async function reconcile(
+  userId: string,
+  extracted: StatementTxn[]
+): Promise<{ matched: MatchedPair[]; missing: StatementTxn[]; discrepancies: Discrepancy[] }> {
+  if (extracted.length === 0) return { matched: [], missing: [], discrepancies: [] };
+
+  const dates = extracted.map((t) => new Date(t.date));
+  const minDate = new Date(Math.min(...dates.map((d) => d.getTime())));
+  const maxDate = new Date(Math.max(...dates.map((d) => d.getTime())));
+  // Expand range by 2 days for matching tolerance
+  minDate.setDate(minDate.getDate() - 2);
+  maxDate.setDate(maxDate.getDate() + 2);
+
+  const existing = await ExpenseModel.find({
+    owner: userId,
+    date: { $gte: minDate, $lte: maxDate },
+  }).lean();
+
+  const matched: MatchedPair[] = [];
+  const discrepancies: Discrepancy[] = [];
+  const missing: StatementTxn[] = [];
+  const usedExistingIds = new Set<string>();
+
+  for (const txn of extracted) {
+    const txnDate = new Date(txn.date);
+    const AMOUNT_TOLERANCE = 0.05;
+    const DATE_TOLERANCE_MS = 2 * 24 * 60 * 60 * 1000; // 2 days
+
+    // Look for exact match: same amount (±tolerance) and same date (±2 days)
+    const exactMatch = existing.find((e) => {
+      if (usedExistingIds.has(String(e._id))) return false;
+      if (e.type !== txn.type) return false;
+      const amountMatch = Math.abs(e.amount - txn.amount) <= AMOUNT_TOLERANCE;
+      const eDateMs = new Date(e.date ?? e.createdAt ?? 0).getTime();
+      const dateMatch = Math.abs(eDateMs - txnDate.getTime()) <= DATE_TOLERANCE_MS;
+      return amountMatch && dateMatch;
+    });
+
+    if (exactMatch) {
+      usedExistingIds.add(String(exactMatch._id));
+      matched.push({
+        extracted: txn,
+        existingId: String(exactMatch._id),
+        existingDescription: (exactMatch.item || exactMatch.description || '') as string,
+      });
+      continue;
+    }
+
+    // Look for same amount but date mismatch → discrepancy
+    const amountMatch = existing.find((e) => {
+      if (usedExistingIds.has(String(e._id))) return false;
+      if (e.type !== txn.type) return false;
+      return Math.abs(e.amount - txn.amount) <= AMOUNT_TOLERANCE;
+    });
+
+    if (amountMatch) {
+      usedExistingIds.add(String(amountMatch._id));
+      discrepancies.push({
+        extracted: txn,
+        existingId: String(amountMatch._id),
+        existingDescription: (amountMatch.item || amountMatch.description || '') as string,
+        existingAmount: amountMatch.amount,
+        reason: 'Date mismatch',
+      });
+      continue;
+    }
+
+    missing.push(txn);
+  }
+
+  return { matched, missing, discrepancies };
+}
+
+// POST /api/import/statement — scan + reconcile (no DB write)
+router.post('/statement', statementUpload.single('file'), async (req: AuthRequest, res: Response): Promise<void> => {
+  if (!req.file) {
+    res.status(400).json({ error: 'No file uploaded' });
+    return;
+  }
+
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    res.status(500).json({ error: 'Statement scanning is not configured' });
+    return;
+  }
+
+  try {
+    const extracted = await extractTransactionsFromFile(req.file.buffer, req.file.mimetype);
+    const { matched, missing, discrepancies } = await reconcile(req.userId!, extracted);
+    res.json({ extracted, matched, missing, discrepancies });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Scan failed';
+    res.status(500).json({ error: msg });
+  }
+});
+
+// POST /api/import/statement/apply — create missing transactions
+router.post('/statement/apply', async (req: AuthRequest, res: Response): Promise<void> => {
+  const transactions = req.body.transactions as StatementTxn[] | undefined;
+  if (!Array.isArray(transactions) || transactions.length === 0) {
+    res.status(400).json({ error: 'No transactions provided' });
+    return;
+  }
+
+  try {
+    const toInsert = transactions.map((t) => ({
+      owner: req.userId!,
+      date: new Date(t.date),
+      description: t.description,
+      amount: t.amount,
+      type: t.type,
+      category: 'Other',
+    }));
+
+    await ExpenseModel.insertMany(toInsert);
+    res.json({ imported: toInsert.length });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to import transactions' });
+  }
 });
 
 export default router;

--- a/src/routes/import.ts
+++ b/src/routes/import.ts
@@ -1,0 +1,139 @@
+import { Router, Response } from 'express';
+import multer from 'multer';
+import { parse } from 'csv-parse/sync';
+import ExpenseModel from '../models/Expense';
+import { protect, AuthRequest } from '../middleware/auth';
+
+const router = Router();
+router.use(protect);
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 5 * 1024 * 1024 },
+  fileFilter: (_req, file, cb) => {
+    if (file.mimetype === 'text/csv' || file.originalname.endsWith('.csv')) {
+      cb(null, true);
+    } else {
+      cb(new Error('Only CSV files are accepted'));
+    }
+  },
+});
+
+function parseAmount(raw: string): number | null {
+  const cleaned = raw.replace(/[,$\s]/g, '');
+  const n = parseFloat(cleaned);
+  return isNaN(n) ? null : n;
+}
+
+function parseDate(raw: string): Date | null {
+  const d = new Date(raw);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+// POST /api/import/expenses
+router.post('/expenses', upload.single('file'), async (req: AuthRequest, res: Response): Promise<void> => {
+  if (!req.file) {
+    res.status(400).json({ message: 'No file uploaded' });
+    return;
+  }
+
+  let rows: Record<string, string>[];
+  try {
+    rows = parse(req.file.buffer, {
+      columns: true,
+      skip_empty_lines: true,
+      trim: true,
+    }) as Record<string, string>[];
+  } catch (e) {
+    res.status(400).json({ message: 'Failed to parse CSV', detail: String(e) });
+    return;
+  }
+
+  const owner = req.userId!;
+  let imported = 0;
+  let skipped = 0;
+  const errors: { row: number; reason: string }[] = [];
+  const toInsert: object[] = [];
+
+  // Normalise header names to lowercase
+  const normalize = (r: Record<string, string>): Record<string, string> => {
+    const out: Record<string, string> = {};
+    Object.entries(r).forEach(([k, v]) => { out[k.toLowerCase().trim()] = v; });
+    return out;
+  };
+
+  for (let i = 0; i < rows.length; i++) {
+    const row = normalize(rows[i]);
+    const rowNum = i + 2; // 1-indexed, +1 for header
+
+    const dateRaw = row['date'] || row['transaction date'] || row['txn date'] || '';
+    const descRaw = row['description'] || row['memo'] || row['name'] || '';
+    const amountRaw = row['amount'] || row['debit'] || '';
+    const categoryRaw = row['category'] || '';
+    const typeRaw = (row['type'] || '').toLowerCase();
+    const notesRaw = row['notes'] || row['note'] || '';
+
+    if (!dateRaw || !amountRaw) {
+      errors.push({ row: rowNum, reason: 'Missing required fields: date, amount' });
+      skipped++;
+      continue;
+    }
+
+    const date = parseDate(dateRaw);
+    if (!date) {
+      errors.push({ row: rowNum, reason: `Unparseable date: "${dateRaw}"` });
+      skipped++;
+      continue;
+    }
+
+    const amount = parseAmount(amountRaw);
+    if (amount === null) {
+      errors.push({ row: rowNum, reason: `Unparseable amount: "${amountRaw}"` });
+      skipped++;
+      continue;
+    }
+
+    // Infer type from amount sign or explicit type column
+    const absAmount = Math.abs(amount);
+    let type: string;
+    if (typeRaw === 'income' || typeRaw === 'credit') {
+      type = 'income';
+    } else if (typeRaw === 'expense' || typeRaw === 'debit') {
+      type = 'expense';
+    } else {
+      type = amount >= 0 ? 'income' : 'expense';
+    }
+
+    // Duplicate detection: same owner + date + description + amount
+    const exists = await ExpenseModel.exists({
+      owner,
+      date: { $gte: new Date(date.getTime() - 1000), $lte: new Date(date.getTime() + 1000) },
+      description: descRaw,
+      amount: absAmount,
+    });
+
+    if (exists) {
+      skipped++;
+      continue;
+    }
+
+    toInsert.push({
+      owner,
+      date,
+      description: descRaw,
+      amount: absAmount,
+      type,
+      category: categoryRaw || 'Other',
+      notes: notesRaw || undefined,
+    });
+    imported++;
+  }
+
+  if (toInsert.length > 0) {
+    await ExpenseModel.insertMany(toInsert);
+  }
+
+  res.json({ imported, skipped, errors });
+});
+
+export default router;

--- a/src/routes/insights.ts
+++ b/src/routes/insights.ts
@@ -1,0 +1,184 @@
+import { Router, Response } from 'express';
+import Anthropic from '@anthropic-ai/sdk';
+import ExpenseModel from '../models/Expense';
+import { WeeklyPulseModel, IWeeklyPulseStats } from '../models/WeeklyPulse';
+import { protect, AuthRequest } from '../middleware/auth';
+
+const router = Router();
+router.use(protect);
+
+function getWeekStart(date: Date): string {
+  const d = new Date(date);
+  const day = d.getDay(); // 0=Sun, 1=Mon
+  const diff = day === 0 ? -6 : 1 - day;
+  d.setDate(d.getDate() + diff);
+  d.setHours(0, 0, 0, 0);
+  return d.toISOString().split('T')[0];
+}
+
+function addDays(dateStr: string, days: number): Date {
+  const d = new Date(dateStr);
+  d.setDate(d.getDate() + days);
+  return d;
+}
+
+async function computeWeeklyStats(userId: string, weekStart: string): Promise<IWeeklyPulseStats | null> {
+  const weekEnd = addDays(weekStart, 7);
+  const fourWeeksAgo = addDays(weekStart, -28);
+
+  const [weekExpenses, prevExpenses] = await Promise.all([
+    ExpenseModel.find({
+      owner: userId,
+      type: 'expense',
+      date: { $gte: new Date(weekStart), $lt: weekEnd },
+    }).lean(),
+    ExpenseModel.find({
+      owner: userId,
+      type: 'expense',
+      date: { $gte: fourWeeksAgo, $lt: new Date(weekStart) },
+    }).lean(),
+  ]);
+
+  if (weekExpenses.length < 3) return null;
+
+  const totalSpend = weekExpenses.reduce((s, e) => s + e.amount, 0);
+
+  const prevTotal = prevExpenses.reduce((s, e) => s + e.amount, 0);
+  const fourWeekAverage = prevTotal > 0 ? prevTotal / 4 : totalSpend;
+  const deltaPercent = fourWeekAverage > 0 ? Math.round(((totalSpend - fourWeekAverage) / fourWeekAverage) * 100) : 0;
+
+  const categoryTotals: Record<string, number> = {};
+  for (const e of weekExpenses) {
+    const cat = e.category || 'Other';
+    categoryTotals[cat] = (categoryTotals[cat] || 0) + e.amount;
+  }
+  const topCategory = Object.entries(categoryTotals).sort((a, b) => b[1] - a[1])[0]?.[0] ?? 'Other';
+
+  const dayTotals: Record<string, number> = {};
+  for (const e of weekExpenses) {
+    const day = new Date(e.date ?? e.createdAt ?? new Date()).toISOString().split('T')[0];
+    dayTotals[day] = (dayTotals[day] || 0) + e.amount;
+  }
+  const highestSpendDay = Object.entries(dayTotals).sort((a, b) => b[1] - a[1])[0]?.[0] ?? weekStart;
+
+  const largest = weekExpenses.sort((a, b) => b.amount - a.amount)[0];
+  const largestTransaction = largest
+    ? {
+        description: (largest.item || largest.description || 'a purchase') as string,
+        amount: largest.amount,
+        category: (largest.category || 'Other') as string,
+      }
+    : null;
+
+  return {
+    totalSpend,
+    fourWeekAverage,
+    deltaPercent,
+    topCategory,
+    highestSpendDay,
+    largestTransaction,
+    transactionCount: weekExpenses.length,
+  };
+}
+
+async function generateNarrative(stats: IWeeklyPulseStats, weekStart: string): Promise<string> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) throw new Error('ANTHROPIC_API_KEY not configured');
+
+  const client = new Anthropic({ apiKey });
+
+  const dayName = new Date(stats.highestSpendDay).toLocaleDateString('en-US', { weekday: 'long' });
+  const direction = stats.deltaPercent >= 0 ? 'more' : 'less';
+  const absDelta = Math.abs(stats.deltaPercent);
+
+  const prompt = `You are a personal finance assistant writing a weekly spending summary.
+
+Weekly stats (week of ${weekStart}):
+- Total spend: ${stats.totalSpend.toFixed(0)} (your currency)
+- 4-week average: ${stats.fourWeekAverage.toFixed(0)} — ${absDelta}% ${direction} than usual
+- Top category: ${stats.topCategory} (${(stats.totalSpend > 0 ? (Object.fromEntries([[stats.topCategory, stats.totalSpend]]))[stats.topCategory] : 0).toFixed(0)})
+- Highest spending day: ${dayName}
+- Biggest purchase: ${stats.largestTransaction ? `${stats.largestTransaction.description} (${stats.largestTransaction.amount.toFixed(0)})` : 'n/a'}
+- Transactions this week: ${stats.transactionCount}
+
+Write a friendly, warm, non-judgmental 3-5 sentence narrative about this spending week. Be specific with the data. Write in second person ("You spent..."). Do not include currency symbols — just use the numbers. Do not give unsolicited advice.`;
+
+  const message = await client.messages.create({
+    model: 'claude-haiku-4-5-20251001',
+    max_tokens: 256,
+    messages: [{ role: 'user', content: prompt }],
+  });
+
+  const block = message.content[0];
+  return block.type === 'text' ? block.text.trim() : '';
+}
+
+// GET /api/insights/weekly-pulse — return most recent pulse
+router.get('/weekly-pulse', async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const pulse = await WeeklyPulseModel.findOne({ userId: req.userId }).sort({ weekStart: -1 }).lean();
+    if (!pulse) {
+      res.json({ pulse: null });
+      return;
+    }
+    res.json({ pulse });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch pulse' });
+  }
+});
+
+// GET /api/insights/previous-pulse — return pulse for previous week
+router.get('/previous-pulse', async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const currentWeekStart = getWeekStart(new Date());
+    const pulse = await WeeklyPulseModel.findOne({
+      userId: req.userId,
+      weekStart: { $lt: currentWeekStart },
+    })
+      .sort({ weekStart: -1 })
+      .lean();
+    if (!pulse) {
+      res.json({ pulse: null });
+      return;
+    }
+    res.json({ pulse });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch previous pulse' });
+  }
+});
+
+// POST /api/insights/weekly-pulse/generate — compute stats + call Claude + store
+router.post('/weekly-pulse/generate', async (req: AuthRequest, res: Response): Promise<void> => {
+  const weekStart = getWeekStart(new Date());
+  const force = req.query.force === 'true';
+
+  try {
+    if (!force) {
+      const existing = await WeeklyPulseModel.findOne({ userId: req.userId, weekStart }).lean();
+      if (existing) {
+        res.json({ pulse: existing, generated: false });
+        return;
+      }
+    }
+
+    const stats = await computeWeeklyStats(req.userId!, weekStart);
+    if (!stats) {
+      res.json({ pulse: null, generated: false, reason: 'insufficient_data' });
+      return;
+    }
+
+    const narrative = await generateNarrative(stats, weekStart);
+
+    const pulse = await WeeklyPulseModel.findOneAndUpdate(
+      { userId: req.userId, weekStart },
+      { userId: req.userId, weekStart, narrative, stats },
+      { upsert: true, new: true }
+    ).lean();
+
+    res.json({ pulse, generated: true });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to generate pulse' });
+  }
+});
+
+export default router;

--- a/src/routes/item-prices.test.ts
+++ b/src/routes/item-prices.test.ts
@@ -1,0 +1,398 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+import request from 'supertest';
+import express from 'express';
+import mongoose from 'mongoose';
+import cors from 'cors';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import itemPriceRoutes from './item-prices';
+import ItemPriceModel from '../models/ItemPrice';
+
+let mongoServer: MongoMemoryServer;
+let app: express.Application;
+
+const JWT_SECRET = 'test-secret';
+
+const generateToken = (userId: string) => jwt.sign({ userId }, JWT_SECRET);
+
+const USER_A = 'user-price-a';
+const USER_B = 'user-price-b';
+const TOKEN_A = generateToken(USER_A);
+const TOKEN_B = generateToken(USER_B);
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  await mongoose.connect(mongoServer.getUri());
+
+  app = express();
+  app.use(express.json());
+  app.use(cors());
+  app.use('/api/item-prices', itemPriceRoutes);
+}, 30000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+beforeEach(async () => {
+  await ItemPriceModel.deleteMany({});
+});
+
+// ─── POST /api/item-prices/extract ────────────────────────────────────────────
+
+describe('POST /api/item-prices/extract', () => {
+  it('requires JWT auth', async () => {
+    const res = await request(app)
+      .post('/api/item-prices/extract')
+      .send({ merchant: "McDonald's", items: [{ itemName: 'Big Mac', price: 30 }] });
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects missing merchant', async () => {
+    const res = await request(app)
+      .post('/api/item-prices/extract')
+      .set('Authorization', `Bearer ${TOKEN_A}`)
+      .send({ items: [{ itemName: 'Big Mac', price: 30 }] });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects empty items array', async () => {
+    const res = await request(app)
+      .post('/api/item-prices/extract')
+      .set('Authorization', `Bearer ${TOKEN_A}`)
+      .send({ merchant: "McDonald's", items: [] });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects item with negative price', async () => {
+    const res = await request(app)
+      .post('/api/item-prices/extract')
+      .set('Authorization', `Bearer ${TOKEN_A}`)
+      .send({ merchant: "McDonald's", items: [{ itemName: 'Big Mac', price: -5 }] });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects item with empty itemName', async () => {
+    const res = await request(app)
+      .post('/api/item-prices/extract')
+      .set('Authorization', `Bearer ${TOKEN_A}`)
+      .send({ merchant: "McDonald's", items: [{ itemName: '   ', price: 30 }] });
+    expect(res.status).toBe(400);
+  });
+
+  it('stores a single item and returns stored count', async () => {
+    const res = await request(app)
+      .post('/api/item-prices/extract')
+      .set('Authorization', `Bearer ${TOKEN_A}`)
+      .send({
+        merchant: "McDonald's",
+        items: [{ itemName: 'Big Mac', price: 30, currency: 'HKD' }],
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.stored).toBe(1);
+    expect(res.body.merchant).toBe("McDonald's");
+
+    const doc = await ItemPriceModel.findOne({ userId: USER_A, merchant: "McDonald's", itemName: 'Big Mac' });
+    expect(doc).not.toBeNull();
+    expect(doc!.price).toBe(30);
+    expect(doc!.currency).toBe('HKD');
+    expect(doc!.occurrences).toBe(1);
+    expect(doc!.priceHistory).toHaveLength(1);
+  });
+
+  it('stores multiple items in a single call', async () => {
+    const res = await request(app)
+      .post('/api/item-prices/extract')
+      .set('Authorization', `Bearer ${TOKEN_A}`)
+      .send({
+        merchant: "McDonald's",
+        items: [
+          { itemName: 'Big Mac', price: 30 },
+          { itemName: 'McFlurry', price: 15 },
+          { itemName: 'Fries', price: 12 },
+        ],
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.stored).toBe(3);
+
+    const count = await ItemPriceModel.countDocuments({ userId: USER_A, merchant: "McDonald's" });
+    expect(count).toBe(3);
+  });
+
+  it('updates price and appends to priceHistory on second scan', async () => {
+    // First scan
+    await request(app)
+      .post('/api/item-prices/extract')
+      .set('Authorization', `Bearer ${TOKEN_A}`)
+      .send({ merchant: "McDonald's", items: [{ itemName: 'Big Mac', price: 28 }] });
+
+    // Second scan with new price
+    await request(app)
+      .post('/api/item-prices/extract')
+      .set('Authorization', `Bearer ${TOKEN_A}`)
+      .send({ merchant: "McDonald's", items: [{ itemName: 'Big Mac', price: 30 }] });
+
+    const doc = await ItemPriceModel.findOne({ userId: USER_A, merchant: "McDonald's", itemName: 'Big Mac' });
+    expect(doc!.price).toBe(30);
+    expect(doc!.occurrences).toBe(2);
+    expect(doc!.priceHistory).toHaveLength(2);
+    expect(doc!.priceHistory[0].price).toBe(28);
+    expect(doc!.priceHistory[1].price).toBe(30);
+  });
+
+  it('defaults currency to HKD when not provided', async () => {
+    await request(app)
+      .post('/api/item-prices/extract')
+      .set('Authorization', `Bearer ${TOKEN_A}`)
+      .send({ merchant: 'Starbucks', items: [{ itemName: 'Latte', price: 45 }] });
+
+    const doc = await ItemPriceModel.findOne({ userId: USER_A, merchant: 'Starbucks', itemName: 'Latte' });
+    expect(doc!.currency).toBe('HKD');
+  });
+
+  it('uses receiptDate when provided', async () => {
+    const receiptDate = '2026-01-15';
+    await request(app)
+      .post('/api/item-prices/extract')
+      .set('Authorization', `Bearer ${TOKEN_A}`)
+      .send({
+        merchant: 'Wellcome',
+        items: [{ itemName: 'Milk', price: 20 }],
+        receiptDate,
+      });
+
+    const doc = await ItemPriceModel.findOne({ userId: USER_A, merchant: 'Wellcome', itemName: 'Milk' });
+    expect(doc!.lastSeen.toISOString().startsWith('2026-01-15')).toBe(true);
+  });
+
+  it('rejects invalid receiptDate', async () => {
+    const res = await request(app)
+      .post('/api/item-prices/extract')
+      .set('Authorization', `Bearer ${TOKEN_A}`)
+      .send({
+        merchant: 'Wellcome',
+        items: [{ itemName: 'Milk', price: 20 }],
+        receiptDate: 'not-a-date',
+      });
+    expect(res.status).toBe(400);
+  });
+
+  it('is scoped to the authenticated user (user isolation)', async () => {
+    await request(app)
+      .post('/api/item-prices/extract')
+      .set('Authorization', `Bearer ${TOKEN_A}`)
+      .send({ merchant: "McDonald's", items: [{ itemName: 'Big Mac', price: 30 }] });
+
+    const docForB = await ItemPriceModel.findOne({ userId: USER_B, merchant: "McDonald's" });
+    expect(docForB).toBeNull();
+  });
+
+  it('normalises currency to uppercase', async () => {
+    await request(app)
+      .post('/api/item-prices/extract')
+      .set('Authorization', `Bearer ${TOKEN_A}`)
+      .send({ merchant: 'KFC', items: [{ itemName: 'Zinger', price: 45, currency: 'hkd' }] });
+
+    const doc = await ItemPriceModel.findOne({ userId: USER_A, merchant: 'KFC', itemName: 'Zinger' });
+    expect(doc!.currency).toBe('HKD');
+  });
+});
+
+// ─── GET /api/item-prices ─────────────────────────────────────────────────────
+
+describe('GET /api/item-prices', () => {
+  beforeEach(async () => {
+    // Seed data for USER_A
+    await ItemPriceModel.create([
+      {
+        userId: USER_A,
+        merchant: "McDonald's",
+        itemName: 'Big Mac',
+        price: 30,
+        currency: 'HKD',
+        lastSeen: new Date('2026-03-01'),
+        priceHistory: [{ price: 30, date: new Date('2026-03-01') }],
+        occurrences: 1,
+      },
+      {
+        userId: USER_A,
+        merchant: "McDonald's",
+        itemName: 'McFlurry',
+        price: 15,
+        currency: 'HKD',
+        lastSeen: new Date('2026-03-01'),
+        priceHistory: [{ price: 15, date: new Date('2026-03-01') }],
+        occurrences: 1,
+      },
+      {
+        userId: USER_A,
+        merchant: 'Starbucks',
+        itemName: 'Latte',
+        price: 45,
+        currency: 'HKD',
+        lastSeen: new Date('2026-03-10'),
+        priceHistory: [{ price: 45, date: new Date('2026-03-10') }],
+        occurrences: 2,
+      },
+      // USER_B data — should never appear in USER_A's results
+      {
+        userId: USER_B,
+        merchant: "McDonald's",
+        itemName: 'Big Mac',
+        price: 999,
+        currency: 'HKD',
+        lastSeen: new Date('2026-03-01'),
+        priceHistory: [{ price: 999, date: new Date('2026-03-01') }],
+        occurrences: 1,
+      },
+    ]);
+  });
+
+  it('requires JWT auth', async () => {
+    const res = await request(app).get('/api/item-prices');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns all items for the user when no filters given', async () => {
+    const res = await request(app)
+      .get('/api/item-prices')
+      .set('Authorization', `Bearer ${TOKEN_A}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(3);
+    // All belong to USER_A
+    for (const item of res.body) {
+      expect(item.userId).toBeUndefined(); // userId not selected
+    }
+  });
+
+  it('filters by merchant', async () => {
+    const res = await request(app)
+      .get("/api/item-prices?merchant=McDonald's")
+      .set('Authorization', `Bearer ${TOKEN_A}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    for (const item of res.body) {
+      expect(item.merchant).toBe("McDonald's");
+    }
+  });
+
+  it('filters by merchant and item', async () => {
+    const res = await request(app)
+      .get("/api/item-prices?merchant=McDonald's&item=Big Mac")
+      .set('Authorization', `Bearer ${TOKEN_A}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].itemName).toBe('Big Mac');
+    expect(res.body[0].price).toBe(30);
+  });
+
+  it('returns empty array when item not found', async () => {
+    const res = await request(app)
+      .get("/api/item-prices?merchant=McDonald's&item=Impossible Burger")
+      .set('Authorization', `Bearer ${TOKEN_A}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(0);
+  });
+
+  it('does not expose other user data', async () => {
+    const res = await request(app)
+      .get('/api/item-prices')
+      .set('Authorization', `Bearer ${TOKEN_A}`);
+    const prices = res.body as Array<{ price: number }>;
+    const hasBadData = prices.some((p) => p.price === 999);
+    expect(hasBadData).toBe(false);
+  });
+});
+
+// ─── GET /api/item-prices/suggest ────────────────────────────────────────────
+
+describe('GET /api/item-prices/suggest', () => {
+  beforeEach(async () => {
+    await ItemPriceModel.create([
+      {
+        userId: USER_A,
+        merchant: "McDonald's",
+        itemName: 'Big Mac',
+        price: 30,
+        currency: 'HKD',
+        lastSeen: new Date('2026-03-27'),
+        priceHistory: [{ price: 30, date: new Date('2026-03-27') }],
+        occurrences: 5,
+      },
+      {
+        userId: USER_A,
+        merchant: "McDonald's",
+        itemName: 'McFlurry',
+        price: 15,
+        currency: 'HKD',
+        lastSeen: new Date('2026-03-20'),
+        priceHistory: [{ price: 15, date: new Date('2026-03-20') }],
+        occurrences: 2,
+      },
+      {
+        userId: USER_A,
+        merchant: 'Starbucks',
+        itemName: 'Latte',
+        price: 45,
+        currency: 'HKD',
+        lastSeen: new Date('2026-03-10'),
+        priceHistory: [{ price: 45, date: new Date('2026-03-10') }],
+        occurrences: 3,
+      },
+    ]);
+  });
+
+  it('requires JWT auth', async () => {
+    const res = await request(app).get("/api/item-prices/suggest?merchant=McDonald's");
+    expect(res.status).toBe(401);
+  });
+
+  it('requires merchant query param', async () => {
+    const res = await request(app)
+      .get('/api/item-prices/suggest')
+      .set('Authorization', `Bearer ${TOKEN_A}`);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns all items at a merchant sorted by occurrences desc', async () => {
+    const res = await request(app)
+      .get("/api/item-prices/suggest?merchant=McDonald's")
+      .set('Authorization', `Bearer ${TOKEN_A}`);
+    expect(res.status).toBe(200);
+    expect(res.body.merchant).toBe("McDonald's");
+    expect(res.body.items).toHaveLength(2);
+    // Big Mac has more occurrences, should be first
+    expect(res.body.items[0].itemName).toBe('Big Mac');
+    expect(res.body.items[1].itemName).toBe('McFlurry');
+  });
+
+  it('returns empty items array for unknown merchant', async () => {
+    const res = await request(app)
+      .get('/api/item-prices/suggest?merchant=Unknown Place')
+      .set('Authorization', `Bearer ${TOKEN_A}`);
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(0);
+  });
+
+  it('does not mix merchants', async () => {
+    const res = await request(app)
+      .get('/api/item-prices/suggest?merchant=Starbucks')
+      .set('Authorization', `Bearer ${TOKEN_A}`);
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(1);
+    expect(res.body.items[0].itemName).toBe('Latte');
+  });
+
+  it('does not include priceHistory in suggestion response', async () => {
+    const res = await request(app)
+      .get("/api/item-prices/suggest?merchant=McDonald's")
+      .set('Authorization', `Bearer ${TOKEN_A}`);
+    expect(res.status).toBe(200);
+    for (const item of res.body.items) {
+      expect(item.priceHistory).toBeUndefined();
+    }
+  });
+});

--- a/src/routes/item-prices.ts
+++ b/src/routes/item-prices.ts
@@ -1,0 +1,188 @@
+import { Router, Response } from 'express';
+import { body, query, validationResult } from 'express-validator';
+import { protect, AuthRequest } from '../middleware/auth';
+import ItemPriceModel from '../models/ItemPrice';
+
+const router = Router();
+router.use(protect);
+
+interface LineItem {
+  itemName: string;
+  price: number;
+  currency?: string;
+}
+
+interface ExtractBody {
+  merchant: string;
+  items: LineItem[];
+  receiptDate?: string;
+}
+
+const extractValidation = [
+  body('merchant')
+    .isString()
+    .withMessage('merchant must be a string')
+    .trim()
+    .notEmpty()
+    .withMessage('merchant is required')
+    .isLength({ max: 200 })
+    .withMessage('merchant must not exceed 200 characters'),
+  body('items')
+    .isArray({ min: 1 })
+    .withMessage('items must be a non-empty array'),
+  body('items.*.itemName')
+    .isString()
+    .withMessage('each item must have a string itemName')
+    .trim()
+    .notEmpty()
+    .withMessage('itemName must not be empty')
+    .isLength({ max: 300 })
+    .withMessage('itemName must not exceed 300 characters'),
+  body('items.*.price')
+    .isFloat({ min: 0 })
+    .withMessage('each item price must be a non-negative number'),
+  body('items.*.currency')
+    .optional()
+    .isString()
+    .withMessage('currency must be a string')
+    .isLength({ min: 3, max: 3 })
+    .withMessage('currency must be a 3-letter ISO code'),
+  body('receiptDate')
+    .optional()
+    .isISO8601()
+    .withMessage('receiptDate must be a valid ISO 8601 date'),
+];
+
+// POST /api/item-prices/extract
+// Extracts line items from a receipt scan and upserts them into the price index.
+router.post('/extract', extractValidation, async (req: AuthRequest, res: Response): Promise<void> => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    res.status(400).json({ error: errors.array()[0].msg });
+    return;
+  }
+
+  const userId = req.userId!;
+  const { merchant, items, receiptDate } = req.body as ExtractBody;
+  const seenDate = receiptDate ? new Date(receiptDate) : new Date();
+  const normalizedMerchant = merchant.trim();
+
+  const upserted: string[] = [];
+
+  try {
+    for (const item of items) {
+      const normalizedItemName = item.itemName.trim();
+      const currency = (item.currency ?? 'HKD').toUpperCase();
+
+      await ItemPriceModel.findOneAndUpdate(
+        { userId, merchant: normalizedMerchant, itemName: normalizedItemName },
+        {
+          $set: {
+            price: item.price,
+            currency,
+            lastSeen: seenDate,
+          },
+          $push: {
+            priceHistory: { price: item.price, date: seenDate },
+          },
+          $inc: { occurrences: 1 },
+          $setOnInsert: {
+            userId,
+            merchant: normalizedMerchant,
+            itemName: normalizedItemName,
+          },
+        },
+        { upsert: true, new: true }
+      );
+
+      upserted.push(normalizedItemName);
+    }
+
+    res.status(200).json({ stored: upserted.length, merchant: normalizedMerchant });
+  } catch (err) {
+    console.error('item-prices extract error:', err);
+    res.status(500).json({ error: 'Failed to store item prices' });
+  }
+});
+
+const lookupValidation = [
+  query('merchant')
+    .optional()
+    .isString()
+    .withMessage('merchant must be a string')
+    .trim()
+    .notEmpty()
+    .withMessage('merchant must not be empty'),
+  query('item')
+    .optional()
+    .isString()
+    .withMessage('item must be a string')
+    .trim()
+    .notEmpty()
+    .withMessage('item must not be empty'),
+];
+
+// GET /api/item-prices?merchant=X&item=Y
+// Looks up the latest known price for a given merchant + item pair.
+router.get('/', lookupValidation, async (req: AuthRequest, res: Response): Promise<void> => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    res.status(400).json({ error: errors.array()[0].msg });
+    return;
+  }
+
+  const userId = req.userId!;
+  const { merchant, item } = req.query as { merchant?: string; item?: string };
+
+  const filter: Record<string, unknown> = { userId };
+  if (merchant) filter.merchant = merchant.trim();
+  if (item) filter.itemName = item.trim();
+
+  try {
+    const results = await ItemPriceModel.find(filter)
+      .select('merchant itemName price currency lastSeen occurrences')
+      .sort({ lastSeen: -1 })
+      .lean();
+
+    res.json(results);
+  } catch (err) {
+    console.error('item-prices lookup error:', err);
+    res.status(500).json({ error: 'Failed to fetch item prices' });
+  }
+});
+
+const suggestValidation = [
+  query('merchant')
+    .isString()
+    .withMessage('merchant must be a string')
+    .trim()
+    .notEmpty()
+    .withMessage('merchant is required'),
+];
+
+// GET /api/item-prices/suggest?merchant=X
+// Returns all known items and latest prices at a given merchant.
+router.get('/suggest', suggestValidation, async (req: AuthRequest, res: Response): Promise<void> => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    res.status(400).json({ error: errors.array()[0].msg });
+    return;
+  }
+
+  const userId = req.userId!;
+  const merchant = (req.query.merchant as string).trim();
+
+  try {
+    const items = await ItemPriceModel.find({ userId, merchant })
+      .select('itemName price currency lastSeen occurrences')
+      .sort({ occurrences: -1, lastSeen: -1 })
+      .lean();
+
+    res.json({ merchant, items });
+  } catch (err) {
+    console.error('item-prices suggest error:', err);
+    res.status(500).json({ error: 'Failed to fetch suggestions' });
+  }
+});
+
+export default router;

--- a/src/routes/jobs.ts
+++ b/src/routes/jobs.ts
@@ -1,0 +1,35 @@
+import { Router, Request, Response } from 'express';
+import { monthlySummaryJob } from '../jobs/monthlySummary';
+
+const router = Router();
+
+function requireApiKey(req: Request, res: Response): boolean {
+  const apiKey = process.env.JOBS_API_KEY;
+  if (!apiKey) {
+    res.status(503).json({ error: 'Jobs API key not configured' });
+    return false;
+  }
+  const provided = req.headers['x-api-key'];
+  if (!provided || provided !== apiKey) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return false;
+  }
+  return true;
+}
+
+// POST /api/jobs/monthly-summary
+// Protected by X-Api-Key header matching JOBS_API_KEY env var.
+// Returns count of summaries sent.
+router.post('/monthly-summary', async (req: Request, res: Response) => {
+  if (!requireApiKey(req, res)) return;
+  const start = Date.now();
+  try {
+    await monthlySummaryJob();
+    res.json({ ok: true, durationMs: Date.now() - start });
+  } catch (error) {
+    console.error('[POST /api/jobs/monthly-summary] Error:', error);
+    res.status(500).json({ error: 'Job failed' });
+  }
+});
+
+export default router;

--- a/src/routes/net-worth.ts
+++ b/src/routes/net-worth.ts
@@ -20,8 +20,9 @@ router.get('/', async (req: AuthRequest, res: Response) => {
     }).sort({ date: 1 });
 
     res.json(snapshots);
-  } catch {
-    res.status(500).json({ error: 'Failed to fetch net worth snapshots' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to fetch net worth snapshots';
+    res.status(500).json({ error: message });
   }
 });
 
@@ -30,8 +31,9 @@ router.get('/latest', async (req: AuthRequest, res: Response) => {
   try {
     const snapshot = await NetWorthModel.findOne({ userId: req.userId }).sort({ date: -1 });
     res.json(snapshot || null);
-  } catch {
-    res.status(500).json({ error: 'Failed to fetch latest snapshot' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to fetch latest snapshot';
+    res.status(500).json({ error: message });
   }
 });
 
@@ -67,8 +69,9 @@ router.post('/', validation, async (req: AuthRequest, res: Response) => {
     );
 
     res.status(201).json(snapshot);
-  } catch {
-    res.status(400).json({ error: 'Failed to save net worth snapshot' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to save net worth snapshot';
+    res.status(400).json({ error: message });
   }
 });
 
@@ -92,8 +95,9 @@ router.put('/:snapshotId', validation, async (req: AuthRequest, res: Response) =
     }
 
     res.json(snapshot);
-  } catch {
-    res.status(400).json({ error: 'Failed to update snapshot' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to update snapshot';
+    res.status(400).json({ error: message });
   }
 });
 
@@ -111,8 +115,9 @@ router.delete('/:snapshotId', async (req: AuthRequest, res: Response) => {
     }
 
     res.json({ message: 'Deleted' });
-  } catch {
-    res.status(500).json({ error: 'Failed to delete snapshot' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to delete snapshot';
+    res.status(500).json({ error: message });
   }
 });
 

--- a/src/routes/net-worth.ts
+++ b/src/routes/net-worth.ts
@@ -1,0 +1,119 @@
+import { Router, Response } from 'express';
+import { body, validationResult } from 'express-validator';
+import NetWorthModel from '../models/NetWorth';
+import { protect, AuthRequest } from '../middleware/auth';
+
+const router = Router();
+
+router.use(protect);
+
+// GET /api/net-worth - get snapshots for past 12 months
+router.get('/', async (req: AuthRequest, res: Response) => {
+  try {
+    const months = Math.min(parseInt(req.query.months as string) || 12, 24);
+    const startDate = new Date();
+    startDate.setMonth(startDate.getMonth() - months);
+
+    const snapshots = await NetWorthModel.find({
+      userId: req.userId,
+      date: { $gte: startDate },
+    }).sort({ date: 1 });
+
+    res.json(snapshots);
+  } catch {
+    res.status(500).json({ error: 'Failed to fetch net worth snapshots' });
+  }
+});
+
+// GET /api/net-worth/latest - get most recent snapshot
+router.get('/latest', async (req: AuthRequest, res: Response) => {
+  try {
+    const snapshot = await NetWorthModel.findOne({ userId: req.userId }).sort({ date: -1 });
+    res.json(snapshot || null);
+  } catch {
+    res.status(500).json({ error: 'Failed to fetch latest snapshot' });
+  }
+});
+
+// POST /api/net-worth - create/update snapshot for today
+const validation = [
+  body('assets').optional().isObject(),
+  body('liabilities').optional().isObject(),
+];
+
+router.post('/', validation, async (req: AuthRequest, res: Response) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    res.status(400).json({ error: errors.array()[0].msg });
+    return;
+  }
+
+  try {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    // Upsert: find or create snapshot for today
+    const snapshot = await NetWorthModel.findOneAndUpdate(
+      { userId: req.userId, date: today },
+      {
+        $set: {
+          userId: req.userId,
+          assets: req.body.assets || {},
+          liabilities: req.body.liabilities || {},
+          date: today,
+        },
+      },
+      { upsert: true, new: true, runValidators: true }
+    );
+
+    res.status(201).json(snapshot);
+  } catch {
+    res.status(400).json({ error: 'Failed to save net worth snapshot' });
+  }
+});
+
+// PUT /api/net-worth/:snapshotId - update a specific snapshot
+router.put('/:snapshotId', validation, async (req: AuthRequest, res: Response) => {
+  try {
+    const snapshot = await NetWorthModel.findOneAndUpdate(
+      { _id: req.params.snapshotId, userId: req.userId },
+      {
+        $set: {
+          assets: req.body.assets,
+          liabilities: req.body.liabilities,
+        },
+      },
+      { new: true, runValidators: true }
+    );
+
+    if (!snapshot) {
+      res.status(404).json({ error: 'Snapshot not found' });
+      return;
+    }
+
+    res.json(snapshot);
+  } catch {
+    res.status(400).json({ error: 'Failed to update snapshot' });
+  }
+});
+
+// DELETE /api/net-worth/:snapshotId
+router.delete('/:snapshotId', async (req: AuthRequest, res: Response) => {
+  try {
+    const deleted = await NetWorthModel.findOneAndDelete({
+      _id: req.params.snapshotId,
+      userId: req.userId,
+    });
+
+    if (!deleted) {
+      res.status(404).json({ error: 'Snapshot not found' });
+      return;
+    }
+
+    res.json({ message: 'Deleted' });
+  } catch {
+    res.status(500).json({ error: 'Failed to delete snapshot' });
+  }
+});
+
+export default router;

--- a/src/routes/receipts.ts
+++ b/src/routes/receipts.ts
@@ -159,8 +159,9 @@ router.post('/scan', (req: Request, res: Response, next: NextFunction) => {
     const jsonMatch = rawText.match(/\{[\s\S]*\}/);
     if (!jsonMatch) throw new Error('No JSON found');
     extracted = JSON.parse(jsonMatch[0]);
-  } catch {
-    res.status(422).json({ error: 'Could not extract data from receipt' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Could not extract data from receipt';
+    res.status(422).json({ error: message });
     return;
   }
 

--- a/src/routes/receipts.ts
+++ b/src/routes/receipts.ts
@@ -1,0 +1,107 @@
+import { Router, Response } from 'express';
+import multer from 'multer';
+import Anthropic from '@anthropic-ai/sdk';
+import { protect, AuthRequest } from '../middleware/auth';
+
+const router = Router();
+router.use(protect);
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 10 * 1024 * 1024 },
+  fileFilter: (_req, file, cb) => {
+    const allowed = ['image/jpeg', 'image/png', 'image/heic', 'image/heif'];
+    if (allowed.includes(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(new Error('Only JPEG, PNG, and HEIC images are accepted'));
+    }
+  },
+});
+
+const scanRateLimit = new Map<string, number[]>();
+
+const checkScanRateLimit = (userId: string): boolean => {
+  const now = Date.now();
+  const hour = 60 * 60 * 1000;
+  const timestamps = (scanRateLimit.get(userId) || []).filter((t) => now - t < hour);
+  if (timestamps.length >= 10) return false;
+  timestamps.push(now);
+  scanRateLimit.set(userId, timestamps);
+  return true;
+};
+
+const EXTRACTION_PROMPT = `You are a receipt data extractor. Analyze this receipt image and extract the following fields as JSON:
+
+{
+  "amount": <total amount as a number>,
+  "description": "<brief description of the purchase>",
+  "category": "<suggest one: Food, Transport, Shopping, Entertainment, Bills, Health, Education, Travel, Other>",
+  "date": "<date in YYYY-MM-DD format>",
+  "merchant": "<store/merchant name>",
+  "currency": "<3-letter currency code, e.g. HKD, USD, TWD>",
+  "confidence": "<high if all fields clearly extracted, medium if some guessed, low if many unclear>"
+}
+
+Rules:
+- Extract the TOTAL amount (not subtotal)
+- If the receipt is in Chinese (Traditional or Simplified), still extract all fields
+- If a field cannot be determined, use null
+- Return ONLY valid JSON, no other text`;
+
+// POST /api/receipts/scan
+router.post('/scan', upload.single('receipt'), async (req: AuthRequest, res: Response) => {
+  if (!req.file) {
+    res.status(400).json({ error: 'No receipt image provided' });
+    return;
+  }
+
+  if (!req.userId || !checkScanRateLimit(req.userId)) {
+    res.status(429).json({ error: 'Rate limit exceeded. Max 10 scans per hour.' });
+    return;
+  }
+
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    res.status(500).json({ error: 'Receipt scanning not configured' });
+    return;
+  }
+
+  try {
+    const client = new Anthropic({ apiKey });
+    const base64Image = req.file.buffer.toString('base64');
+    const mediaType = req.file.mimetype === 'image/heic' || req.file.mimetype === 'image/heif'
+      ? 'image/jpeg' as const
+      : req.file.mimetype as 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp';
+
+    const message = await client.messages.create({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 1024,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'image',
+              source: { type: 'base64', media_type: mediaType, data: base64Image },
+            },
+            { type: 'text', text: EXTRACTION_PROMPT },
+          ],
+        },
+      ],
+    });
+
+    const textBlock = message.content.find((b) => b.type === 'text');
+    if (!textBlock || textBlock.type !== 'text') {
+      res.status(422).json({ error: 'Could not extract data from receipt' });
+      return;
+    }
+
+    const parsed = JSON.parse(textBlock.text);
+    res.json(parsed);
+  } catch {
+    res.status(422).json({ error: 'Could not extract data from receipt' });
+  }
+});
+
+export default router;

--- a/src/routes/receipts.ts
+++ b/src/routes/receipts.ts
@@ -1,17 +1,33 @@
-import { Router, Response } from 'express';
-import multer from 'multer';
+import { Router, Request, Response, NextFunction } from 'express';
+import multer, { MulterError } from 'multer';
 import Anthropic from '@anthropic-ai/sdk';
 import { protect, AuthRequest } from '../middleware/auth';
 
 const router = Router();
 router.use(protect);
 
+// In-memory rate limiter: userId -> timestamps of scans in the last hour
+const scanTimestamps = new Map<string, number[]>();
+const RATE_LIMIT = 10;
+const RATE_WINDOW_MS = 60 * 60 * 1000;
+
+function isRateLimited(userId: string): boolean {
+  const now = Date.now();
+  const cutoff = now - RATE_WINDOW_MS;
+  const times = (scanTimestamps.get(userId) ?? []).filter((t) => t > cutoff);
+  if (times.length >= RATE_LIMIT) return true;
+  times.push(now);
+  scanTimestamps.set(userId, times);
+  return false;
+}
+
+const ACCEPTED_MIMETYPES = ['image/jpeg', 'image/png', 'image/heic', 'image/heif'];
+
 const upload = multer({
   storage: multer.memoryStorage(),
   limits: { fileSize: 10 * 1024 * 1024 },
   fileFilter: (_req, file, cb) => {
-    const allowed = ['image/jpeg', 'image/png', 'image/heic', 'image/heif'];
-    if (allowed.includes(file.mimetype)) {
+    if (ACCEPTED_MIMETYPES.includes(file.mimetype) || file.originalname.match(/\.(jpg|jpeg|png|heic|heif)$/i)) {
       cb(null, true);
     } else {
       cb(new Error('Only JPEG, PNG, and HEIC images are accepted'));
@@ -19,89 +35,151 @@ const upload = multer({
   },
 });
 
-const scanRateLimit = new Map<string, number[]>();
+const CATEGORIES = [
+  'Food', 'Transport', 'Shopping', 'Entertainment', 'Health',
+  'Utilities', 'Groceries', 'Travel', 'Education', 'Dining',
+  'Subscriptions', 'Housing', 'Insurance', 'Personal Care', 'Other',
+];
 
-const checkScanRateLimit = (userId: string): boolean => {
-  const now = Date.now();
-  const hour = 60 * 60 * 1000;
-  const timestamps = (scanRateLimit.get(userId) || []).filter((t) => now - t < hour);
-  if (timestamps.length >= 10) return false;
-  timestamps.push(now);
-  scanRateLimit.set(userId, timestamps);
-  return true;
-};
+const EXTRACTION_PROMPT = `You are a receipt data extraction assistant. Extract transaction data from this receipt image.
 
-const EXTRACTION_PROMPT = `You are a receipt data extractor. Analyze this receipt image and extract the following fields as JSON:
+The receipt may be in English or Traditional Chinese (繁體中文).
 
-{
-  "amount": <total amount as a number>,
-  "description": "<brief description of the purchase>",
-  "category": "<suggest one: Food, Transport, Shopping, Entertainment, Bills, Health, Education, Travel, Other>",
-  "date": "<date in YYYY-MM-DD format>",
-  "merchant": "<store/merchant name>",
-  "currency": "<3-letter currency code, e.g. HKD, USD, TWD>",
-  "confidence": "<high if all fields clearly extracted, medium if some guessed, low if many unclear>"
-}
+Return ONLY a valid JSON object with these fields:
+- amount: number (total amount paid, required)
+- description: string (short description of purchase, e.g. "Grocery shopping at ParknShop")
+- merchant: string | null (store/merchant name)
+- date: string | null (ISO 8601 date YYYY-MM-DD, or null if not found)
+- category: string (best matching category from: ${CATEGORIES.join(', ')})
+- currency: string (3-letter ISO currency code, e.g. HKD, USD, CNY — default to HKD if unclear)
 
 Rules:
-- Extract the TOTAL amount (not subtotal)
-- If the receipt is in Chinese (Traditional or Simplified), still extract all fields
-- If a field cannot be determined, use null
-- Return ONLY valid JSON, no other text`;
+- amount must be the final total paid (including tax, excluding tips if itemised separately)
+- For Traditional Chinese receipts, translate merchant and description to English
+- If amount cannot be determined, return null for amount
+- Return ONLY the JSON object, no explanation`;
+
+function computeConfidence(data: {
+  amount: number | null;
+  date: string | null;
+  merchant: string | null;
+  description: string | null;
+}): 'high' | 'medium' | 'low' {
+  if (data.amount && data.date && data.merchant) return 'high';
+  if (data.amount && (data.date || data.merchant)) return 'medium';
+  return 'low';
+}
+
+function resolveMediaType(mimetype: string): 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp' {
+  if (mimetype === 'image/png') return 'image/png';
+  // HEIC/HEIF are JPEG-compatible containers — pass as jpeg; Claude will attempt to process
+  return 'image/jpeg';
+}
 
 // POST /api/receipts/scan
-router.post('/scan', upload.single('receipt'), async (req: AuthRequest, res: Response) => {
+router.post('/scan', (req: Request, res: Response, next: NextFunction) => {
+  upload.single('image')(req, res, (err) => {
+    if (err instanceof MulterError) {
+      res.status(400).json({ error: err.code === 'LIMIT_FILE_SIZE' ? 'File too large. Maximum size is 10MB.' : err.message });
+      return;
+    }
+    if (err) {
+      res.status(400).json({ error: (err as Error).message });
+      return;
+    }
+    next();
+  });
+}, async (req: AuthRequest, res: Response): Promise<void> => {
   if (!req.file) {
-    res.status(400).json({ error: 'No receipt image provided' });
+    res.status(400).json({ error: 'No image uploaded' });
     return;
   }
 
-  if (!req.userId || !checkScanRateLimit(req.userId)) {
-    res.status(429).json({ error: 'Rate limit exceeded. Max 10 scans per hour.' });
+  const userId = req.userId!;
+
+  if (isRateLimited(userId)) {
+    res.status(429).json({ error: 'Rate limit exceeded. Maximum 10 scans per hour.' });
     return;
   }
 
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {
-    res.status(500).json({ error: 'Receipt scanning not configured' });
+    res.status(500).json({ error: 'Receipt scanning is not configured' });
     return;
   }
 
-  try {
-    const client = new Anthropic({ apiKey });
-    const base64Image = req.file.buffer.toString('base64');
-    const mediaType = req.file.mimetype === 'image/heic' || req.file.mimetype === 'image/heif'
-      ? 'image/jpeg' as const
-      : req.file.mimetype as 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp';
+  const client = new Anthropic({ apiKey });
+  const imageBase64 = req.file.buffer.toString('base64');
+  const mediaType = resolveMediaType(req.file.mimetype);
 
+  let rawText: string;
+  try {
     const message = await client.messages.create({
       model: 'claude-haiku-4-5-20251001',
-      max_tokens: 1024,
+      max_tokens: 512,
       messages: [
         {
           role: 'user',
           content: [
             {
               type: 'image',
-              source: { type: 'base64', media_type: mediaType, data: base64Image },
+              source: {
+                type: 'base64',
+                media_type: mediaType,
+                data: imageBase64,
+              },
             },
-            { type: 'text', text: EXTRACTION_PROMPT },
+            {
+              type: 'text',
+              text: EXTRACTION_PROMPT,
+            },
           ],
         },
       ],
     });
 
-    const textBlock = message.content.find((b) => b.type === 'text');
-    if (!textBlock || textBlock.type !== 'text') {
-      res.status(422).json({ error: 'Could not extract data from receipt' });
-      return;
-    }
+    const block = message.content[0];
+    rawText = block.type === 'text' ? block.text : '';
+  } catch (err) {
+    console.error('Claude API error:', err);
+    res.status(422).json({ error: 'Could not extract data from receipt' });
+    return;
+  }
 
-    const parsed = JSON.parse(textBlock.text);
-    res.json(parsed);
+  let extracted: {
+    amount: number | null;
+    description: string | null;
+    merchant: string | null;
+    date: string | null;
+    category: string;
+    currency: string;
+  };
+
+  try {
+    const jsonMatch = rawText.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) throw new Error('No JSON found');
+    extracted = JSON.parse(jsonMatch[0]);
   } catch {
     res.status(422).json({ error: 'Could not extract data from receipt' });
+    return;
   }
+
+  if (extracted.amount === null || extracted.amount === undefined) {
+    res.status(422).json({ error: 'Could not extract data from receipt' });
+    return;
+  }
+
+  const confidence = computeConfidence(extracted);
+
+  res.json({
+    amount: extracted.amount,
+    description: extracted.description ?? null,
+    category: extracted.category ?? 'Other',
+    date: extracted.date ?? null,
+    merchant: extracted.merchant ?? null,
+    currency: extracted.currency ?? 'HKD',
+    confidence,
+  });
 });
 
 export default router;

--- a/src/routes/recurring.ts
+++ b/src/routes/recurring.ts
@@ -1,0 +1,165 @@
+import { Router, Response } from 'express';
+import { body, validationResult } from 'express-validator';
+import RecurringExpenseModel from '../models/RecurringExpense';
+import { protect, AuthRequest } from '../middleware/auth';
+import { validateRecurringData } from '../utils/recurring';
+
+const router = Router();
+
+router.use(protect);
+
+const recurringValidation = [
+  body('name').notEmpty().withMessage('name is required'),
+  body('amount').isNumeric().withMessage('amount must be a number'),
+  body('start_date').isISO8601().withMessage('start_date must be a valid date'),
+  body('end_date').optional().isISO8601().withMessage('end_date must be a valid date'),
+  body('frequency')
+    .isIn(['DAILY', 'WEEKLY', 'MONTHLY', 'QUARTERLY', 'YEARLY'])
+    .withMessage('frequency must be one of: DAILY, WEEKLY, MONTHLY, QUARTERLY, YEARLY'),
+];
+
+// GET /api/recurring - list all recurring expenses for user
+router.get('/', async (req: AuthRequest, res: Response) => {
+  try {
+    const recurring = await RecurringExpenseModel.find({ userId: req.userId }).sort({
+      start_date: 1,
+    });
+    res.json({ recurring });
+  } catch {
+    res.status(500).json({ error: 'Failed to fetch recurring expenses' });
+  }
+});
+
+// POST /api/recurring - create new recurring expense
+router.post('/', recurringValidation, async (req: AuthRequest, res: Response) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    res.status(400).json({ error: errors.array()[0].msg });
+    return;
+  }
+
+  try {
+    const { name, amount, category, start_date, end_date, frequency, description } = req.body;
+
+    // Additional validation
+    const validation = validateRecurringData({
+      name,
+      amount,
+      start_date,
+      end_date,
+      frequency,
+    });
+
+    if (!validation.valid) {
+      res.status(400).json({ error: validation.errors[0] });
+      return;
+    }
+
+    const recurring = new RecurringExpenseModel({
+      userId: req.userId,
+      name,
+      amount: parseFloat(amount),
+      category,
+      start_date: new Date(start_date),
+      end_date: end_date ? new Date(end_date) : undefined,
+      frequency,
+      description,
+    });
+
+    const saved = await recurring.save();
+    res.status(201).json(saved.toObject());
+  } catch (error: any) {
+    res.status(400).json({ error: error.message || 'Failed to create recurring expense' });
+  }
+});
+
+// GET /api/recurring/:id - get specific recurring expense
+router.get('/:id', async (req: AuthRequest, res: Response) => {
+  try {
+    const recurring = await RecurringExpenseModel.findOne({
+      _id: req.params.id,
+      userId: req.userId,
+    });
+
+    if (!recurring) {
+      res.status(404).json({ error: 'Recurring expense not found' });
+      return;
+    }
+
+    res.json(recurring.toObject());
+  } catch {
+    res.status(500).json({ error: 'Failed to fetch recurring expense' });
+  }
+});
+
+// PUT /api/recurring/:id - update recurring expense
+router.put('/:id', recurringValidation, async (req: AuthRequest, res: Response) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    res.status(400).json({ error: errors.array()[0].msg });
+    return;
+  }
+
+  try {
+    const { name, amount, category, start_date, end_date, frequency, description } = req.body;
+
+    const validation = validateRecurringData({
+      name,
+      amount,
+      start_date,
+      end_date,
+      frequency,
+    });
+
+    if (!validation.valid) {
+      res.status(400).json({ error: validation.errors[0] });
+      return;
+    }
+
+    const updated = await RecurringExpenseModel.findOneAndUpdate(
+      { _id: req.params.id, userId: req.userId },
+      {
+        $set: {
+          name,
+          amount: parseFloat(amount),
+          category,
+          start_date: new Date(start_date),
+          end_date: end_date ? new Date(end_date) : undefined,
+          frequency,
+          description,
+        },
+      },
+      { new: true, runValidators: true }
+    );
+
+    if (!updated) {
+      res.status(404).json({ error: 'Recurring expense not found' });
+      return;
+    }
+
+    res.json(updated.toObject());
+  } catch (error: any) {
+    res.status(400).json({ error: error.message || 'Failed to update recurring expense' });
+  }
+});
+
+// DELETE /api/recurring/:id - delete recurring expense
+router.delete('/:id', async (req: AuthRequest, res: Response) => {
+  try {
+    const deleted = await RecurringExpenseModel.findOneAndDelete({
+      _id: req.params.id,
+      userId: req.userId,
+    });
+
+    if (!deleted) {
+      res.status(404).json({ error: 'Recurring expense not found' });
+      return;
+    }
+
+    res.json({ message: 'Recurring expense deleted' });
+  } catch {
+    res.status(500).json({ error: 'Failed to delete recurring expense' });
+  }
+});
+
+export default router;

--- a/src/routes/recurring.ts
+++ b/src/routes/recurring.ts
@@ -50,8 +50,9 @@ router.get('/', async (req: AuthRequest, res: Response) => {
       start_date: 1,
     });
     res.json({ recurring });
-  } catch {
-    res.status(500).json({ error: 'Failed to fetch recurring expenses' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to fetch recurring expenses';
+    res.status(500).json({ error: message });
   }
 });
 
@@ -112,8 +113,9 @@ router.get('/:id', async (req: AuthRequest, res: Response) => {
     }
 
     res.json(recurring.toObject());
-  } catch {
-    res.status(500).json({ error: 'Failed to fetch recurring expense' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to fetch recurring expense';
+    res.status(500).json({ error: message });
   }
 });
 
@@ -182,8 +184,9 @@ router.delete('/:id', async (req: AuthRequest, res: Response) => {
     }
 
     res.json({ message: 'Recurring expense deleted' });
-  } catch {
-    res.status(500).json({ error: 'Failed to delete recurring expense' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to delete recurring expense';
+    res.status(500).json({ error: message });
   }
 });
 

--- a/src/routes/recurring.ts
+++ b/src/routes/recurring.ts
@@ -1,10 +1,35 @@
-import { Router, Response } from 'express';
+import { Router, Request, Response } from 'express';
 import { body, validationResult } from 'express-validator';
 import RecurringExpenseModel from '../models/RecurringExpense';
 import { protect, AuthRequest } from '../middleware/auth';
 import { validateRecurringData } from '../utils/recurring';
+import { processRecurringJob } from '../jobs/processRecurring';
 
 const router = Router();
+
+// POST /api/recurring/process - manually trigger recurring expense processing
+// Protected by JOBS_API_KEY header (same as other job endpoints)
+router.post('/process', async (req: Request, res: Response) => {
+  const apiKey = process.env.JOBS_API_KEY;
+  if (!apiKey) {
+    res.status(503).json({ error: 'Jobs API key not configured' });
+    return;
+  }
+  const provided = req.headers['x-api-key'];
+  if (!provided || provided !== apiKey) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  const start = Date.now();
+  try {
+    const result = await processRecurringJob();
+    res.json({ ok: true, durationMs: Date.now() - start, ...result });
+  } catch (error) {
+    console.error('[POST /api/recurring/process] Error:', error);
+    res.status(500).json({ error: 'Recurring processing job failed' });
+  }
+});
 
 router.use(protect);
 

--- a/src/routes/recurring.ts
+++ b/src/routes/recurring.ts
@@ -35,7 +35,7 @@ router.use(protect);
 
 const recurringValidation = [
   body('name').notEmpty().withMessage('name is required'),
-  body('amount').isNumeric().withMessage('amount must be a number'),
+  body('amount').isFloat({ gt: 0 }).withMessage('amount must be a positive number'),
   body('start_date').isISO8601().withMessage('start_date must be a valid date'),
   body('end_date').optional().isISO8601().withMessage('end_date must be a valid date'),
   body('frequency')

--- a/src/routes/reports.ts
+++ b/src/routes/reports.ts
@@ -73,8 +73,9 @@ router.get('/monthly', async (req: AuthRequest, res: Response) => {
     });
 
     res.json({ data });
-  } catch {
-    res.status(500).json({ error: 'Failed to fetch monthly report' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to fetch monthly report';
+    res.status(500).json({ error: message });
   }
 });
 
@@ -146,8 +147,9 @@ router.get('/budget-summary', async (req: AuthRequest, res: Response) => {
     const totalRemaining = totalBudgeted - totalSpent;
 
     res.json({ data, totalBudgeted, totalSpent, totalRemaining });
-  } catch {
-    res.status(500).json({ error: 'Failed to fetch budget summary' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to fetch budget summary';
+    res.status(500).json({ error: message });
   }
 });
 
@@ -158,8 +160,9 @@ router.post('/weekly-digest', async (req: AuthRequest, res: Response) => {
     const message = formatDigestMessage(data);
     const sent = await sendWeeklyDigestForUser(userId);
     res.json({ sent, digest: data, message });
-  } catch {
-    res.status(500).json({ error: 'Failed to generate weekly digest' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to generate weekly digest';
+    res.status(500).json({ error: message });
   }
 });
 

--- a/src/routes/reports.ts
+++ b/src/routes/reports.ts
@@ -1,0 +1,79 @@
+import { Router, Response } from 'express';
+import ExpenseModel from '../models/Expense';
+import { protect, AuthRequest } from '../middleware/auth';
+
+const router = Router();
+
+router.use(protect);
+
+function monthLabel(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  return `${y}-${m}`;
+}
+
+function subtractMonths(date: Date, n: number): Date {
+  const d = new Date(date);
+  d.setDate(1);
+  d.setMonth(d.getMonth() - n);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+router.get('/monthly', async (req: AuthRequest, res: Response) => {
+  try {
+    const months = Math.min(parseInt(req.query.months as string) || 6, 24);
+    const now = new Date();
+    const startDate = subtractMonths(now, months - 1);
+
+    const rows = await ExpenseModel.aggregate([
+      {
+        $match: {
+          owner: req.userId,
+          date: { $gte: startDate },
+        },
+      },
+      {
+        $group: {
+          _id: { $dateToString: { format: '%Y-%m', date: '$date' } },
+          income: {
+            $sum: { $cond: [{ $eq: ['$type', 'income'] }, '$amount', 0] },
+          },
+          expenses: {
+            $sum: { $cond: [{ $eq: ['$type', 'expense'] }, '$amount', 0] },
+          },
+          transactionCount: { $sum: 1 },
+        },
+      },
+      { $sort: { _id: 1 } },
+    ]);
+
+    const monthMap: Record<string, { income: number; expenses: number; transactionCount: number }> = {};
+    for (const row of rows) {
+      monthMap[row._id] = {
+        income: row.income,
+        expenses: row.expenses,
+        transactionCount: row.transactionCount,
+      };
+    }
+
+    const data = Array.from({ length: months }, (_, i) => {
+      const d = subtractMonths(now, months - 1 - i);
+      const label = monthLabel(d);
+      const entry = monthMap[label] || { income: 0, expenses: 0, transactionCount: 0 };
+      return {
+        month: label,
+        income: entry.income,
+        expenses: entry.expenses,
+        net: entry.income - entry.expenses,
+        transactionCount: entry.transactionCount,
+      };
+    });
+
+    res.json({ data });
+  } catch {
+    res.status(500).json({ error: 'Failed to fetch monthly report' });
+  }
+});
+
+export default router;

--- a/src/routes/reports.ts
+++ b/src/routes/reports.ts
@@ -1,6 +1,7 @@
 import { Router, Response } from 'express';
 import ExpenseModel from '../models/Expense';
 import { protect, AuthRequest } from '../middleware/auth';
+import { sendWeeklyDigestForUser, aggregateWeeklyData, formatDigestMessage } from '../utils/weeklyDigest';
 
 const router = Router();
 
@@ -73,6 +74,18 @@ router.get('/monthly', async (req: AuthRequest, res: Response) => {
     res.json({ data });
   } catch {
     res.status(500).json({ error: 'Failed to fetch monthly report' });
+  }
+});
+
+router.post('/weekly-digest', async (req: AuthRequest, res: Response) => {
+  try {
+    const userId = req.userId as string;
+    const data = await aggregateWeeklyData(userId, new Date());
+    const message = formatDigestMessage(data);
+    const sent = await sendWeeklyDigestForUser(userId);
+    res.json({ sent, digest: data, message });
+  } catch {
+    res.status(500).json({ error: 'Failed to generate weekly digest' });
   }
 });
 

--- a/src/routes/reports.ts
+++ b/src/routes/reports.ts
@@ -1,5 +1,6 @@
 import { Router, Response } from 'express';
 import ExpenseModel from '../models/Expense';
+import UserModel from '../models/User';
 import { protect, AuthRequest } from '../middleware/auth';
 import { sendWeeklyDigestForUser, aggregateWeeklyData, formatDigestMessage } from '../utils/weeklyDigest';
 
@@ -74,6 +75,79 @@ router.get('/monthly', async (req: AuthRequest, res: Response) => {
     res.json({ data });
   } catch {
     res.status(500).json({ error: 'Failed to fetch monthly report' });
+  }
+});
+
+router.get('/budget-summary', async (req: AuthRequest, res: Response) => {
+  try {
+    const monthParam = req.query.month as string | undefined;
+    let year: number;
+    let month: number;
+
+    if (monthParam) {
+      if (!/^\d{4}-(0[1-9]|1[0-2])$/.test(monthParam)) {
+        res.status(400).json({ error: 'month must be in YYYY-MM format' });
+        return;
+      }
+      [year, month] = monthParam.split('-').map(Number);
+    } else {
+      const now = new Date();
+      year = now.getFullYear();
+      month = now.getMonth() + 1;
+    }
+
+    const startDate = new Date(year, month - 1, 1);
+    const endDate = new Date(year, month, 1);
+
+    const user = await UserModel.findById(req.userId).lean();
+    const budgets = user?.budgets || [];
+
+    const spendingRows = await ExpenseModel.aggregate([
+      {
+        $match: {
+          owner: req.userId,
+          type: 'expense',
+          date: { $gte: startDate, $lt: endDate },
+        },
+      },
+      {
+        $group: {
+          _id: '$category',
+          spent: { $sum: '$amount' },
+        },
+      },
+    ]);
+
+    const spendingMap = new Map<string, number>();
+    for (const row of spendingRows) {
+      spendingMap.set(row._id || 'Uncategorised', row.spent);
+    }
+
+    const categories = new Set<string>();
+    for (const b of budgets) categories.add(b.category);
+    for (const [cat] of spendingMap) categories.add(cat);
+
+    const budgetMap = new Map<string, number>();
+    for (const b of budgets) budgetMap.set(b.category, b.limit);
+
+    const data = Array.from(categories).map((category) => {
+      const budgetLimit = budgetMap.get(category) ?? 0;
+      const spent = spendingMap.get(category) ?? 0;
+      const remaining = budgetLimit - spent;
+      const percentUsed = budgetLimit > 0 ? Math.round((spent / budgetLimit) * 10000) / 100 : 0;
+      const overBudget = budgetLimit > 0 && spent > budgetLimit;
+      return { category, budgetLimit, spent, remaining, percentUsed, overBudget };
+    });
+
+    data.sort((a, b) => b.percentUsed - a.percentUsed);
+
+    const totalBudgeted = data.reduce((sum, d) => sum + d.budgetLimit, 0);
+    const totalSpent = data.reduce((sum, d) => sum + d.spent, 0);
+    const totalRemaining = totalBudgeted - totalSpent;
+
+    res.json({ data, totalBudgeted, totalSpent, totalRemaining });
+  } catch {
+    res.status(500).json({ error: 'Failed to fetch budget summary' });
   }
 });
 

--- a/src/routes/templates.ts
+++ b/src/routes/templates.ts
@@ -1,0 +1,197 @@
+import { Router, Response } from 'express';
+import { body, validationResult } from 'express-validator';
+import TransactionTemplateModel from '../models/TransactionTemplate';
+import ExpenseModel from '../models/Expense';
+import { protect, AuthRequest } from '../middleware/auth';
+
+const router = Router();
+
+router.use(protect);
+
+const templateValidation = [
+  body('name').notEmpty().withMessage('name is required'),
+  body('amount').isNumeric().withMessage('amount must be a number'),
+  body('frequency')
+    .isIn(['weekly', 'biweekly', 'monthly'])
+    .withMessage('frequency must be one of: weekly, biweekly, monthly'),
+  body('category').optional().isString().withMessage('category must be a string'),
+  body('description').optional().isString().withMessage('description must be a string'),
+];
+
+// GET /api/templates - list all templates for user
+router.get('/', async (req: AuthRequest, res: Response) => {
+  try {
+    const templates = await TransactionTemplateModel.find({ owner: req.userId }).sort({
+      createdAt: -1,
+    });
+    res.json({ templates });
+  } catch {
+    res.status(500).json({ error: 'Failed to fetch templates' });
+  }
+});
+
+// POST /api/templates - create new template
+router.post('/', templateValidation, async (req: AuthRequest, res: Response) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    res.status(400).json({ error: errors.array()[0].msg });
+    return;
+  }
+
+  try {
+    const { name, amount, category, description, frequency } = req.body;
+
+    const template = new TransactionTemplateModel({
+      owner: req.userId,
+      name,
+      amount: parseFloat(amount),
+      category,
+      description,
+      frequency,
+    });
+
+    const saved = await template.save();
+    res.status(201).json(saved.toObject());
+  } catch (error: any) {
+    res.status(400).json({ error: error.message || 'Failed to create template' });
+  }
+});
+
+// GET /api/templates/:id - get specific template
+router.get('/:id', async (req: AuthRequest, res: Response) => {
+  try {
+    const template = await TransactionTemplateModel.findOne({
+      _id: req.params.id,
+      owner: req.userId,
+    });
+
+    if (!template) {
+      res.status(404).json({ error: 'Template not found' });
+      return;
+    }
+
+    res.json(template.toObject());
+  } catch {
+    res.status(500).json({ error: 'Failed to fetch template' });
+  }
+});
+
+// PUT /api/templates/:id - update template
+router.put('/:id', templateValidation, async (req: AuthRequest, res: Response) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    res.status(400).json({ error: errors.array()[0].msg });
+    return;
+  }
+
+  try {
+    const { name, amount, category, description, frequency } = req.body;
+
+    const updated = await TransactionTemplateModel.findOneAndUpdate(
+      { _id: req.params.id, owner: req.userId },
+      {
+        $set: {
+          name,
+          amount: parseFloat(amount),
+          category,
+          description,
+          frequency,
+        },
+      },
+      { new: true, runValidators: true }
+    );
+
+    if (!updated) {
+      res.status(404).json({ error: 'Template not found' });
+      return;
+    }
+
+    res.json(updated.toObject());
+  } catch (error: any) {
+    res.status(400).json({ error: error.message || 'Failed to update template' });
+  }
+});
+
+// DELETE /api/templates/:id - delete template
+router.delete('/:id', async (req: AuthRequest, res: Response) => {
+  try {
+    const deleted = await TransactionTemplateModel.findOneAndDelete({
+      _id: req.params.id,
+      owner: req.userId,
+    });
+
+    if (!deleted) {
+      res.status(404).json({ error: 'Template not found' });
+      return;
+    }
+
+    res.json({ message: 'Template deleted' });
+  } catch {
+    res.status(500).json({ error: 'Failed to delete template' });
+  }
+});
+
+// POST /api/templates/apply/:id - apply single template to create expense
+router.post('/apply/:id', async (req: AuthRequest, res: Response) => {
+  try {
+    const template = await TransactionTemplateModel.findOne({
+      _id: req.params.id,
+      owner: req.userId,
+    });
+
+    if (!template) {
+      res.status(404).json({ error: 'Template not found' });
+      return;
+    }
+
+    const expense = new ExpenseModel({
+      owner: req.userId,
+      description: template.name,
+      category: template.category,
+      amount: template.amount,
+      date: new Date(),
+    });
+
+    const saved = await expense.save();
+    res.status(201).json(saved.toObject());
+  } catch (error: any) {
+    res.status(400).json({ error: error.message || 'Failed to apply template' });
+  }
+});
+
+// POST /api/templates/apply-multiple - apply multiple templates at once
+router.post('/apply-multiple', async (req: AuthRequest, res: Response) => {
+  const { templateIds } = req.body;
+
+  if (!Array.isArray(templateIds) || templateIds.length === 0) {
+    res.status(400).json({ error: 'templateIds must be a non-empty array' });
+    return;
+  }
+
+  try {
+    const templates = await TransactionTemplateModel.find({
+      _id: { $in: templateIds },
+      owner: req.userId,
+    });
+
+    if (templates.length !== templateIds.length) {
+      res.status(404).json({ error: 'Some templates not found or unauthorized' });
+      return;
+    }
+
+    const expenses = templates.map((template) => ({
+      owner: req.userId,
+      description: template.name,
+      category: template.category,
+      amount: template.amount,
+      date: new Date(),
+    }));
+
+    const created = await ExpenseModel.insertMany(expenses);
+    res.status(201).json({ created: created.length, expenses: created });
+  } catch (error: any) {
+    res.status(400).json({ error: error.message || 'Failed to apply templates' });
+  }
+});
+
+export default router;

--- a/src/routes/templates.ts
+++ b/src/routes/templates.ts
@@ -25,8 +25,9 @@ router.get('/', async (req: AuthRequest, res: Response) => {
       createdAt: -1,
     });
     res.json({ templates });
-  } catch {
-    res.status(500).json({ error: 'Failed to fetch templates' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to fetch templates';
+    res.status(500).json({ error: message });
   }
 });
 
@@ -71,8 +72,9 @@ router.get('/:id', async (req: AuthRequest, res: Response) => {
     }
 
     res.json(template.toObject());
-  } catch {
-    res.status(500).json({ error: 'Failed to fetch template' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to fetch template';
+    res.status(500).json({ error: message });
   }
 });
 
@@ -126,8 +128,9 @@ router.delete('/:id', async (req: AuthRequest, res: Response) => {
     }
 
     res.json({ message: 'Template deleted' });
-  } catch {
-    res.status(500).json({ error: 'Failed to delete template' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to delete template';
+    res.status(500).json({ error: message });
   }
 });
 

--- a/src/routes/transactions.ts
+++ b/src/routes/transactions.ts
@@ -1,0 +1,44 @@
+import { Router, Response } from 'express';
+import { body, validationResult } from 'express-validator';
+import { protect, AuthRequest } from '../middleware/auth';
+import { parseTransactionText } from '../utils/parseTransactionText';
+
+const router = Router();
+
+router.use(protect);
+
+router.post(
+  '/parse-text',
+  [
+    body('text')
+      .isString()
+      .trim()
+      .notEmpty()
+      .withMessage('text is required')
+      .isLength({ max: 500 })
+      .withMessage('text must be at most 500 characters'),
+    body('locale')
+      .optional()
+      .isString()
+      .isLength({ max: 10 })
+      .withMessage('locale must be at most 10 characters'),
+  ],
+  (req: AuthRequest, res: Response): void => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({ errors: errors.array() });
+      return;
+    }
+
+    const { text, locale } = req.body as { text: string; locale?: string };
+
+    try {
+      const parsed = parseTransactionText(text, locale);
+      res.json(parsed);
+    } catch {
+      res.status(500).json({ error: 'Failed to parse transaction text' });
+    }
+  },
+);
+
+export default router;

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -1,0 +1,62 @@
+import { Router, Response } from 'express';
+import { body, validationResult } from 'express-validator';
+import UserModel from '../models/User';
+import { protect, AuthRequest } from '../middleware/auth';
+
+const router = Router();
+
+router.use(protect);
+
+// GET /api/users/me
+router.get('/me', async (req: AuthRequest, res: Response) => {
+  try {
+    const user = await UserModel.findById(req.userId).select('-password').lean();
+    if (!user) {
+      res.status(404).json({ error: 'User not found' });
+      return;
+    }
+    res.json({ user });
+  } catch {
+    res.status(500).json({ error: 'Failed to fetch user' });
+  }
+});
+
+// PATCH /api/users/preferences
+router.patch(
+  '/preferences',
+  [
+    body('themePreference')
+      .isIn(['light', 'dark', 'system'])
+      .withMessage('themePreference must be one of: light, dark, system'),
+  ],
+  async (req: AuthRequest, res: Response) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({ error: errors.array()[0].msg });
+      return;
+    }
+
+    try {
+      const { themePreference } = req.body as { themePreference: 'light' | 'dark' | 'system' };
+
+      const user = await UserModel.findByIdAndUpdate(
+        req.userId,
+        { $set: { themePreference } },
+        { new: true, runValidators: true }
+      )
+        .select('-password')
+        .lean();
+
+      if (!user) {
+        res.status(404).json({ error: 'User not found' });
+        return;
+      }
+
+      res.json({ user });
+    } catch {
+      res.status(500).json({ error: 'Failed to update preferences' });
+    }
+  }
+);
+
+export default router;

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -59,4 +59,54 @@ router.patch(
   }
 );
 
+// PATCH /api/users/password
+router.patch(
+  '/password',
+  [
+    body('currentPassword')
+      .notEmpty()
+      .withMessage('currentPassword is required'),
+    body('newPassword')
+      .isLength({ min: 6 })
+      .withMessage('newPassword must be at least 6 characters'),
+  ],
+  async (req: AuthRequest, res: Response) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({ error: errors.array()[0].msg });
+      return;
+    }
+
+    try {
+      const { currentPassword, newPassword } = req.body as {
+        currentPassword: string;
+        newPassword: string;
+      };
+
+      const user = await UserModel.findById(req.userId);
+      if (!user) {
+        res.status(404).json({ error: 'User not found' });
+        return;
+      }
+
+      if (!user.password) {
+        res.status(400).json({ error: 'Password change not available for social login accounts' });
+        return;
+      }
+
+      const isMatch = await user.comparePassword(currentPassword);
+      if (!isMatch) {
+        res.status(400).json({ error: 'Current password is incorrect' });
+        return;
+      }
+
+      user.password = newPassword;
+      await user.save();
+
+      res.json({ message: 'Password updated' });
+    } catch {
+      res.status(500).json({ error: 'Failed to update password' });
+    }
+  }
+);
 export default router;

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -16,8 +16,9 @@ router.get('/me', async (req: AuthRequest, res: Response) => {
       return;
     }
     res.json({ user });
-  } catch {
-    res.status(500).json({ error: 'Failed to fetch user' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to fetch user';
+    res.status(500).json({ error: message });
   }
 });
 
@@ -53,8 +54,9 @@ router.patch(
       }
 
       res.json({ user });
-    } catch {
-      res.status(500).json({ error: 'Failed to update preferences' });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to update preferences';
+      res.status(500).json({ error: message });
     }
   }
 );
@@ -104,8 +106,9 @@ router.patch(
       await user.save();
 
       res.json({ message: 'Password updated' });
-    } catch {
-      res.status(500).json({ error: 'Failed to update password' });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to update password';
+      res.status(500).json({ error: message });
     }
   }
 );

--- a/src/utils/alerts.ts
+++ b/src/utils/alerts.ts
@@ -1,0 +1,155 @@
+import UserModel from '../models/User';
+import ExpenseModel from '../models/Expense';
+import AlertModel from '../models/Alert';
+
+/**
+ * Check if an expense causes any budget threshold to be exceeded
+ * and queue alert notifications for Telegram
+ */
+export async function checkAndQueueBudgetAlerts(userId: string): Promise<void> {
+  try {
+    const user = await UserModel.findById(userId).lean();
+    if (!user || !user.budgets || user.budgets.length === 0) return;
+
+    // Get current month boundaries
+    const now = new Date();
+    const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+    const monthEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0);
+
+    // Get all expenses for current month
+    const expenses = await ExpenseModel.find(
+      {
+        owner: userId,
+        type: 'expense',
+        date: { $gte: monthStart, $lte: monthEnd },
+      },
+      { category: 1, amount: 1 }
+    ).lean();
+
+    // Calculate spend by category
+    const categorySpend: { [key: string]: number } = {};
+    expenses.forEach((exp) => {
+      const cat = exp.category || 'Uncategorized';
+      categorySpend[cat] = (categorySpend[cat] || 0) + exp.amount;
+    });
+
+    // Check each budget for alerts
+    for (const budget of user.budgets) {
+      if (!budget.enable_alerts) continue;
+
+      const spend = categorySpend[budget.category] || 0;
+      const threshold = budget.alert_threshold || 0.9;
+      const percentUsed = budget.limit > 0 ? (spend / budget.limit) * 100 : 0;
+
+      // Queue alert if threshold exceeded
+      if (percentUsed >= threshold * 100) {
+        // Check if we already have an unsent alert for this category this month
+        const existingAlert = await AlertModel.findOne({
+          userId,
+          category: budget.category,
+          sent: false,
+          createdAt: { $gte: monthStart },
+        });
+
+        if (!existingAlert) {
+          const remaining = Math.max(0, budget.limit - spend);
+          const message = formatAlertMessage(
+            budget.category,
+            spend,
+            budget.limit,
+            remaining,
+            Math.round(percentUsed)
+          );
+
+          await AlertModel.create({
+            userId,
+            category: budget.category,
+            amount: spend,
+            limit: budget.limit,
+            percentUsed: Math.round(percentUsed),
+            message,
+            sent: false,
+          });
+        }
+      }
+    }
+  } catch (error) {
+    console.error('Error checking budget alerts:', error);
+  }
+}
+
+/**
+ * Format alert message for Telegram
+ */
+function formatAlertMessage(
+  category: string,
+  spend: number,
+  limit: number,
+  remaining: number,
+  percentUsed: number
+): string {
+  return (
+    `🚨 Budget Alert: ${category}\n\n` +
+    `Spent: $${spend.toFixed(2)}\n` +
+    `Limit: $${limit.toFixed(2)}\n` +
+    `Remaining: $${remaining.toFixed(2)}\n` +
+    `Usage: ${percentUsed}%`
+  );
+}
+
+/**
+ * Send Telegram message
+ */
+export async function sendTelegramMessage(message: string): Promise<boolean> {
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  const chatId = process.env.TELEGRAM_CHAT_ID;
+
+  if (!token || !chatId) {
+    console.log('Telegram env vars not configured, skipping notification');
+    return false;
+  }
+
+  try {
+    const url = `https://api.telegram.org/bot${token}/sendMessage`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        chat_id: chatId,
+        text: message,
+        parse_mode: 'HTML',
+      }),
+    });
+
+    if (!response.ok) {
+      console.error('Telegram API error:', response.status, response.statusText);
+      return false;
+    }
+
+    return true;
+  } catch (error) {
+    console.error('Error sending Telegram message:', error);
+    return false;
+  }
+}
+
+/**
+ * Process pending alert queue and send via Telegram
+ */
+export async function processPendingAlerts(): Promise<void> {
+  try {
+    const unsent = await AlertModel.find({ sent: false });
+
+    for (const alert of unsent) {
+      const sent = await sendTelegramMessage(alert.message);
+      if (sent) {
+        await AlertModel.updateOne(
+          { _id: alert._id },
+          { $set: { sent: true, sentAt: new Date() } }
+        );
+      }
+    }
+  } catch (error) {
+    console.error('Error processing pending alerts:', error);
+  }
+}

--- a/src/utils/exchangeRates.ts
+++ b/src/utils/exchangeRates.ts
@@ -1,0 +1,93 @@
+import type { SupportedCurrency } from '../models/Expense';
+
+// Fallback approximate rates: how many HKD per 1 unit of foreign currency
+// These are approximate as of early 2026 and serve as fallback when API is unavailable
+const FALLBACK_RATES: Record<string, number> = {
+  CNY: 1.08,
+  JPY: 0.052,
+  USD: 7.80,
+  EUR: 8.50,
+  GBP: 9.90,
+  TWD: 0.24,
+  THB: 0.22,
+  KRW: 0.0057,
+};
+
+const EXCHANGE_RATE_API_URL = process.env.EXCHANGE_RATE_API_URL || 'https://open.er-api.com/v6/latest/HKD';
+
+interface ExchangeRateResponse {
+  rates: Record<string, number>;
+  source: 'api' | 'fallback';
+  updatedAt: string;
+}
+
+let cachedRates: ExchangeRateResponse | null = null;
+let cacheExpiry = 0;
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+export async function getExchangeRates(): Promise<ExchangeRateResponse> {
+  if (cachedRates && Date.now() < cacheExpiry) {
+    return cachedRates;
+  }
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+
+    const response = await fetch(EXCHANGE_RATE_API_URL, { signal: controller.signal });
+    clearTimeout(timeout);
+
+    if (!response.ok) {
+      throw new Error(`API returned ${response.status}`);
+    }
+
+    const data = await response.json() as { result: string; rates: Record<string, number> };
+
+    if (data.result !== 'success' || !data.rates) {
+      throw new Error('Invalid API response');
+    }
+
+    // API returns rates FROM HKD, e.g. HKD->USD = 0.128
+    // We need rates TO HKD, e.g. 1 USD = 7.8 HKD
+    const targetCurrencies = ['CNY', 'JPY', 'USD', 'EUR', 'GBP', 'TWD', 'THB', 'KRW'];
+    const rates: Record<string, number> = {};
+
+    for (const currency of targetCurrencies) {
+      const apiRate = data.rates[currency];
+      if (apiRate && apiRate > 0) {
+        rates[currency] = Math.round((1 / apiRate) * 10000) / 10000;
+      } else {
+        rates[currency] = FALLBACK_RATES[currency];
+      }
+    }
+
+    cachedRates = {
+      rates,
+      source: 'api',
+      updatedAt: new Date().toISOString(),
+    };
+    cacheExpiry = Date.now() + CACHE_TTL_MS;
+
+    return cachedRates;
+  } catch {
+    // Fallback to hardcoded rates
+    const fallback: ExchangeRateResponse = {
+      rates: { ...FALLBACK_RATES },
+      source: 'fallback',
+      updatedAt: new Date().toISOString(),
+    };
+    cachedRates = fallback;
+    cacheExpiry = Date.now() + 5 * 60 * 1000; // Cache fallback for 5 minutes
+    return fallback;
+  }
+}
+
+export function convertToHKD(amount: number, currency: SupportedCurrency, rate: number): number {
+  if (currency === 'HKD') return amount;
+  return Math.round(amount * rate * 100) / 100;
+}
+
+export function clearRateCache(): void {
+  cachedRates = null;
+  cacheExpiry = 0;
+}

--- a/src/utils/monthlySummary.ts
+++ b/src/utils/monthlySummary.ts
@@ -1,0 +1,199 @@
+import UserModel, { IBudget, IUser } from '../models/User';
+import ExpenseModel from '../models/Expense';
+import { sendTelegramMessageToChat } from './telegram';
+
+interface CategoryTotal {
+  category: string;
+  total: number;
+}
+
+interface BudgetAlert {
+  category: string;
+  spent: number;
+  limit: number;
+  percentUsed: number;
+}
+
+export interface MonthlySummaryData {
+  month: string;
+  totalIncome: number;
+  totalExpense: number;
+  net: number;
+  topCategories: CategoryTotal[];
+  budgetAlerts: BudgetAlert[];
+  prevMonthExpense: number;
+  momChangePercent: number | null;
+}
+
+export function getPreviousMonthBounds(now: Date): { start: Date; end: Date; label: string } {
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth(); // 0-indexed; this is "current" month index
+  // Previous month
+  const prevMonth = month === 0 ? 11 : month - 1;
+  const prevYear = month === 0 ? year - 1 : year;
+  const start = new Date(Date.UTC(prevYear, prevMonth, 1));
+  const end = new Date(Date.UTC(prevYear, prevMonth + 1, 1));
+  const label = `${prevYear}-${String(prevMonth + 1).padStart(2, '0')}`;
+  return { start, end, label };
+}
+
+export function getPriorMonthBounds(now: Date): { start: Date; end: Date } {
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth();
+  // Two months back
+  const priorMonth = month <= 1 ? month + 10 : month - 2;
+  const priorYear = month <= 1 ? year - 1 : year;
+  const start = new Date(Date.UTC(priorYear, priorMonth, 1));
+  const end = new Date(Date.UTC(priorYear, priorMonth + 1, 1));
+  return { start, end };
+}
+
+export async function aggregateMonthlySummary(userId: string, now?: Date): Promise<MonthlySummaryData> {
+  const currentDate = now ?? new Date();
+  const { start, end, label } = getPreviousMonthBounds(currentDate);
+  const prior = getPriorMonthBounds(currentDate);
+
+  const matchStage = {
+    $match: {
+      owner: userId,
+      date: { $gte: start, $lt: end },
+    },
+  };
+
+  const [summaryResult, categoryResult, priorResult] = await Promise.all([
+    ExpenseModel.aggregate([
+      matchStage,
+      {
+        $group: {
+          _id: '$type',
+          total: { $sum: '$amount' },
+        },
+      },
+    ]),
+    ExpenseModel.aggregate([
+      matchStage,
+      { $match: { type: 'expense' } },
+      {
+        $group: {
+          _id: '$category',
+          total: { $sum: '$amount' },
+        },
+      },
+      { $sort: { total: -1 } },
+      { $limit: 5 },
+    ]),
+    ExpenseModel.aggregate([
+      {
+        $match: {
+          owner: userId,
+          type: 'expense',
+          date: { $gte: prior.start, $lt: prior.end },
+        },
+      },
+      {
+        $group: {
+          _id: null,
+          total: { $sum: '$amount' },
+        },
+      },
+    ]),
+  ]);
+
+  const totalIncome = summaryResult.find((r: { _id: string }) => r._id === 'income')?.total ?? 0;
+  const totalExpense = summaryResult.find((r: { _id: string }) => r._id === 'expense')?.total ?? 0;
+  const net = totalIncome - totalExpense;
+
+  const topCategories: CategoryTotal[] = categoryResult.map(
+    (row: { _id: string | null; total: number }) => ({
+      category: row._id ?? 'Uncategorised',
+      total: row.total,
+    })
+  );
+
+  const prevMonthExpense: number = priorResult[0]?.total ?? 0;
+  let momChangePercent: number | null = null;
+  if (prevMonthExpense > 0) {
+    momChangePercent = Math.round(((totalExpense - prevMonthExpense) / prevMonthExpense) * 100);
+  }
+
+  return { month: label, totalIncome, totalExpense, net, topCategories, budgetAlerts: [], prevMonthExpense, momChangePercent };
+}
+
+export async function buildBudgetAlerts(userId: string, totalsByCategory: CategoryTotal[], budgets: IBudget[]): Promise<BudgetAlert[]> {
+  const alerts: BudgetAlert[] = [];
+  const budgetMap = new Map<string, number>();
+  for (const b of budgets) budgetMap.set(b.category, b.limit);
+
+  for (const cat of totalsByCategory) {
+    const limit = budgetMap.get(cat.category);
+    if (limit && limit > 0 && cat.total > limit) {
+      const percentUsed = Math.round((cat.total / limit) * 10000) / 100;
+      alerts.push({ category: cat.category, spent: cat.total, limit, percentUsed });
+    }
+  }
+  return alerts;
+}
+
+export function formatMonthlySummaryMessage(data: MonthlySummaryData): string {
+  const { month, totalIncome, totalExpense, net, topCategories, budgetAlerts, momChangePercent } = data;
+
+  let msg = `<b>Monthly Summary — ${month}</b>\n\n`;
+  msg += `<b>Income:</b> $${totalIncome.toFixed(2)}\n`;
+  msg += `<b>Expenses:</b> $${totalExpense.toFixed(2)}\n`;
+  msg += `<b>Net:</b> $${net.toFixed(2)}\n`;
+
+  if (momChangePercent !== null) {
+    const arrow = momChangePercent > 0 ? '↑' : momChangePercent < 0 ? '↓' : '→';
+    msg += `<b>vs Prior Month:</b> ${arrow} ${Math.abs(momChangePercent)}%\n`;
+  } else {
+    msg += `<b>vs Prior Month:</b> No data\n`;
+  }
+
+  if (topCategories.length > 0) {
+    msg += `\n<b>Top Categories:</b>\n`;
+    topCategories.forEach((cat, i) => {
+      msg += `  ${i + 1}. ${cat.category} — $${cat.total.toFixed(2)}\n`;
+    });
+  }
+
+  if (budgetAlerts.length > 0) {
+    msg += `\n<b>Over Budget:</b>\n`;
+    for (const alert of budgetAlerts) {
+      msg += `  ${alert.category}: $${alert.spent.toFixed(2)} / $${alert.limit.toFixed(2)} (${alert.percentUsed}%)\n`;
+    }
+  }
+
+  return msg;
+}
+
+export async function sendMonthlySummaryForUser(userId: string, now?: Date): Promise<boolean> {
+  const data = await aggregateMonthlySummary(userId, now);
+
+  const user = await UserModel.findById(userId).lean();
+  if (!user?.telegramChatId) return false;
+
+  const alerts = await buildBudgetAlerts(userId, data.topCategories, (user as IUser).budgets ?? []);
+  data.budgetAlerts = alerts;
+
+  const message = formatMonthlySummaryMessage(data);
+  return sendTelegramMessageToChat(user.telegramChatId, message);
+}
+
+export async function processMonthlySummaries(): Promise<number> {
+  const users = await UserModel.find({
+    telegramChatId: { $exists: true, $ne: '' },
+  }).lean();
+
+  let sentCount = 0;
+  for (const user of users) {
+    const userId = (user as IUser)._id.toString();
+    try {
+      const sent = await sendMonthlySummaryForUser(userId);
+      if (sent) sentCount++;
+    } catch (error) {
+      console.error(`[MonthlySummary] Failed for user ${userId}:`, error);
+    }
+  }
+
+  return sentCount;
+}

--- a/src/utils/parseTransactionText.ts
+++ b/src/utils/parseTransactionText.ts
@@ -1,0 +1,296 @@
+/**
+ * Natural-language parser for quick expense entry.
+ *
+ * Ported from money-flow-mobile/lib/parse-quick-expense.ts and enhanced
+ * with participant detection, date parsing, split-bill support, and
+ * Cantonese/Chinese patterns.
+ */
+
+export interface ParsedTransaction {
+  merchant?: string;
+  amount?: number;
+  currency?: string;
+  category?: string;
+  subcategory?: string;
+  participants?: string[];
+  date?: string;
+  notes?: string;
+  confidence?: number;
+  missing_fields?: string[];
+}
+
+// ── Category keyword map ────────────────────────────────────────────────
+
+const CATEGORY_KEYWORDS: Record<string, readonly string[]> = {
+  food: [
+    'food', 'restaurant', 'dinner', 'lunch', 'breakfast', 'cafe', 'coffee',
+    'pizza', 'burger', 'sushi', 'grocery', 'groceries', 'supermarket', 'market',
+    'starbucks', 'mcdonald', 'kfc', 'subway', 'snack', 'milk', 'tea', 'ramen',
+    'noodle', 'rice', 'bread', 'bakery', 'eat', 'meal', 'brunch',
+    // Cantonese food keywords
+    '食', '飲', '餐', '茶', '麥當勞', '咖啡', '奶茶', '飯', '麵',
+  ],
+  transport: [
+    'transport', 'uber', 'taxi', 'gas', 'petrol', 'bus', 'metro', 'mtr',
+    'parking', 'fuel', 'grab', 'lyft', 'train', 'flight',
+    '車', '巴士', '的士', '地鐵', '港鐵',
+  ],
+  shopping: [
+    'shopping', 'clothes', 'fashion', 'dress', 'shoes', 'clothing', 'amazon',
+    'shirt', 'pants',
+    '買', '衫',
+  ],
+  entertainment: [
+    'entertainment', 'movie', 'cinema', 'game', 'show', 'concert', 'netflix',
+    'gaming', 'spotify', 'museum', 'tickets',
+    '戲', '電影',
+  ],
+  bills: [
+    'bill', 'bills', 'utilities', 'electricity', 'water', 'internet', 'phone',
+    'utility', 'rent', 'insurance', 'subscription',
+    '租', '水電', '電話',
+  ],
+  health: [
+    'health', 'doctor', 'pharmacy', 'medicine', 'gym', 'medical', 'dental',
+    'hospital',
+    '醫', '藥',
+  ],
+  education: [
+    'education', 'school', 'course', 'book', 'tuition', 'class', 'textbook',
+    'udemy', 'coursera',
+    '書', '學',
+  ],
+};
+
+// ── Currency maps ───────────────────────────────────────────────────────
+
+const CURRENCY_CODES: Record<string, string> = {
+  cny: 'CNY', rmb: 'CNY', jpy: 'JPY', yen: 'JPY',
+  usd: 'USD', eur: 'EUR', gbp: 'GBP', twd: 'TWD',
+  thb: 'THB', krw: 'KRW', cad: 'CAD', hkd: 'HKD',
+};
+
+const CURRENCY_SYMBOL_PREFIXES: Record<string, string> = {
+  '\u00a5': 'CNY', '\uffe5': 'CNY', '\u20ac': 'EUR',
+  '\u00a3': 'GBP', '\u20a9': 'KRW',
+};
+
+// ── Date helpers ────────────────────────────────────────────────────────
+
+function toISODate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+const DATE_KEYWORDS: Record<string, () => string> = {
+  today: () => toISODate(new Date()),
+  yesterday: () => {
+    const d = new Date();
+    d.setDate(d.getDate() - 1);
+    return toISODate(d);
+  },
+  '今日': () => toISODate(new Date()),
+  '今天': () => toISODate(new Date()),
+  '昨日': () => {
+    const d = new Date();
+    d.setDate(d.getDate() - 1);
+    return toISODate(d);
+  },
+  '昨天': () => {
+    const d = new Date();
+    d.setDate(d.getDate() - 1);
+    return toISODate(d);
+  },
+};
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+function suggestCategory(text: string): string | undefined {
+  const lower = text.toLowerCase();
+  for (const [category, keywords] of Object.entries(CATEGORY_KEYWORDS)) {
+    if (keywords.some((kw) => lower.includes(kw))) {
+      return category;
+    }
+  }
+  return undefined;
+}
+
+function extractParticipants(text: string): { participants: string[]; cleaned: string } {
+  const participants: string[] = [];
+  let cleaned = text;
+
+  // English: "with Casey", "with Casey and Bob"
+  const withPattern = /\bwith\s+([A-Z][a-z]+(?:\s+and\s+[A-Z][a-z]+)*)/g;
+  let match = withPattern.exec(cleaned);
+  while (match) {
+    const names = match[1].split(/\s+and\s+/i);
+    participants.push(...names.map((n) => n.trim()));
+    cleaned = cleaned.replace(match[0], '');
+    match = withPattern.exec(cleaned);
+  }
+
+  // Cantonese: "同Casey" or "同Casey同Bob"
+  const cantoneseWithPattern = /同([A-Z][a-z]+)/g;
+  let cantMatch = cantoneseWithPattern.exec(cleaned);
+  while (cantMatch) {
+    participants.push(cantMatch[1]);
+    cleaned = cleaned.replace(cantMatch[0], '');
+    cantMatch = cantoneseWithPattern.exec(cleaned);
+  }
+
+  return { participants: [...new Set(participants)], cleaned: cleaned.trim() };
+}
+
+function extractDate(text: string): { date: string | undefined; cleaned: string } {
+  let cleaned = text;
+  let date: string | undefined;
+
+  // Check keyword dates
+  for (const [keyword, fn] of Object.entries(DATE_KEYWORDS)) {
+    if (cleaned.toLowerCase().includes(keyword.toLowerCase())) {
+      cleaned = cleaned.replace(new RegExp(keyword, 'i'), '').trim();
+      date = fn();
+      break;
+    }
+  }
+
+  // Always strip time patterns like "12:00"
+  cleaned = cleaned.replace(/\b\d{1,2}:\d{2}\b/, '').trim();
+
+  return { date, cleaned };
+}
+
+function extractSplitBill(text: string): { splitBill: boolean; cleaned: string } {
+  const patterns = [/\beach\b/i, /\bper\s+person\b/i, /\bsplit\b/i, /\bAA\b/, /每人/];
+  for (const pat of patterns) {
+    if (pat.test(text)) {
+      return { splitBill: true, cleaned: text.replace(pat, '').trim() };
+    }
+  }
+  return { splitBill: false, cleaned: text };
+}
+
+function extractAmount(text: string): { amount: number | undefined; currency: string | undefined; cleaned: string } {
+  let cleaned = text;
+  let currency: string | undefined;
+
+  // Check symbol-prefixed amounts (e.g., "EUR50", "GBP12")
+  for (const [sym, cur] of Object.entries(CURRENCY_SYMBOL_PREFIXES)) {
+    const escaped = sym.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const regex = new RegExp(`${escaped}(\\d+\\.?\\d*)`);
+    const m = cleaned.match(regex);
+    if (m) {
+      currency = cur;
+      cleaned = cleaned.replace(regex, m[1]);
+      break;
+    }
+  }
+
+  // $-prefixed amounts
+  const dollarMatch = cleaned.match(/\$(\d+\.?\d*)/);
+  if (dollarMatch) {
+    cleaned = cleaned.replace(/\$\d+\.?\d*/, dollarMatch[1]);
+  }
+
+  // Find amount — first numeric token
+  const parts = cleaned.split(/\s+/);
+  let amount: number | undefined;
+  const remaining: string[] = [];
+
+  for (const part of parts) {
+    const num = parseFloat(part);
+    if (!isNaN(num) && num >= 0 && amount === undefined) {
+      amount = num;
+      // Check if the next-ish word is a currency code
+    } else {
+      // Check for currency code
+      const curCode = CURRENCY_CODES[part.toLowerCase()];
+      if (curCode && !currency) {
+        currency = curCode;
+      } else {
+        remaining.push(part);
+      }
+    }
+  }
+
+  // HKD is default — omit from response
+  if (currency === 'HKD') {
+    currency = undefined;
+  }
+
+  return { amount, currency, cleaned: remaining.join(' ').trim() };
+}
+
+// ── Main parser ─────────────────────────────────────────────────────────
+
+export function parseTransactionText(text: string, _locale?: string): ParsedTransaction {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return {
+      confidence: 0,
+      missing_fields: ['amount', 'merchant'],
+    };
+  }
+
+  // Pipeline: extract structured data step by step, cleaning the text along the way
+  const dateResult = extractDate(trimmed);
+  const participantResult = extractParticipants(dateResult.cleaned);
+  const splitResult = extractSplitBill(participantResult.cleaned);
+  const amountResult = extractAmount(splitResult.cleaned);
+
+  const description = amountResult.cleaned
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+
+  const category = suggestCategory(description || trimmed);
+
+  // Build the result
+  const result: ParsedTransaction = {};
+  let confidence = 0;
+  const missingFields: string[] = [];
+
+  if (amountResult.amount !== undefined && amountResult.amount > 0) {
+    result.amount = amountResult.amount;
+    confidence += 0.4;
+  } else {
+    missingFields.push('amount');
+  }
+
+  if (description) {
+    result.merchant = description;
+    confidence += 0.3;
+  } else {
+    missingFields.push('merchant');
+  }
+
+  if (category) {
+    result.category = category;
+    confidence += 0.15;
+  }
+
+  if (amountResult.currency) {
+    result.currency = amountResult.currency;
+  }
+
+  if (dateResult.date) {
+    result.date = dateResult.date;
+    confidence += 0.05;
+  }
+
+  if (participantResult.participants.length > 0) {
+    result.participants = participantResult.participants;
+    confidence += 0.05;
+
+    // If split bill, note it
+    if (splitResult.splitBill) {
+      result.notes = `Split bill (${amountResult.amount ?? '?'} each)`;
+      confidence += 0.05;
+    }
+  }
+
+  result.confidence = Math.min(confidence, 1);
+  if (missingFields.length > 0) {
+    result.missing_fields = missingFields;
+  }
+
+  return result;
+}

--- a/src/utils/parseTransactionText.ts
+++ b/src/utils/parseTransactionText.ts
@@ -188,8 +188,12 @@ function extractAmount(text: string): { amount: number | undefined; currency: st
   // $-prefixed amounts
   const dollarMatch = cleaned.match(/\$(\d+\.?\d*)/);
   if (dollarMatch) {
-    cleaned = cleaned.replace(/\$\d+\.?\d*/, dollarMatch[1]);
+    cleaned = cleaned.replace(/\$\d+\.?\d*/, ' ' + dollarMatch[1] + ' ');
   }
+
+  // Separate CJK characters from numbers (e.g. "每人65" → "每人 65")
+  cleaned = cleaned.replace(/([\u4e00-\u9fff\u3400-\u4dbf])(\d)/g, '$1 $2');
+  cleaned = cleaned.replace(/(\d)([\u4e00-\u9fff\u3400-\u4dbf])/g, '$1 $2');
 
   // Find amount — first numeric token
   const parts = cleaned.split(/\s+/);

--- a/src/utils/recurring.ts
+++ b/src/utils/recurring.ts
@@ -1,0 +1,178 @@
+import RecurringExpenseModel, { RecurringFrequency, IRecurringExpense } from '../models/RecurringExpense';
+import ExpenseModel from '../models/Expense';
+
+/**
+ * Calculate the next occurrence date for a recurring expense based on frequency
+ */
+export function calculateNextOccurrence(date: Date, frequency: RecurringFrequency): Date {
+  const next = new Date(date);
+  const originalDay = next.getDate();
+
+  switch (frequency) {
+    case 'DAILY':
+      next.setDate(next.getDate() + 1);
+      break;
+    case 'WEEKLY':
+      next.setDate(next.getDate() + 7);
+      break;
+    case 'MONTHLY': {
+      const year = next.getFullYear();
+      const month = next.getMonth();
+      // Add one month and keep the same day, but cap at the last day of month
+      const lastDayOfNextMonth = new Date(year, month + 2, 0).getDate();
+      next.setMonth(month + 1);
+      next.setDate(Math.min(originalDay, lastDayOfNextMonth));
+      break;
+    }
+    case 'QUARTERLY': {
+      const year = next.getFullYear();
+      const month = next.getMonth();
+      // Add 3 months and keep the same day, but cap at the last day of month
+      const lastDayOfTargetMonth = new Date(year, month + 4, 0).getDate();
+      next.setMonth(month + 3);
+      next.setDate(Math.min(originalDay, lastDayOfTargetMonth));
+      break;
+    }
+    case 'YEARLY':
+      next.setFullYear(next.getFullYear() + 1);
+      break;
+  }
+
+  return next;
+}
+
+/**
+ * Check if a recurring expense should generate a transaction today
+ */
+function shouldGenerateTransaction(
+  recurring: IRecurringExpense,
+  lastGenerated?: Date
+): boolean {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const startDate = new Date(recurring.start_date);
+  startDate.setHours(0, 0, 0, 0);
+
+  // Not started yet
+  if (startDate > today) {
+    return false;
+  }
+
+  // Already expired
+  if (recurring.end_date) {
+    const endDate = new Date(recurring.end_date);
+    endDate.setHours(0, 0, 0, 0);
+    if (endDate < today) {
+      return false;
+    }
+  }
+
+  // If no last generated, check if start date is today or past
+  if (!lastGenerated) {
+    return startDate <= today;
+  }
+
+  // Check if next occurrence is today or past
+  const lastGenDate = new Date(lastGenerated);
+  lastGenDate.setHours(0, 0, 0, 0);
+  const nextOccurrence = calculateNextOccurrence(lastGenDate, recurring.frequency);
+  nextOccurrence.setHours(0, 0, 0, 0);
+
+  return nextOccurrence <= today;
+}
+
+/**
+ * Process all recurring expenses and generate transactions for today
+ * Called daily by the cron job
+ */
+export async function processRecurringExpenses(): Promise<void> {
+  try {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    const recurringExpenses = await RecurringExpenseModel.find({
+      start_date: { $lte: today },
+      $or: [{ end_date: { $exists: false } }, { end_date: { $gte: today } }],
+    });
+
+    for (const recurring of recurringExpenses) {
+      try {
+        // Find the most recent generated expense for this recurring item
+        const lastGenerated = await ExpenseModel.findOne(
+          {
+            owner: recurring.userId,
+            description: recurring.name,
+            category: recurring.category,
+            amount: recurring.amount,
+            type: 'expense',
+          },
+          { createdAt: 1 },
+          { sort: { createdAt: -1 } }
+        ).lean();
+
+        // Check if we should generate a new transaction
+        if (shouldGenerateTransaction(recurring, lastGenerated?.createdAt as Date)) {
+          // Create the expense
+          await ExpenseModel.create({
+            owner: recurring.userId,
+            description: recurring.name,
+            amount: recurring.amount,
+            category: recurring.category,
+            type: 'expense',
+            date: today,
+            notes: `Auto-generated from recurring: ${recurring.name}`,
+          });
+        }
+      } catch (error) {
+        console.error(`Error processing recurring expense ${recurring._id}:`, error);
+      }
+    }
+  } catch (error) {
+    console.error('Error processing recurring expenses:', error);
+  }
+}
+
+/**
+ * Validate recurring expense data
+ */
+export function validateRecurringData(data: any): { valid: boolean; errors: string[] } {
+  const errors: string[] = [];
+
+  if (!data.name || typeof data.name !== 'string' || data.name.trim() === '') {
+    errors.push('name is required and must be a non-empty string');
+  }
+
+  if (!data.amount || typeof data.amount !== 'number' || data.amount <= 0) {
+    errors.push('amount is required and must be a positive number');
+  }
+
+  if (!data.start_date) {
+    errors.push('start_date is required');
+  } else {
+    const startDate = new Date(data.start_date);
+    if (isNaN(startDate.getTime())) {
+      errors.push('start_date must be a valid date');
+    }
+  }
+
+  if (data.end_date) {
+    const endDate = new Date(data.end_date);
+    if (isNaN(endDate.getTime())) {
+      errors.push('end_date must be a valid date');
+    } else if (data.start_date) {
+      const startDate = new Date(data.start_date);
+      if (endDate < startDate) {
+        errors.push('end_date must be after start_date');
+      }
+    }
+  }
+
+  if (!data.frequency || !['DAILY', 'WEEKLY', 'MONTHLY', 'QUARTERLY', 'YEARLY'].includes(data.frequency)) {
+    errors.push(
+      'frequency is required and must be one of: DAILY, WEEKLY, MONTHLY, QUARTERLY, YEARLY'
+    );
+  }
+
+  return { valid: errors.length === 0, errors };
+}

--- a/src/utils/recurring.ts
+++ b/src/utils/recurring.ts
@@ -1,6 +1,18 @@
 import RecurringExpenseModel, { RecurringFrequency, IRecurringExpense } from '../models/RecurringExpense';
 import ExpenseModel from '../models/Expense';
 
+export interface ProcessingResult {
+  processed: number;
+  expensesCreated: number;
+  errors: number;
+  details: Array<{
+    recurringId: string;
+    name: string;
+    expensesCreated: number;
+    error?: string;
+  }>;
+}
+
 /**
  * Calculate the next occurrence date for a recurring expense based on frequency
  */
@@ -18,8 +30,9 @@ export function calculateNextOccurrence(date: Date, frequency: RecurringFrequenc
     case 'MONTHLY': {
       const year = next.getFullYear();
       const month = next.getMonth();
-      // Add one month and keep the same day, but cap at the last day of month
       const lastDayOfNextMonth = new Date(year, month + 2, 0).getDate();
+      // Set date to 1 first to avoid overflow when setting month
+      next.setDate(1);
       next.setMonth(month + 1);
       next.setDate(Math.min(originalDay, lastDayOfNextMonth));
       break;
@@ -27,8 +40,9 @@ export function calculateNextOccurrence(date: Date, frequency: RecurringFrequenc
     case 'QUARTERLY': {
       const year = next.getFullYear();
       const month = next.getMonth();
-      // Add 3 months and keep the same day, but cap at the last day of month
       const lastDayOfTargetMonth = new Date(year, month + 4, 0).getDate();
+      // Set date to 1 first to avoid overflow when setting month
+      next.setDate(1);
       next.setMonth(month + 3);
       next.setDate(Math.min(originalDay, lastDayOfTargetMonth));
       break;
@@ -42,95 +56,160 @@ export function calculateNextOccurrence(date: Date, frequency: RecurringFrequenc
 }
 
 /**
- * Check if a recurring expense should generate a transaction today
+ * Normalize a date to midnight UTC for consistent comparison
  */
-function shouldGenerateTransaction(
-  recurring: IRecurringExpense,
-  lastGenerated?: Date
-): boolean {
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-
-  const startDate = new Date(recurring.start_date);
-  startDate.setHours(0, 0, 0, 0);
-
-  // Not started yet
-  if (startDate > today) {
-    return false;
-  }
-
-  // Already expired
-  if (recurring.end_date) {
-    const endDate = new Date(recurring.end_date);
-    endDate.setHours(0, 0, 0, 0);
-    if (endDate < today) {
-      return false;
-    }
-  }
-
-  // If no last generated, check if start date is today or past
-  if (!lastGenerated) {
-    return startDate <= today;
-  }
-
-  // Check if next occurrence is today or past
-  const lastGenDate = new Date(lastGenerated);
-  lastGenDate.setHours(0, 0, 0, 0);
-  const nextOccurrence = calculateNextOccurrence(lastGenDate, recurring.frequency);
-  nextOccurrence.setHours(0, 0, 0, 0);
-
-  return nextOccurrence <= today;
+function toMidnight(date: Date): Date {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  return d;
 }
 
 /**
- * Process all recurring expenses and generate transactions for today
- * Called daily by the cron job
+ * Process a single recurring expense, creating all missed expenses up to today.
+ * Uses processedUntil to guarantee idempotency -- if the job runs twice,
+ * no duplicate expenses are created.
  */
-export async function processRecurringExpenses(): Promise<void> {
-  try {
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
+async function processSingleRecurring(
+  recurring: IRecurringExpense
+): Promise<{ expensesCreated: number }> {
+  const now = new Date();
+  const today = toMidnight(now);
+  let expensesCreated = 0;
 
-    const recurringExpenses = await RecurringExpenseModel.find({
-      start_date: { $lte: today },
-      $or: [{ end_date: { $exists: false } }, { end_date: { $gte: today } }],
+  // Determine the starting point for generating expenses.
+  // If processedUntil exists, we start from there (already processed up to that date).
+  // Otherwise, start from start_date (first occurrence).
+  let cursor: Date;
+  if (recurring.processedUntil) {
+    // processedUntil marks the last date we created an expense for,
+    // so advance to the next occurrence from there
+    cursor = calculateNextOccurrence(new Date(recurring.processedUntil), recurring.frequency);
+  } else {
+    // Never processed: first expense should be on start_date
+    cursor = toMidnight(new Date(recurring.start_date));
+  }
+
+  // Cap at end_date if set
+  const endDate = recurring.end_date ? toMidnight(new Date(recurring.end_date)) : null;
+
+  // Generate all missed expenses up to today
+  // Safety: cap at 365 iterations to prevent runaway loops
+  let iterations = 0;
+  const MAX_ITERATIONS = 365;
+
+  while (toMidnight(cursor) <= today && iterations < MAX_ITERATIONS) {
+    // Stop if past end_date
+    if (endDate && toMidnight(cursor) > endDate) {
+      break;
+    }
+
+    // Create the expense entry
+    await ExpenseModel.create({
+      owner: recurring.userId,
+      description: recurring.description
+        ? `${recurring.name} - ${recurring.description}`
+        : recurring.name,
+      amount: recurring.amount,
+      category: recurring.category || undefined,
+      type: 'expense',
+      date: new Date(cursor),
     });
 
-    for (const recurring of recurringExpenses) {
-      try {
-        // Find the most recent generated expense for this recurring item
-        const lastGenerated = await ExpenseModel.findOne(
-          {
-            owner: recurring.userId,
-            description: recurring.name,
-            category: recurring.category,
-            amount: recurring.amount,
-            type: 'expense',
-          },
-          { createdAt: 1 },
-          { sort: { createdAt: -1 } }
-        ).lean();
+    expensesCreated++;
 
-        // Check if we should generate a new transaction
-        if (shouldGenerateTransaction(recurring, lastGenerated?.createdAt as Date)) {
-          // Create the expense
-          await ExpenseModel.create({
-            owner: recurring.userId,
-            description: recurring.name,
-            amount: recurring.amount,
-            category: recurring.category,
-            type: 'expense',
-            date: today,
-            notes: `Auto-generated from recurring: ${recurring.name}`,
-          });
-        }
-      } catch (error) {
-        console.error(`Error processing recurring expense ${recurring._id}:`, error);
+    // Update processedUntil atomically to ensure idempotency
+    await RecurringExpenseModel.updateOne(
+      { _id: recurring._id },
+      {
+        $set: {
+          processedUntil: new Date(cursor),
+          lastProcessedDate: now,
+          nextDueDate: calculateNextOccurrence(new Date(cursor), recurring.frequency),
+        },
       }
-    }
-  } catch (error) {
-    console.error('Error processing recurring expenses:', error);
+    );
+
+    // Advance cursor
+    cursor = calculateNextOccurrence(new Date(cursor), recurring.frequency);
+    iterations++;
   }
+
+  return { expensesCreated };
+}
+
+/**
+ * Process all due recurring expenses.
+ * Idempotent: uses processedUntil to track what's been generated.
+ * Back-creates missed expenses if the server was down.
+ */
+export async function processRecurringExpenses(): Promise<ProcessingResult> {
+  const result: ProcessingResult = {
+    processed: 0,
+    expensesCreated: 0,
+    errors: 0,
+    details: [],
+  };
+
+  const today = toMidnight(new Date());
+
+  // Find all active recurring expenses that are due.
+  // A recurring expense is due if:
+  // 1. It has nextDueDate <= today, OR
+  // 2. It has no processedUntil and start_date <= today (legacy/new records)
+  const recurringExpenses = await RecurringExpenseModel.find({
+    active: { $ne: false },
+    start_date: { $lte: today },
+    $and: [
+      {
+        $or: [
+          { end_date: { $exists: false } },
+          { end_date: null },
+          { end_date: { $gte: today } },
+        ],
+      },
+      {
+        $or: [
+          { nextDueDate: { $lte: today } },
+          { nextDueDate: { $exists: false } },
+          { processedUntil: { $exists: false }, start_date: { $lte: today } },
+        ],
+      },
+    ],
+  });
+
+  for (const recurring of recurringExpenses) {
+    try {
+      const { expensesCreated } = await processSingleRecurring(recurring);
+      result.processed++;
+      result.expensesCreated += expensesCreated;
+      result.details.push({
+        recurringId: String(recurring._id),
+        name: recurring.name,
+        expensesCreated,
+      });
+
+      if (expensesCreated > 0) {
+        console.log(
+          `[RecurringProcessor] Created ${expensesCreated} expense(s) for "${recurring.name}" (${recurring._id})`
+        );
+      }
+    } catch (error) {
+      result.errors++;
+      const message = error instanceof Error ? error.message : String(error);
+      result.details.push({
+        recurringId: String(recurring._id),
+        name: recurring.name,
+        expensesCreated: 0,
+        error: message,
+      });
+      console.error(
+        `[RecurringProcessor] Error processing "${recurring.name}" (${recurring._id}):`,
+        error
+      );
+    }
+  }
+
+  return result;
 }
 
 /**

--- a/src/utils/telegram.ts
+++ b/src/utils/telegram.ts
@@ -1,0 +1,34 @@
+/**
+ * Send a Telegram message to a specific chat ID
+ */
+export async function sendTelegramMessageToChat(chatId: string, message: string): Promise<boolean> {
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+
+  if (!token) {
+    console.log('[Telegram] Bot token not configured, skipping notification');
+    return false;
+  }
+
+  try {
+    const url = `https://api.telegram.org/bot${token}/sendMessage`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        chat_id: chatId,
+        text: message,
+        parse_mode: 'HTML',
+      }),
+    });
+
+    if (!response.ok) {
+      console.error('[Telegram] API error:', response.status, response.statusText);
+      return false;
+    }
+
+    return true;
+  } catch (error) {
+    console.error('[Telegram] Error sending message:', error);
+    return false;
+  }
+}

--- a/src/utils/weeklyDigest.ts
+++ b/src/utils/weeklyDigest.ts
@@ -1,0 +1,164 @@
+import UserModel, { IUser } from '../models/User';
+import ExpenseModel from '../models/Expense';
+import { sendTelegramMessageToChat } from './telegram';
+
+interface CategoryTotal {
+  category: string;
+  total: number;
+}
+
+interface WeeklyDigestData {
+  totalSpent: number;
+  lastWeekTotal: number;
+  changePercent: number | null;
+  transactionCount: number;
+  topCategories: CategoryTotal[];
+}
+
+function getWeekBoundaries(now: Date): { thisWeekStart: Date; thisWeekEnd: Date; lastWeekStart: Date; lastWeekEnd: Date } {
+  const day = now.getDay(); // 0 = Sunday
+  const thisWeekStart = new Date(now);
+  thisWeekStart.setDate(now.getDate() - day);
+  thisWeekStart.setHours(0, 0, 0, 0);
+
+  const thisWeekEnd = new Date(now);
+  thisWeekEnd.setHours(23, 59, 59, 999);
+
+  const lastWeekStart = new Date(thisWeekStart);
+  lastWeekStart.setDate(lastWeekStart.getDate() - 7);
+
+  const lastWeekEnd = new Date(thisWeekStart);
+  lastWeekEnd.setMilliseconds(-1);
+
+  return { thisWeekStart, thisWeekEnd, lastWeekStart, lastWeekEnd };
+}
+
+async function aggregateWeeklyData(userId: string, now: Date): Promise<WeeklyDigestData> {
+  const { thisWeekStart, thisWeekEnd, lastWeekStart, lastWeekEnd } = getWeekBoundaries(now);
+
+  const [thisWeekResult, lastWeekResult, categoryResult] = await Promise.all([
+    ExpenseModel.aggregate([
+      {
+        $match: {
+          owner: userId,
+          type: 'expense',
+          date: { $gte: thisWeekStart, $lte: thisWeekEnd },
+        },
+      },
+      {
+        $group: {
+          _id: null,
+          total: { $sum: '$amount' },
+          count: { $sum: 1 },
+        },
+      },
+    ]),
+    ExpenseModel.aggregate([
+      {
+        $match: {
+          owner: userId,
+          type: 'expense',
+          date: { $gte: lastWeekStart, $lte: lastWeekEnd },
+        },
+      },
+      {
+        $group: {
+          _id: null,
+          total: { $sum: '$amount' },
+        },
+      },
+    ]),
+    ExpenseModel.aggregate([
+      {
+        $match: {
+          owner: userId,
+          type: 'expense',
+          date: { $gte: thisWeekStart, $lte: thisWeekEnd },
+        },
+      },
+      {
+        $group: {
+          _id: '$category',
+          total: { $sum: '$amount' },
+        },
+      },
+      { $sort: { total: -1 } },
+      { $limit: 3 },
+    ]),
+  ]);
+
+  const totalSpent = thisWeekResult[0]?.total ?? 0;
+  const transactionCount = thisWeekResult[0]?.count ?? 0;
+  const lastWeekTotal = lastWeekResult[0]?.total ?? 0;
+
+  let changePercent: number | null = null;
+  if (lastWeekTotal > 0) {
+    changePercent = Math.round(((totalSpent - lastWeekTotal) / lastWeekTotal) * 100);
+  }
+
+  const topCategories: CategoryTotal[] = categoryResult.map(
+    (row: { _id: string | null; total: number }) => ({
+      category: row._id || 'Uncategorized',
+      total: row.total,
+    })
+  );
+
+  return { totalSpent, lastWeekTotal, changePercent, transactionCount, topCategories };
+}
+
+function formatDigestMessage(data: WeeklyDigestData): string {
+  const { totalSpent, changePercent, transactionCount, topCategories } = data;
+
+  let msg = `<b>Weekly Spending Digest</b>\n\n`;
+  msg += `<b>Total Spent:</b> $${totalSpent.toFixed(2)}\n`;
+  msg += `<b>Transactions:</b> ${transactionCount}\n`;
+
+  if (changePercent !== null) {
+    const arrow = changePercent > 0 ? '↑' : changePercent < 0 ? '↓' : '→';
+    msg += `<b>vs Last Week:</b> ${arrow} ${Math.abs(changePercent)}%\n`;
+  } else {
+    msg += `<b>vs Last Week:</b> No data\n`;
+  }
+
+  if (topCategories.length > 0) {
+    msg += `\n<b>Top Categories:</b>\n`;
+    topCategories.forEach((cat, i) => {
+      msg += `  ${i + 1}. ${cat.category} — $${cat.total.toFixed(2)}\n`;
+    });
+  }
+
+  return msg;
+}
+
+export async function sendWeeklyDigestForUser(userId: string, now?: Date): Promise<boolean> {
+  const currentDate = now ?? new Date();
+  const data = await aggregateWeeklyData(userId, currentDate);
+  const message = formatDigestMessage(data);
+
+  const user = await UserModel.findById(userId).lean();
+  if (!user?.telegramChatId) return false;
+
+  return sendTelegramMessageToChat(user.telegramChatId, message);
+}
+
+export async function processWeeklyDigests(): Promise<number> {
+  const users = await UserModel.find({
+    weeklyDigestEnabled: true,
+    telegramChatId: { $exists: true, $ne: '' },
+  }).lean();
+
+  let sentCount = 0;
+  for (const user of users) {
+    try {
+      const sent = await sendWeeklyDigestForUser((user as IUser)._id.toString());
+      if (sent) sentCount++;
+    } catch (error) {
+      console.error(`[WeeklyDigest] Failed for user ${(user as IUser)._id}:`, error);
+    }
+  }
+
+  return sentCount;
+}
+
+export { aggregateWeeklyData, formatDigestMessage, getWeekBoundaries };
+export type { WeeklyDigestData, CategoryTotal };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,6 @@
       "esModuleInterop": true,
       "skipLibCheck": true
     },
-    "exclude": ["__tests__", "node_modules"]
+    "exclude": ["__tests__", "node_modules", "scripts"]
   }
   

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
       "strict": true,
       "esModuleInterop": true,
       "skipLibCheck": true
-    }
+    },
+    "exclude": ["__tests__", "node_modules"]
   }
   

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,6 +54,11 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
   integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
 
+"@types/bcryptjs@^2.4.6":
+  version "2.4.6"
+  resolved "https://registry.yarnpkg.com/@types/bcryptjs/-/bcryptjs-2.4.6.tgz#2b92e3c2121c66eba3901e64faf8bb922ec291fa"
+  integrity sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==
+
 "@types/body-parser@*":
   version "1.19.3"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.3.tgz#fb558014374f7d9e56c8f34bab2042a3a07d25cd"
@@ -66,6 +71,13 @@
   version "3.4.36"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.36.tgz#e511558c15a39cb29bd5357eebb57bd1459cd1ab"
   integrity sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==
+  dependencies:
+    "@types/node" "*"
+
+"@types/cors@^2.8.14":
+  version "2.8.19"
+  resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.19.tgz#d93ea2673fd8c9f697367f5eeefc2bbfa94f0342"
+  integrity sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==
   dependencies:
     "@types/node" "*"
 
@@ -94,6 +106,14 @@
   resolved "https://registry.yarnpkg.com/@types/http-errors/-/http-errors-2.0.2.tgz#a86e00bbde8950364f8e7846687259ffcd96e8c2"
   integrity sha512-lPG6KlZs88gef6aD85z3HNkztpj7w2R7HmR3gygjfXCQmsLloWNARFkMuzKiiY8FGdh1XDpgBdrSf4aKDiA7Kg==
 
+"@types/jsonwebtoken@^9.0.4":
+  version "9.0.10"
+  resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz#a7932a47177dcd4283b6146f3bd5c26d82647f09"
+  integrity sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==
+  dependencies:
+    "@types/ms" "*"
+    "@types/node" "*"
+
 "@types/mime@*":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.2.tgz#c1ae807f13d308ee7511a5b81c74f327028e66e8"
@@ -104,12 +124,10 @@
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.3.tgz#bbe64987e0eb05de150c305005055c7ad784a9ce"
   integrity sha512-Ys+/St+2VF4+xuY6+kDIXGxbNRO0mesVg0bbxEfB97Od1Vjpjx9KD1qxs64Gcb3CWPirk9Xe+PT4YiiHQ9T+eg==
 
-"@types/mongoose@^5.11.97":
-  version "5.11.97"
-  resolved "https://registry.yarnpkg.com/@types/mongoose/-/mongoose-5.11.97.tgz#80b0357f3de6807eb597262f52e49c3e13ee14d8"
-  integrity sha512-cqwOVYT3qXyLiGw7ueU2kX9noE8DPGRY6z8eUxudhXY8NZ7DMKYAxyZkLSevGfhCX3dO/AoX5/SO9lAzfjon0Q==
-  dependencies:
-    mongoose "*"
+"@types/ms@*":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-2.1.0.tgz#052aa67a48eccc4309d7f0191b7e41434b90bb78"
+  integrity sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==
 
 "@types/node@*":
   version "20.8.6"
@@ -183,6 +201,14 @@ acorn@^8.4.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.10.0.tgz#8be5b3907a67221a81ab23c7889c4c5526b62ec5"
   integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
 
+anymatch@~3.1.2:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
+  integrity sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
+  dependencies:
+    normalize-path "^3.0.0"
+    picomatch "^2.0.4"
+
 arg@^4.1.0:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
@@ -192,6 +218,21 @@ array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
   integrity sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==
+
+balanced-match@^4.0.2:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
+  integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
+
+bcryptjs@^2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/bcryptjs/-/bcryptjs-2.4.3.tgz#9ab5627b93e60621ff7cdac5da9733027df1d0cb"
+  integrity sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==
+
+binary-extensions@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"
+  integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
 
 body-parser@1.20.1:
   version "1.20.1"
@@ -211,10 +252,29 @@ body-parser@1.20.1:
     type-is "~1.6.18"
     unpipe "1.0.0"
 
+brace-expansion@^5.0.2:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.4.tgz#614daaecd0a688f660bbbc909a8748c3d80d4336"
+  integrity sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==
+  dependencies:
+    balanced-match "^4.0.2"
+
+braces@~3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
+  integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
+  dependencies:
+    fill-range "^7.1.1"
+
 bson@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/bson/-/bson-5.5.0.tgz#a419cc69f368d2def3b8b22ea03ed1c9be40e53f"
   integrity sha512-B+QB4YmDx9RStKv8LLSl/aVIEV3nYJc3cJNNTK2Cd1TL+7P+cNpw9mAPeCgc5K+j01Dv6sxUzcITXDx7ZU3F0w==
+
+buffer-equal-constant-time@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==
 
 bytes@3.1.2:
   version "3.1.2"
@@ -228,6 +288,21 @@ call-bind@^1.0.0:
   dependencies:
     function-bind "^1.1.1"
     get-intrinsic "^1.0.2"
+
+chokidar@^3.5.2:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
+  integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 content-disposition@0.5.4:
   version "0.5.4"
@@ -251,6 +326,14 @@ cookie@0.5.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
 
+cors@^2.8.5:
+  version "2.8.6"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.6.tgz#ff5dd69bd95e547503820d29aba4f8faf8dfec96"
+  integrity sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
+
 create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
@@ -270,6 +353,13 @@ debug@4.x:
   dependencies:
     ms "2.1.2"
 
+debug@^4:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
+
 depd@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
@@ -284,6 +374,18 @@ diff@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
+
+dotenv@^16.3.1:
+  version "16.6.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.6.1.tgz#773f0e69527a8315c7285d5ee73c4459d20a8020"
+  integrity sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==
+
+ecdsa-sig-formatter@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
+  dependencies:
+    safe-buffer "^5.0.1"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -304,6 +406,14 @@ etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
+
+express-validator@^7.0.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/express-validator/-/express-validator-7.3.1.tgz#7884e452b2318ae9faabc8b28fd41ffa21d00d28"
+  integrity sha512-IGenaSf+DnWc69lKuqlRE9/i/2t5/16VpH5bXoqdxWz1aCpRvEdrBuu1y95i/iL5QP8ZYVATiwLFhwk3EDl5vg==
+  dependencies:
+    lodash "^4.17.21"
+    validator "~13.15.23"
 
 express@^4.18.2:
   version "4.18.2"
@@ -342,6 +452,13 @@ express@^4.18.2:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
+fill-range@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"
+  integrity sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==
+  dependencies:
+    to-regex-range "^5.0.1"
+
 finalhandler@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.2.0.tgz#7d23fe5731b207b4640e4fcd00aec1f9207a7b32"
@@ -365,6 +482,11 @@ fresh@0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
 
+fsevents@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
 function-bind@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
@@ -379,6 +501,18 @@ get-intrinsic@^1.0.2:
     has "^1.0.3"
     has-proto "^1.0.1"
     has-symbols "^1.0.3"
+
+glob-parent@~5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
+  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
+  dependencies:
+    is-glob "^4.0.1"
+
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+  integrity sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==
 
 has-proto@^1.0.1:
   version "1.0.1"
@@ -413,6 +547,11 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+ignore-by-default@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
+  integrity sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==
+
 inherits@2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
@@ -428,10 +567,107 @@ ipaddr.js@1.9.1:
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
+is-binary-path@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
+  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
+  dependencies:
+    binary-extensions "^2.0.0"
+
+is-extglob@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
+  integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
+
+is-glob@^4.0.1, is-glob@~4.0.1:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
+  integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
+  dependencies:
+    is-extglob "^2.1.1"
+
+is-number@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
+  integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+
+jsonwebtoken@^9.0.2:
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz#6cd57ab01e9b0ac07cb847d53d3c9b6ee31f7ae2"
+  integrity sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==
+  dependencies:
+    jws "^4.0.1"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    semver "^7.5.4"
+
+jwa@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-2.0.1.tgz#bf8176d1ad0cd72e0f3f58338595a13e110bc804"
+  integrity sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==
+  dependencies:
+    buffer-equal-constant-time "^1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jws@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-4.0.1.tgz#07edc1be8fac20e677b283ece261498bd38f0690"
+  integrity sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==
+  dependencies:
+    jwa "^2.0.1"
+    safe-buffer "^5.0.1"
+
 kareem@2.5.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/kareem/-/kareem-2.5.1.tgz#7b8203e11819a8e77a34b3517d3ead206764d15d"
   integrity sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA==
+
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==
+
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==
+
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  integrity sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
+
+lodash@^4.17.21:
+  version "4.17.23"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.23.tgz#f113b0378386103be4f6893388c73d0bde7f2c5a"
+  integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==
 
 make-error@^1.1.1:
   version "1.3.6"
@@ -475,6 +711,13 @@ mime@1.6.0:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
+minimatch@^10.2.1:
+  version "10.2.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.4.tgz#465b3accbd0218b8281f5301e27cedc697f96fde"
+  integrity sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==
+  dependencies:
+    brace-expansion "^5.0.2"
+
 mongodb-connection-string-url@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz#57901bf352372abdde812c81be47b75c6b2ec5cf"
@@ -493,19 +736,6 @@ mongodb@5.9.0:
     socks "^2.7.1"
   optionalDependencies:
     "@mongodb-js/saslprep" "^1.1.0"
-
-mongoose@*:
-  version "7.6.2"
-  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-7.6.2.tgz#c55c8c41352a6e5223bd7b60aa2715331e1d2b65"
-  integrity sha512-OVx6RWbfNOzBbfTvXoOkgZmaizdXDU/B/KbBjietXQoInSg/OSULjOavXJzL51XWFkbefqkOvbeE07DfvW6FkQ==
-  dependencies:
-    bson "^5.5.0"
-    kareem "2.5.1"
-    mongodb "5.9.0"
-    mpath "0.9.0"
-    mquery "5.0.0"
-    ms "2.1.3"
-    sift "16.0.1"
 
 mongoose@^7.6.3:
   version "7.6.3"
@@ -542,7 +772,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3:
+ms@2.1.3, ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -551,6 +781,32 @@ negotiator@0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
+
+nodemon@^3.0.1:
+  version "3.1.14"
+  resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-3.1.14.tgz#8487ca379c515301d221ec007f27f24ecafa2b51"
+  integrity sha512-jakjZi93UtB3jHMWsXL68FXSAosbLfY0In5gtKq3niLSkrWznrVBzXFNOEMJUfc9+Ke7SHWoAZsiMkNP3vq6Jw==
+  dependencies:
+    chokidar "^3.5.2"
+    debug "^4"
+    ignore-by-default "^1.0.1"
+    minimatch "^10.2.1"
+    pstree.remy "^1.1.8"
+    semver "^7.5.3"
+    simple-update-notifier "^2.0.0"
+    supports-color "^5.5.0"
+    touch "^3.1.0"
+    undefsafe "^2.0.5"
+
+normalize-path@^3.0.0, normalize-path@~3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
+  integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
+
+object-assign@^4:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
 
 object-inspect@^1.9.0:
   version "1.13.0"
@@ -574,6 +830,11 @@ path-to-regexp@0.1.7:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==
 
+picomatch@^2.0.4, picomatch@^2.2.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
+  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
 proxy-addr@~2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
@@ -581,6 +842,11 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+pstree.remy@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/pstree.remy/-/pstree.remy-1.1.8.tgz#c242224f4a67c21f686839bbdb4ac282b8373d3a"
+  integrity sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==
 
 punycode@^2.1.1:
   version "2.3.0"
@@ -609,7 +875,14 @@ raw-body@2.5.1:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-safe-buffer@5.2.1:
+readdirp@~3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
+  integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
+  dependencies:
+    picomatch "^2.2.1"
+
+safe-buffer@5.2.1, safe-buffer@^5.0.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -618,6 +891,11 @@ safe-buffer@5.2.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+semver@^7.5.3, semver@^7.5.4:
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
+  integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
 
 send@0.18.0:
   version "0.18.0"
@@ -667,6 +945,13 @@ sift@16.0.1:
   resolved "https://registry.yarnpkg.com/sift/-/sift-16.0.1.tgz#e9c2ccc72191585008cf3e36fc447b2d2633a053"
   integrity sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ==
 
+simple-update-notifier@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz#d70b92bdab7d6d90dfd73931195a30b6e3d7cebb"
+  integrity sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==
+  dependencies:
+    semver "^7.5.3"
+
 smart-buffer@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
@@ -692,10 +977,29 @@ statuses@2.0.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
 
+supports-color@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
+  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
+  dependencies:
+    has-flag "^3.0.0"
+
+to-regex-range@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
+  integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
+  dependencies:
+    is-number "^7.0.0"
+
 toidentifier@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
+
+touch@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/touch/-/touch-3.1.1.tgz#097a23d7b161476435e5c1344a95c0f75b4a5694"
+  integrity sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==
 
 tr46@^3.0.0:
   version "3.0.0"
@@ -736,6 +1040,11 @@ typescript@^5.2.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
   integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
+undefsafe@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/undefsafe/-/undefsafe-2.0.5.tgz#38733b9327bdcd226db889fb723a6efd162e6e2c"
+  integrity sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==
+
 undici-types@~5.25.1:
   version "5.25.3"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.25.3.tgz#e044115914c85f0bcbb229f346ab739f064998c3"
@@ -756,7 +1065,12 @@ v8-compile-cache-lib@^3.0.1:
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
   integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
-vary@~1.1.2:
+validator@~13.15.23:
+  version "13.15.26"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.15.26.tgz#36c3deeab30e97806a658728a155c66fcaa5b944"
+  integrity sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==
+
+vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@anthropic-ai/sdk@^0.80.0":
+  version "0.80.0"
+  resolved "https://registry.yarnpkg.com/@anthropic-ai/sdk/-/sdk-0.80.0.tgz#d480aee13b7b1d4faf324845fad7a924eebdaa5b"
+  integrity sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g==
+  dependencies:
+    json-schema-to-ts "^3.1.1"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.27.1", "@babel/code-frame@^7.28.6", "@babel/code-frame@^7.29.0":
   version "7.29.0"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz"
@@ -16,7 +23,7 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz"
   integrity sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==
 
-"@babel/core@^7.0.0", "@babel/core@^7.0.0 || ^8.0.0-0", "@babel/core@^7.0.0-0", "@babel/core@^7.11.0 || ^8.0.0-0", "@babel/core@^7.11.0 || ^8.0.0-beta.1", "@babel/core@^7.23.9", "@babel/core@^7.27.4", "@babel/core@>=7.0.0-beta.0 <8":
+"@babel/core@^7.23.9", "@babel/core@^7.27.4":
   version "7.29.0"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz"
   integrity sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==
@@ -235,6 +242,11 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.28.6"
 
+"@babel/runtime@^7.18.3":
+  version "7.29.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.2.tgz#9a6e2d05f4b6692e1801cd4fb176ad823930ed5e"
+  integrity sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==
+
 "@babel/template@^7.28.6":
   version "7.28.6"
   resolved "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz"
@@ -276,6 +288,28 @@
   integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
+
+"@emnapi/core@^1.4.3":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.9.1.tgz#2143069c744ca2442074f8078462e51edd63c7bd"
+  integrity sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==
+  dependencies:
+    "@emnapi/wasi-threads" "1.2.0"
+    tslib "^2.4.0"
+
+"@emnapi/runtime@^1.4.3":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.9.1.tgz#115ff2a0d589865be6bd8e9d701e499c473f2a8d"
+  integrity sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==
+  dependencies:
+    tslib "^2.4.0"
+
+"@emnapi/wasi-threads@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz#a19d9772cc3d195370bf6e2a805eec40aa75e18e"
+  integrity sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==
+  dependencies:
+    tslib "^2.4.0"
 
 "@fastify/otel@0.17.1":
   version "0.17.1"
@@ -500,7 +534,7 @@
     jest-haste-map "30.3.0"
     slash "^3.0.0"
 
-"@jest/transform@^29.0.0 || ^30.0.0", "@jest/transform@30.3.0":
+"@jest/transform@30.3.0":
   version "30.3.0"
   resolved "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz"
   integrity sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==
@@ -520,7 +554,7 @@
     slash "^3.0.0"
     write-file-atomic "^5.0.1"
 
-"@jest/types@^29.0.0 || ^30.0.0", "@jest/types@30.3.0":
+"@jest/types@30.3.0":
   version "30.3.0"
   resolved "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz"
   integrity sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==
@@ -559,14 +593,6 @@
   resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
 
-"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.23", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25", "@jridgewell/trace-mapping@^0.3.28":
-  version "0.3.31"
-  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz"
-  integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
-  dependencies:
-    "@jridgewell/resolve-uri" "^3.1.0"
-    "@jridgewell/sourcemap-codec" "^1.4.14"
-
 "@jridgewell/trace-mapping@0.3.9":
   version "0.3.9"
   resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz"
@@ -575,12 +601,29 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.23", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25", "@jridgewell/trace-mapping@^0.3.28":
+  version "0.3.31"
+  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz"
+  integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
+
 "@mongodb-js/saslprep@^1.1.0", "@mongodb-js/saslprep@^1.3.0":
   version "1.4.6"
   resolved "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.6.tgz"
   integrity sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==
   dependencies:
     sparse-bitfield "^3.0.3"
+
+"@napi-rs/wasm-runtime@^0.2.11":
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz#3e78a8b96e6c33a6c517e1894efbd5385a7cb6f2"
+  integrity sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==
+  dependencies:
+    "@emnapi/core" "^1.4.3"
+    "@emnapi/runtime" "^1.4.3"
+    "@tybys/wasm-util" "^0.10.0"
 
 "@noble/hashes@^1.1.5":
   version "1.8.0"
@@ -608,17 +651,17 @@
   dependencies:
     "@opentelemetry/api" "^1.3.0"
 
-"@opentelemetry/api@^1.1.0", "@opentelemetry/api@^1.3.0", "@opentelemetry/api@^1.7.0", "@opentelemetry/api@^1.8", "@opentelemetry/api@^1.9.0", "@opentelemetry/api@>=1.0.0 <1.10.0", "@opentelemetry/api@>=1.3.0 <1.10.0":
+"@opentelemetry/api@^1.3.0", "@opentelemetry/api@^1.9.0":
   version "1.9.0"
   resolved "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz"
   integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
 
-"@opentelemetry/context-async-hooks@^1.30.1 || ^2.1.0", "@opentelemetry/context-async-hooks@^2.6.0":
+"@opentelemetry/context-async-hooks@^2.6.0":
   version "2.6.0"
   resolved "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.0.tgz"
   integrity sha512-L8UyDwqpTcbkIK5cgwDRDYDoEhQoj8wp8BwsO19w3LB1Z41yEQm2VJyNfAi9DrLP/YTqXqWpKHyZfR9/tFYo1Q==
 
-"@opentelemetry/core@^1.30.1 || ^2.1.0", "@opentelemetry/core@^2.0.0", "@opentelemetry/core@^2.6.0", "@opentelemetry/core@2.6.0":
+"@opentelemetry/core@2.6.0", "@opentelemetry/core@^2.0.0", "@opentelemetry/core@^2.6.0":
   version "2.6.0"
   resolved "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.0.tgz"
   integrity sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==
@@ -759,15 +802,6 @@
     "@opentelemetry/instrumentation" "^0.213.0"
     "@opentelemetry/semantic-conventions" "^1.33.0"
 
-"@opentelemetry/instrumentation-mysql@0.59.0":
-  version "0.59.0"
-  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.59.0.tgz"
-  integrity sha512-r+V/Fh0sm7Ga8/zk/TI5H5FQRAjwr0RrpfPf8kNIehlsKf12XnvIaZi8ViZkpX0gyPEpLXqzqWD6QHlgObgzZw==
-  dependencies:
-    "@opentelemetry/instrumentation" "^0.213.0"
-    "@opentelemetry/semantic-conventions" "^1.33.0"
-    "@types/mysql" "2.15.27"
-
 "@opentelemetry/instrumentation-mysql2@0.59.0":
   version "0.59.0"
   resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.59.0.tgz"
@@ -776,6 +810,15 @@
     "@opentelemetry/instrumentation" "^0.213.0"
     "@opentelemetry/semantic-conventions" "^1.33.0"
     "@opentelemetry/sql-common" "^0.41.2"
+
+"@opentelemetry/instrumentation-mysql@0.59.0":
+  version "0.59.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.59.0.tgz"
+  integrity sha512-r+V/Fh0sm7Ga8/zk/TI5H5FQRAjwr0RrpfPf8kNIehlsKf12XnvIaZi8ViZkpX0gyPEpLXqzqWD6QHlgObgzZw==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.213.0"
+    "@opentelemetry/semantic-conventions" "^1.33.0"
+    "@types/mysql" "2.15.27"
 
 "@opentelemetry/instrumentation-pg@0.65.0":
   version "0.65.0"
@@ -816,6 +859,15 @@
     "@opentelemetry/instrumentation" "^0.213.0"
     "@opentelemetry/semantic-conventions" "^1.24.0"
 
+"@opentelemetry/instrumentation@0.213.0", "@opentelemetry/instrumentation@^0.213.0":
+  version "0.213.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.213.0.tgz"
+  integrity sha512-3i9NdkET/KvQomeh7UaR/F4r9P25Rx6ooALlWXPIjypcEOUxksCmVu0zA70NBJWlrMW1rPr/LRidFAflLI+s/w==
+  dependencies:
+    "@opentelemetry/api-logs" "0.213.0"
+    import-in-the-middle "^3.0.0"
+    require-in-the-middle "^8.0.0"
+
 "@opentelemetry/instrumentation@^0.207.0":
   version "0.207.0"
   resolved "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.207.0.tgz"
@@ -834,21 +886,12 @@
     import-in-the-middle "^2.0.6"
     require-in-the-middle "^8.0.0"
 
-"@opentelemetry/instrumentation@^0.213.0", "@opentelemetry/instrumentation@>=0.57.1 <1", "@opentelemetry/instrumentation@0.213.0":
-  version "0.213.0"
-  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.213.0.tgz"
-  integrity sha512-3i9NdkET/KvQomeh7UaR/F4r9P25Rx6ooALlWXPIjypcEOUxksCmVu0zA70NBJWlrMW1rPr/LRidFAflLI+s/w==
-  dependencies:
-    "@opentelemetry/api-logs" "0.213.0"
-    import-in-the-middle "^3.0.0"
-    require-in-the-middle "^8.0.0"
-
 "@opentelemetry/redis-common@^0.38.2":
   version "0.38.2"
   resolved "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.38.2.tgz"
   integrity sha512-1BCcU93iwSRZvDAgwUxC/DV4T/406SkMfxGqu5ojc3AvNI+I9GhV7v0J1HljsczuuhcnFLYqD5VmwVXfCGHzxA==
 
-"@opentelemetry/resources@^1.30.1 || ^2.1.0", "@opentelemetry/resources@^2.6.0", "@opentelemetry/resources@2.6.0":
+"@opentelemetry/resources@2.6.0", "@opentelemetry/resources@^2.6.0":
   version "2.6.0"
   resolved "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.0.tgz"
   integrity sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ==
@@ -856,7 +899,7 @@
     "@opentelemetry/core" "2.6.0"
     "@opentelemetry/semantic-conventions" "^1.29.0"
 
-"@opentelemetry/sdk-trace-base@^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base@^2.6.0":
+"@opentelemetry/sdk-trace-base@^2.6.0":
   version "2.6.0"
   resolved "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.0.tgz"
   integrity sha512-g/OZVkqlxllgFM7qMKqbPV9c1DUPhQ7d4n3pgZFcrnrNft9eJXZM2TNHTPYREJBrtNdRytYyvwjgL5geDKl3EQ==
@@ -865,7 +908,7 @@
     "@opentelemetry/resources" "2.6.0"
     "@opentelemetry/semantic-conventions" "^1.29.0"
 
-"@opentelemetry/semantic-conventions@^1.24.0", "@opentelemetry/semantic-conventions@^1.27.0", "@opentelemetry/semantic-conventions@^1.28.0", "@opentelemetry/semantic-conventions@^1.29.0", "@opentelemetry/semantic-conventions@^1.30.0", "@opentelemetry/semantic-conventions@^1.33.0", "@opentelemetry/semantic-conventions@^1.33.1", "@opentelemetry/semantic-conventions@^1.34.0", "@opentelemetry/semantic-conventions@^1.36.0", "@opentelemetry/semantic-conventions@^1.39.0", "@opentelemetry/semantic-conventions@^1.40.0":
+"@opentelemetry/semantic-conventions@^1.24.0", "@opentelemetry/semantic-conventions@^1.27.0", "@opentelemetry/semantic-conventions@^1.28.0", "@opentelemetry/semantic-conventions@^1.29.0", "@opentelemetry/semantic-conventions@^1.30.0", "@opentelemetry/semantic-conventions@^1.33.0", "@opentelemetry/semantic-conventions@^1.33.1", "@opentelemetry/semantic-conventions@^1.34.0", "@opentelemetry/semantic-conventions@^1.36.0", "@opentelemetry/semantic-conventions@^1.40.0":
   version "1.40.0"
   resolved "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz"
   integrity sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==
@@ -1001,6 +1044,13 @@
   version "1.0.4"
   resolved "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz"
   integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
+
+"@tybys/wasm-util@^0.10.0":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.1.tgz#ecddd3205cf1e2d5274649ff0eedd2991ed7f414"
+  integrity sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==
+  dependencies:
+    tslib "^2.4.0"
 
 "@types/babel__core@^7.20.5":
   version "7.20.5"
@@ -1299,10 +1349,102 @@
   resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
 
+"@unrs/resolver-binding-android-arm-eabi@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz#9f5b04503088e6a354295e8ea8fe3cb99e43af81"
+  integrity sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==
+
+"@unrs/resolver-binding-android-arm64@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz#7414885431bd7178b989aedc4d25cccb3865bc9f"
+  integrity sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==
+
 "@unrs/resolver-binding-darwin-arm64@1.11.1":
   version "1.11.1"
   resolved "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz"
   integrity sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==
+
+"@unrs/resolver-binding-darwin-x64@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz#fd4d81257b13f4d1a083890a6a17c00de571f0dc"
+  integrity sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==
+
+"@unrs/resolver-binding-freebsd-x64@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz#d2513084d0f37c407757e22f32bd924a78cfd99b"
+  integrity sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==
+
+"@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz#844d2605d057488d77fab09705f2866b86164e0a"
+  integrity sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==
+
+"@unrs/resolver-binding-linux-arm-musleabihf@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz#204892995cefb6bd1d017d52d097193bc61ddad3"
+  integrity sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==
+
+"@unrs/resolver-binding-linux-arm64-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz#023eb0c3aac46066a10be7a3f362e7b34f3bdf9d"
+  integrity sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==
+
+"@unrs/resolver-binding-linux-arm64-musl@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz#9e6f9abb06424e3140a60ac996139786f5d99be0"
+  integrity sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==
+
+"@unrs/resolver-binding-linux-ppc64-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz#b111417f17c9d1b02efbec8e08398f0c5527bb44"
+  integrity sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==
+
+"@unrs/resolver-binding-linux-riscv64-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz#92ffbf02748af3e99873945c9a8a5ead01d508a9"
+  integrity sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==
+
+"@unrs/resolver-binding-linux-riscv64-musl@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz#0bec6f1258fc390e6b305e9ff44256cb207de165"
+  integrity sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==
+
+"@unrs/resolver-binding-linux-s390x-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz#577843a084c5952f5906770633ccfb89dac9bc94"
+  integrity sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==
+
+"@unrs/resolver-binding-linux-x64-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz#36fb318eebdd690f6da32ac5e0499a76fa881935"
+  integrity sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==
+
+"@unrs/resolver-binding-linux-x64-musl@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz#bfb9af75f783f98f6a22c4244214efe4df1853d6"
+  integrity sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==
+
+"@unrs/resolver-binding-wasm32-wasi@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz#752c359dd875684b27429500d88226d7cc72f71d"
+  integrity sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==
+  dependencies:
+    "@napi-rs/wasm-runtime" "^0.2.11"
+
+"@unrs/resolver-binding-win32-arm64-msvc@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz#ce5735e600e4c2fbb409cd051b3b7da4a399af35"
+  integrity sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==
+
+"@unrs/resolver-binding-win32-ia32-msvc@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz#72fc57bc7c64ec5c3de0d64ee0d1810317bc60a6"
+  integrity sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==
+
+"@unrs/resolver-binding-win32-x64-msvc@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz#538b1e103bf8d9864e7b85cc96fa8d6fb6c40777"
+  integrity sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==
 
 accepts@~1.3.8:
   version "1.3.8"
@@ -1322,7 +1464,7 @@ acorn-walk@^8.1.1:
   resolved "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
-acorn@^8, acorn@^8.15.0:
+acorn@^8.15.0:
   version "8.16.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz"
   integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
@@ -1423,7 +1565,7 @@ b4a@^1.6.4:
   resolved "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz"
   integrity sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==
 
-"babel-jest@^29.0.0 || ^30.0.0", babel-jest@30.3.0:
+babel-jest@30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz"
   integrity sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==
@@ -1493,7 +1635,7 @@ balanced-match@^4.0.2:
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz"
   integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
 
-bare-events@*, bare-events@^2.5.4, bare-events@^2.7.0:
+bare-events@^2.5.4, bare-events@^2.7.0:
   version "2.8.2"
   resolved "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz"
   integrity sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==
@@ -1536,6 +1678,11 @@ bare-url@^2.2.2:
   dependencies:
     bare-path "^3.0.0"
 
+base64-js@^1.3.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 baseline-browser-mapping@^2.9.0:
   version "2.10.10"
   resolved "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.10.tgz"
@@ -1545,6 +1692,11 @@ bcryptjs@^2.4.3:
   version "2.4.3"
   resolved "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz"
   integrity sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==
+
+bignumber.js@^9.0.0:
+  version "9.3.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.3.1.tgz#759c5aaddf2ffdc4f154f7b493e1c8770f88c4d7"
+  integrity sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==
 
 binary-extensions@^2.0.0:
   version "2.3.0"
@@ -1598,7 +1750,7 @@ braces@~3.0.2:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.24.0, "browserslist@>= 4.21.0":
+browserslist@^4.24.0:
   version "4.28.1"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz"
   integrity sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==
@@ -1861,12 +2013,10 @@ csv-parse@^6.2.1:
   resolved "https://registry.npmjs.org/csv-parse/-/csv-parse-6.2.1.tgz"
   integrity sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ==
 
-debug@^4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.4, debug@^4.3.5, debug@^4.3.7, debug@^4.4.3, debug@4:
-  version "4.4.3"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
-  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
-  dependencies:
-    ms "^2.1.3"
+data-uri-to-buffer@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
+  integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
 
 debug@2.6.9:
   version "2.6.9"
@@ -1874,6 +2024,13 @@ debug@2.6.9:
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
+
+debug@4, debug@^4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.4, debug@^4.3.5, debug@^4.3.7, debug@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
 
 debug@4.x:
   version "4.3.4"
@@ -1897,12 +2054,12 @@ delayed-stream@~1.0.0:
   resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
-depd@~2.0.0, depd@2.0.0:
+depd@2.0.0, depd@~2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
-destroy@~1.2.0, destroy@1.2.0:
+destroy@1.2.0, destroy@~1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
@@ -1944,7 +2101,7 @@ eastasianwidth@^0.2.0:
   resolved "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz"
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
 
-ecdsa-sig-formatter@1.0.11:
+ecdsa-sig-formatter@1.0.11, ecdsa-sig-formatter@^1.0.11:
   version "1.0.11"
   resolved "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz"
   integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
@@ -2067,7 +2224,7 @@ exit-x@^0.2.2:
   resolved "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz"
   integrity sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==
 
-expect@^30.0.0, expect@30.3.0:
+expect@30.3.0, expect@^30.0.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz"
   integrity sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==
@@ -2124,12 +2281,17 @@ express@^4.18.2:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
+extend@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+
 fast-fifo@^1.2.0, fast-fifo@^1.3.2:
   version "1.3.2"
   resolved "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz"
   integrity sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==
 
-fast-json-stable-stringify@^2.1.0, fast-json-stable-stringify@2.x:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -2145,6 +2307,14 @@ fb-watchman@^2.0.2:
   integrity sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==
   dependencies:
     bser "2.1.1"
+
+fetch-blob@^3.1.2, fetch-blob@^3.1.4:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
+  integrity sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==
+  dependencies:
+    node-domexception "^1.0.0"
+    web-streams-polyfill "^3.0.3"
 
 fill-range@^7.1.1:
   version "7.1.1"
@@ -2207,6 +2377,13 @@ form-data@^4.0.0, form-data@^4.0.5:
     hasown "^2.0.2"
     mime-types "^2.1.12"
 
+formdata-polyfill@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
+  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
+  dependencies:
+    fetch-blob "^3.1.2"
+
 formidable@^3.5.4:
   version "3.5.4"
   resolved "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz"
@@ -2245,6 +2422,24 @@ function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
+
+gaxios@^7.0.0, gaxios@^7.1.4:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/gaxios/-/gaxios-7.1.4.tgz#33a5b78e2c5c01cf5a5d17f58dd188839867fc9c"
+  integrity sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==
+  dependencies:
+    extend "^3.0.2"
+    https-proxy-agent "^7.0.1"
+    node-fetch "^3.3.2"
+
+gcp-metadata@8.1.2:
+  version "8.1.2"
+  resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-8.1.2.tgz#e62e3373ddf41fc727ccc31c55c687b798bee898"
+  integrity sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==
+  dependencies:
+    gaxios "^7.0.0"
+    google-logging-utils "^1.0.0"
+    json-bigint "^1.0.0"
 
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -2321,6 +2516,23 @@ glob@^7.1.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+google-auth-library@^10.6.2:
+  version "10.6.2"
+  resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-10.6.2.tgz#44557c536aec626b7cda48a85b5d026e2c9b74c4"
+  integrity sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==
+  dependencies:
+    base64-js "^1.3.0"
+    ecdsa-sig-formatter "^1.0.11"
+    gaxios "^7.1.4"
+    gcp-metadata "8.1.2"
+    google-logging-utils "1.1.3"
+    jws "^4.0.0"
+
+google-logging-utils@1.1.3, google-logging-utils@^1.0.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/google-logging-utils/-/google-logging-utils-1.1.3.tgz#17b71f1f95d266d2ddd356b8f00178433f041b17"
+  integrity sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==
+
 gopd@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz"
@@ -2388,7 +2600,7 @@ http-errors@~2.0.0, http-errors@~2.0.1:
     statuses "~2.0.2"
     toidentifier "~1.0.1"
 
-https-proxy-agent@^7.0.6:
+https-proxy-agent@^7.0.1, https-proxy-agent@^7.0.6:
   version "7.0.6"
   resolved "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz"
   integrity sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==
@@ -2413,17 +2625,7 @@ ignore-by-default@^1.0.1:
   resolved "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz"
   integrity sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==
 
-import-in-the-middle@^2.0.0:
-  version "2.0.6"
-  resolved "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz"
-  integrity sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==
-  dependencies:
-    acorn "^8.15.0"
-    acorn-import-attributes "^1.9.5"
-    cjs-module-lexer "^2.2.0"
-    module-details-from-path "^1.0.4"
-
-import-in-the-middle@^2.0.6:
+import-in-the-middle@^2.0.0, import-in-the-middle@^2.0.6:
   version "2.0.6"
   resolved "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz"
   integrity sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==
@@ -2464,7 +2666,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@^2.0.3, inherits@~2.0.4, inherits@2:
+inherits@2, inherits@^2.0.3, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -2778,7 +2980,7 @@ jest-resolve-dependencies@30.3.0:
     jest-regex-util "30.0.1"
     jest-snapshot "30.3.0"
 
-jest-resolve@*, jest-resolve@30.3.0:
+jest-resolve@30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.3.0.tgz"
   integrity sha512-NRtTAHQlpd15F9rUR36jqwelbrDV/dY4vzNte3S2kxCKUJRYNd5/6nTSbYiak1VX5g8IoFF23Uj5TURkUW8O5g==
@@ -2875,7 +3077,7 @@ jest-snapshot@30.3.0:
     semver "^7.7.2"
     synckit "^0.11.8"
 
-"jest-util@^29.0.0 || ^30.0.0", jest-util@30.3.0:
+jest-util@30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz"
   integrity sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==
@@ -2924,7 +3126,7 @@ jest-worker@30.3.0:
     merge-stream "^2.0.0"
     supports-color "^8.1.1"
 
-"jest@^29.0.0 || ^30.0.0", jest@^30.3.0:
+jest@^30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/jest/-/jest-30.3.0.tgz"
   integrity sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==
@@ -2952,10 +3154,25 @@ jsesc@^3.0.2:
   resolved "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz"
   integrity sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==
 
+json-bigint@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-bigint/-/json-bigint-1.0.0.tgz#ae547823ac0cad8398667f8cd9ef4730f5b01ff1"
+  integrity sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==
+  dependencies:
+    bignumber.js "^9.0.0"
+
 json-parse-even-better-errors@^2.3.0:
   version "2.3.1"
   resolved "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
+
+json-schema-to-ts@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz#81f3acaf5a34736492f6f5f51870ef9ece1ca853"
+  integrity sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    ts-algebra "^2.0.0"
 
 json5@^2.2.3:
   version "2.2.3"
@@ -2987,7 +3204,7 @@ jwa@^2.0.1:
     ecdsa-sig-formatter "1.0.11"
     safe-buffer "^5.0.1"
 
-jws@^4.0.1:
+jws@^4.0.0, jws@^4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz"
   integrity sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==
@@ -3235,15 +3452,6 @@ mongodb-memory-server@^11.0.1:
     mongodb-memory-server-core "11.0.1"
     tslib "^2.8.1"
 
-mongodb@^7.0.0:
-  version "7.1.1"
-  resolved "https://registry.npmjs.org/mongodb/-/mongodb-7.1.1.tgz"
-  integrity sha512-067DXiMjcpYQl6bGjWQoTUEE9UoRViTtKFcoqX7z08I+iDZv/emH1g8XEFiO3qiDfXAheT5ozl1VffDTKhIW/w==
-  dependencies:
-    "@mongodb-js/saslprep" "^1.3.0"
-    bson "^7.1.1"
-    mongodb-connection-string-url "^7.0.0"
-
 mongodb@5.9.2:
   version "5.9.2"
   resolved "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz"
@@ -3254,6 +3462,15 @@ mongodb@5.9.2:
     socks "^2.7.1"
   optionalDependencies:
     "@mongodb-js/saslprep" "^1.1.0"
+
+mongodb@^7.0.0:
+  version "7.1.1"
+  resolved "https://registry.npmjs.org/mongodb/-/mongodb-7.1.1.tgz"
+  integrity sha512-067DXiMjcpYQl6bGjWQoTUEE9UoRViTtKFcoqX7z08I+iDZv/emH1g8XEFiO3qiDfXAheT5ozl1VffDTKhIW/w==
+  dependencies:
+    "@mongodb-js/saslprep" "^1.3.0"
+    bson "^7.1.1"
+    mongodb-connection-string-url "^7.0.0"
 
 mongoose@^7.6.3:
   version "7.8.9"
@@ -3280,11 +3497,6 @@ mquery@5.0.0:
   dependencies:
     debug "4.x"
 
-ms@^2.1.1, ms@^2.1.3, ms@2.1.3:
-  version "2.1.3"
-  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
-  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
-
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
@@ -3294,6 +3506,11 @@ ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+ms@2.1.3, ms@^2.1.1, ms@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 multer@^2.1.1:
   version "2.1.1"
@@ -3331,6 +3548,20 @@ new-find-package-json@^2.0.0:
   integrity sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==
   dependencies:
     debug "^4.3.4"
+
+node-domexception@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
+  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
+
+node-fetch@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.3.2.tgz#d1e889bacdf733b4ff3b2b243eb7a12866a0b78b"
+  integrity sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==
+  dependencies:
+    data-uri-to-buffer "^4.0.0"
+    fetch-blob "^3.1.4"
+    formdata-polyfill "^4.0.10"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -3506,12 +3737,7 @@ picocolors@^1.1.1:
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^2.0.4:
-  version "2.3.1"
-  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
-
-picomatch@^2.2.1:
+picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.3.1"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -3555,7 +3781,7 @@ postgres-interval@^1.1.0:
   dependencies:
     xtend "^4.0.0"
 
-pretty-format@^30.0.0, pretty-format@30.3.0:
+pretty-format@30.3.0, pretty-format@^30.0.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz"
   integrity sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==
@@ -3662,7 +3888,7 @@ resolve-from@^5.0.0:
   resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
-safe-buffer@^5.0.1, safe-buffer@~5.2.0, safe-buffer@5.2.1:
+safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -3672,12 +3898,7 @@ safe-buffer@^5.0.1, safe-buffer@~5.2.0, safe-buffer@5.2.1:
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-semver@^6.0.0:
-  version "6.3.1"
-  resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
-  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
-
-semver@^6.3.1:
+semver@^6.0.0, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
@@ -3716,7 +3937,7 @@ serve-static@~1.16.2:
     parseurl "~1.3.3"
     send "~0.19.1"
 
-setprototypeof@~1.2.0, setprototypeof@1.2.0:
+setprototypeof@1.2.0, setprototypeof@~1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
@@ -3805,7 +4026,7 @@ smart-buffer@^4.2.0:
   resolved "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz"
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
 
-socks@^2.7.1, socks@^2.8.6:
+socks@^2.7.1:
   version "2.8.7"
   resolved "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz"
   integrity sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==
@@ -3864,13 +4085,6 @@ streamx@^2.12.5, streamx@^2.15.0, streamx@^2.25.0:
     fast-fifo "^1.3.2"
     text-decoder "^1.1.0"
 
-string_decoder@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
-  dependencies:
-    safe-buffer "~5.2.0"
-
 string-length@^4.0.2:
   version "4.0.2"
   resolved "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz"
@@ -3893,16 +4107,7 @@ string-similarity@^4.0.4:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string-width@^4.1.0, string-width@^4.2.0:
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.2.3:
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3919,6 +4124,13 @@ string-width@^5.0.1, string-width@^5.1.2:
     eastasianwidth "^0.2.0"
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
+
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
 
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
@@ -4077,6 +4289,11 @@ tr46@^5.1.0:
   dependencies:
     punycode "^2.3.1"
 
+ts-algebra@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ts-algebra/-/ts-algebra-2.0.0.tgz#4e3e0953878f26518fce7f6bb115064a65388b7a"
+  integrity sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==
+
 ts-jest@^29.4.6:
   version "29.4.6"
   resolved "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz"
@@ -4092,7 +4309,7 @@ ts-jest@^29.4.6:
     type-fest "^4.41.0"
     yargs-parser "^21.1.1"
 
-ts-node@^10.9.1, ts-node@>=9.0.0:
+ts-node@^10.9.1:
   version "10.9.1"
   resolved "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz"
   integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
@@ -4144,7 +4361,7 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^5.2.2, typescript@>=2.7, "typescript@>=4.3 <6":
+typescript@^5.2.2:
   version "5.2.2"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz"
   integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
@@ -4244,6 +4461,11 @@ walker@^1.0.8:
   integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
   dependencies:
     makeerror "1.0.12"
+
+web-streams-polyfill@^3.0.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz#2073b91a2fdb1fbfbd401e7de0ac9f8214cecb4b"
+  integrity sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==
 
 webidl-conversions@^7.0.0:
   version "7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,16 +2,284 @@
 # yarn lockfile v1
 
 
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.27.1", "@babel/code-frame@^7.28.6", "@babel/code-frame@^7.29.0":
+  version "7.29.0"
+  resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz"
+  integrity sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.28.5"
+    js-tokens "^4.0.0"
+    picocolors "^1.1.1"
+
+"@babel/compat-data@^7.28.6":
+  version "7.29.0"
+  resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz"
+  integrity sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==
+
+"@babel/core@^7.0.0", "@babel/core@^7.0.0 || ^8.0.0-0", "@babel/core@^7.0.0-0", "@babel/core@^7.11.0 || ^8.0.0-0", "@babel/core@^7.11.0 || ^8.0.0-beta.1", "@babel/core@^7.23.9", "@babel/core@^7.27.4", "@babel/core@>=7.0.0-beta.0 <8":
+  version "7.29.0"
+  resolved "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz"
+  integrity sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==
+  dependencies:
+    "@babel/code-frame" "^7.29.0"
+    "@babel/generator" "^7.29.0"
+    "@babel/helper-compilation-targets" "^7.28.6"
+    "@babel/helper-module-transforms" "^7.28.6"
+    "@babel/helpers" "^7.28.6"
+    "@babel/parser" "^7.29.0"
+    "@babel/template" "^7.28.6"
+    "@babel/traverse" "^7.29.0"
+    "@babel/types" "^7.29.0"
+    "@jridgewell/remapping" "^2.3.5"
+    convert-source-map "^2.0.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.2.3"
+    semver "^6.3.1"
+
+"@babel/generator@^7.27.5", "@babel/generator@^7.29.0":
+  version "7.29.1"
+  resolved "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz"
+  integrity sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==
+  dependencies:
+    "@babel/parser" "^7.29.0"
+    "@babel/types" "^7.29.0"
+    "@jridgewell/gen-mapping" "^0.3.12"
+    "@jridgewell/trace-mapping" "^0.3.28"
+    jsesc "^3.0.2"
+
+"@babel/helper-compilation-targets@^7.28.6":
+  version "7.28.6"
+  resolved "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz"
+  integrity sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==
+  dependencies:
+    "@babel/compat-data" "^7.28.6"
+    "@babel/helper-validator-option" "^7.27.1"
+    browserslist "^4.24.0"
+    lru-cache "^5.1.1"
+    semver "^6.3.1"
+
+"@babel/helper-globals@^7.28.0":
+  version "7.28.0"
+  resolved "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz"
+  integrity sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==
+
+"@babel/helper-module-imports@^7.28.6":
+  version "7.28.6"
+  resolved "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz"
+  integrity sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==
+  dependencies:
+    "@babel/traverse" "^7.28.6"
+    "@babel/types" "^7.28.6"
+
+"@babel/helper-module-transforms@^7.28.6":
+  version "7.28.6"
+  resolved "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz"
+  integrity sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==
+  dependencies:
+    "@babel/helper-module-imports" "^7.28.6"
+    "@babel/helper-validator-identifier" "^7.28.5"
+    "@babel/traverse" "^7.28.6"
+
+"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.28.6", "@babel/helper-plugin-utils@^7.8.0":
+  version "7.28.6"
+  resolved "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz"
+  integrity sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==
+
+"@babel/helper-string-parser@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz"
+  integrity sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
+
+"@babel/helper-validator-identifier@^7.28.5":
+  version "7.28.5"
+  resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz"
+  integrity sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==
+
+"@babel/helper-validator-option@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz"
+  integrity sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==
+
+"@babel/helpers@^7.28.6":
+  version "7.29.2"
+  resolved "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz"
+  integrity sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==
+  dependencies:
+    "@babel/template" "^7.28.6"
+    "@babel/types" "^7.29.0"
+
+"@babel/parser@^7.1.0", "@babel/parser@^7.20.7", "@babel/parser@^7.23.9", "@babel/parser@^7.28.6", "@babel/parser@^7.29.0":
+  version "7.29.2"
+  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz"
+  integrity sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==
+  dependencies:
+    "@babel/types" "^7.29.0"
+
+"@babel/plugin-syntax-async-generators@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz"
+  integrity sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-bigint@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz"
+  integrity sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-class-properties@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz"
+  integrity sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.12.13"
+
+"@babel/plugin-syntax-class-static-block@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz"
+  integrity sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-syntax-import-attributes@^7.24.7":
+  version "7.28.6"
+  resolved "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz"
+  integrity sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.28.6"
+
+"@babel/plugin-syntax-import-meta@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz"
+  integrity sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-syntax-json-strings@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz"
+  integrity sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-jsx@^7.27.1":
+  version "7.28.6"
+  resolved "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz"
+  integrity sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.28.6"
+
+"@babel/plugin-syntax-logical-assignment-operators@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz"
+  integrity sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-syntax-nullish-coalescing-operator@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz"
+  integrity sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-numeric-separator@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz"
+  integrity sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-syntax-object-rest-spread@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz"
+  integrity sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-optional-catch-binding@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz"
+  integrity sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-optional-chaining@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz"
+  integrity sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-private-property-in-object@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz"
+  integrity sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-syntax-top-level-await@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz"
+  integrity sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-syntax-typescript@^7.27.1":
+  version "7.28.6"
+  resolved "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz"
+  integrity sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.28.6"
+
+"@babel/template@^7.28.6":
+  version "7.28.6"
+  resolved "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz"
+  integrity sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==
+  dependencies:
+    "@babel/code-frame" "^7.28.6"
+    "@babel/parser" "^7.28.6"
+    "@babel/types" "^7.28.6"
+
+"@babel/traverse@^7.28.6", "@babel/traverse@^7.29.0":
+  version "7.29.0"
+  resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz"
+  integrity sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==
+  dependencies:
+    "@babel/code-frame" "^7.29.0"
+    "@babel/generator" "^7.29.0"
+    "@babel/helper-globals" "^7.28.0"
+    "@babel/parser" "^7.29.0"
+    "@babel/template" "^7.28.6"
+    "@babel/types" "^7.29.0"
+    debug "^4.3.1"
+
+"@babel/types@^7.0.0", "@babel/types@^7.20.7", "@babel/types@^7.27.3", "@babel/types@^7.28.2", "@babel/types@^7.28.6", "@babel/types@^7.29.0":
+  version "7.29.0"
+  resolved "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz"
+  integrity sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==
+  dependencies:
+    "@babel/helper-string-parser" "^7.27.1"
+    "@babel/helper-validator-identifier" "^7.28.5"
+
+"@bcoe/v8-coverage@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
+  integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
+
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
-  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  resolved "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz"
   integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
 "@fastify/otel@0.17.1":
   version "0.17.1"
-  resolved "https://registry.yarnpkg.com/@fastify/otel/-/otel-0.17.1.tgz#a7f13edc40dbc2e0c2a59d54e388f11e4d2235ce"
+  resolved "https://registry.npmjs.org/@fastify/otel/-/otel-0.17.1.tgz"
   integrity sha512-K4wyxfUZx2ux5o+b6BtTqouYFVILohLZmSbA2tKUueJstNcBnoGPVhllCaOvbQ3ZrXdUxUC/fyrSWSCqHhdOPg==
   dependencies:
     "@opentelemetry/core" "^2.0.0"
@@ -19,72 +287,347 @@
     "@opentelemetry/semantic-conventions" "^1.28.0"
     minimatch "^10.2.4"
 
-"@jridgewell/resolve-uri@^3.0.3":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz#c08679063f279615a3326583ba3a90d1d82cc721"
-  integrity sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==
+"@isaacs/cliui@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz"
+  integrity sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==
+  dependencies:
+    string-width "^5.1.2"
+    string-width-cjs "npm:string-width@^4.2.0"
+    strip-ansi "^7.0.1"
+    strip-ansi-cjs "npm:strip-ansi@^6.0.1"
+    wrap-ansi "^8.1.0"
+    wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
-"@jridgewell/sourcemap-codec@^1.4.10":
-  version "1.4.15"
-  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
-  integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
+"@istanbuljs/load-nyc-config@^1.0.0":
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz"
+  integrity sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==
+  dependencies:
+    camelcase "^5.3.1"
+    find-up "^4.1.0"
+    get-package-type "^0.1.0"
+    js-yaml "^3.13.1"
+    resolve-from "^5.0.0"
+
+"@istanbuljs/schema@^0.1.2", "@istanbuljs/schema@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz"
+  integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
+
+"@jest/console@30.3.0":
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/@jest/console/-/console-30.3.0.tgz"
+  integrity sha512-PAwCvFJ4696XP2qZj+LAn1BWjZaJ6RjG6c7/lkMaUJnkyMS34ucuIsfqYvfskVNvUI27R/u4P1HMYFnlVXG/Ww==
+  dependencies:
+    "@jest/types" "30.3.0"
+    "@types/node" "*"
+    chalk "^4.1.2"
+    jest-message-util "30.3.0"
+    jest-util "30.3.0"
+    slash "^3.0.0"
+
+"@jest/core@30.3.0":
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/@jest/core/-/core-30.3.0.tgz"
+  integrity sha512-U5mVPsBxLSO6xYbf+tgkymLx+iAhvZX43/xI1+ej2ZOPnPdkdO1CzDmFKh2mZBn2s4XZixszHeQnzp1gm/DIxw==
+  dependencies:
+    "@jest/console" "30.3.0"
+    "@jest/pattern" "30.0.1"
+    "@jest/reporters" "30.3.0"
+    "@jest/test-result" "30.3.0"
+    "@jest/transform" "30.3.0"
+    "@jest/types" "30.3.0"
+    "@types/node" "*"
+    ansi-escapes "^4.3.2"
+    chalk "^4.1.2"
+    ci-info "^4.2.0"
+    exit-x "^0.2.2"
+    graceful-fs "^4.2.11"
+    jest-changed-files "30.3.0"
+    jest-config "30.3.0"
+    jest-haste-map "30.3.0"
+    jest-message-util "30.3.0"
+    jest-regex-util "30.0.1"
+    jest-resolve "30.3.0"
+    jest-resolve-dependencies "30.3.0"
+    jest-runner "30.3.0"
+    jest-runtime "30.3.0"
+    jest-snapshot "30.3.0"
+    jest-util "30.3.0"
+    jest-validate "30.3.0"
+    jest-watcher "30.3.0"
+    pretty-format "30.3.0"
+    slash "^3.0.0"
+
+"@jest/diff-sequences@30.3.0":
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz"
+  integrity sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==
+
+"@jest/environment@30.3.0":
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz"
+  integrity sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==
+  dependencies:
+    "@jest/fake-timers" "30.3.0"
+    "@jest/types" "30.3.0"
+    "@types/node" "*"
+    jest-mock "30.3.0"
+
+"@jest/expect-utils@30.3.0":
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.3.0.tgz"
+  integrity sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==
+  dependencies:
+    "@jest/get-type" "30.1.0"
+
+"@jest/expect@30.3.0":
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/@jest/expect/-/expect-30.3.0.tgz"
+  integrity sha512-76Nlh4xJxk2D/9URCn3wFi98d2hb19uWE1idLsTt2ywhvdOldbw3S570hBgn25P4ICUZ/cBjybrBex2g17IDbg==
+  dependencies:
+    expect "30.3.0"
+    jest-snapshot "30.3.0"
+
+"@jest/fake-timers@30.3.0":
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz"
+  integrity sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==
+  dependencies:
+    "@jest/types" "30.3.0"
+    "@sinonjs/fake-timers" "^15.0.0"
+    "@types/node" "*"
+    jest-message-util "30.3.0"
+    jest-mock "30.3.0"
+    jest-util "30.3.0"
+
+"@jest/get-type@30.1.0":
+  version "30.1.0"
+  resolved "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz"
+  integrity sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==
+
+"@jest/globals@30.3.0":
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/@jest/globals/-/globals-30.3.0.tgz"
+  integrity sha512-+owLCBBdfpgL3HU+BD5etr1SvbXpSitJK0is1kiYjJxAAJggYMRQz5hSdd5pq1sSggfxPbw2ld71pt4x5wwViA==
+  dependencies:
+    "@jest/environment" "30.3.0"
+    "@jest/expect" "30.3.0"
+    "@jest/types" "30.3.0"
+    jest-mock "30.3.0"
+
+"@jest/pattern@30.0.1":
+  version "30.0.1"
+  resolved "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz"
+  integrity sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==
+  dependencies:
+    "@types/node" "*"
+    jest-regex-util "30.0.1"
+
+"@jest/reporters@30.3.0":
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/@jest/reporters/-/reporters-30.3.0.tgz"
+  integrity sha512-a09z89S+PkQnL055bVj8+pe2Caed2PBOaczHcXCykW5ngxX9EWx/1uAwncxc/HiU0oZqfwseMjyhxgRjS49qPw==
+  dependencies:
+    "@bcoe/v8-coverage" "^0.2.3"
+    "@jest/console" "30.3.0"
+    "@jest/test-result" "30.3.0"
+    "@jest/transform" "30.3.0"
+    "@jest/types" "30.3.0"
+    "@jridgewell/trace-mapping" "^0.3.25"
+    "@types/node" "*"
+    chalk "^4.1.2"
+    collect-v8-coverage "^1.0.2"
+    exit-x "^0.2.2"
+    glob "^10.5.0"
+    graceful-fs "^4.2.11"
+    istanbul-lib-coverage "^3.0.0"
+    istanbul-lib-instrument "^6.0.0"
+    istanbul-lib-report "^3.0.0"
+    istanbul-lib-source-maps "^5.0.0"
+    istanbul-reports "^3.1.3"
+    jest-message-util "30.3.0"
+    jest-util "30.3.0"
+    jest-worker "30.3.0"
+    slash "^3.0.0"
+    string-length "^4.0.2"
+    v8-to-istanbul "^9.0.1"
+
+"@jest/schemas@30.0.5":
+  version "30.0.5"
+  resolved "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz"
+  integrity sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==
+  dependencies:
+    "@sinclair/typebox" "^0.34.0"
+
+"@jest/snapshot-utils@30.3.0":
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.3.0.tgz"
+  integrity sha512-ORbRN9sf5PP82v3FXNSwmO1OTDR2vzR2YTaR+E3VkSBZ8zadQE6IqYdYEeFH1NIkeB2HIGdF02dapb6K0Mj05g==
+  dependencies:
+    "@jest/types" "30.3.0"
+    chalk "^4.1.2"
+    graceful-fs "^4.2.11"
+    natural-compare "^1.4.0"
+
+"@jest/source-map@30.0.1":
+  version "30.0.1"
+  resolved "https://registry.npmjs.org/@jest/source-map/-/source-map-30.0.1.tgz"
+  integrity sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.25"
+    callsites "^3.1.0"
+    graceful-fs "^4.2.11"
+
+"@jest/test-result@30.3.0":
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/@jest/test-result/-/test-result-30.3.0.tgz"
+  integrity sha512-e/52nJGuD74AKTSe0P4y5wFRlaXP0qmrS17rqOMHeSwm278VyNyXE3gFO/4DTGF9w+65ra3lo3VKj0LBrzmgdQ==
+  dependencies:
+    "@jest/console" "30.3.0"
+    "@jest/types" "30.3.0"
+    "@types/istanbul-lib-coverage" "^2.0.6"
+    collect-v8-coverage "^1.0.2"
+
+"@jest/test-sequencer@30.3.0":
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.3.0.tgz"
+  integrity sha512-dgbWy9b8QDlQeRZcv7LNF+/jFiiYHTKho1xirauZ7kVwY7avjFF6uTT0RqlgudB5OuIPagFdVtfFMosjVbk1eA==
+  dependencies:
+    "@jest/test-result" "30.3.0"
+    graceful-fs "^4.2.11"
+    jest-haste-map "30.3.0"
+    slash "^3.0.0"
+
+"@jest/transform@^29.0.0 || ^30.0.0", "@jest/transform@30.3.0":
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz"
+  integrity sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==
+  dependencies:
+    "@babel/core" "^7.27.4"
+    "@jest/types" "30.3.0"
+    "@jridgewell/trace-mapping" "^0.3.25"
+    babel-plugin-istanbul "^7.0.1"
+    chalk "^4.1.2"
+    convert-source-map "^2.0.0"
+    fast-json-stable-stringify "^2.1.0"
+    graceful-fs "^4.2.11"
+    jest-haste-map "30.3.0"
+    jest-regex-util "30.0.1"
+    jest-util "30.3.0"
+    pirates "^4.0.7"
+    slash "^3.0.0"
+    write-file-atomic "^5.0.1"
+
+"@jest/types@^29.0.0 || ^30.0.0", "@jest/types@30.3.0":
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz"
+  integrity sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==
+  dependencies:
+    "@jest/pattern" "30.0.1"
+    "@jest/schemas" "30.0.5"
+    "@types/istanbul-lib-coverage" "^2.0.6"
+    "@types/istanbul-reports" "^3.0.4"
+    "@types/node" "*"
+    "@types/yargs" "^17.0.33"
+    chalk "^4.1.2"
+
+"@jridgewell/gen-mapping@^0.3.12", "@jridgewell/gen-mapping@^0.3.5":
+  version "0.3.13"
+  resolved "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz"
+  integrity sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.0"
+    "@jridgewell/trace-mapping" "^0.3.24"
+
+"@jridgewell/remapping@^2.3.5":
+  version "2.3.5"
+  resolved "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz"
+  integrity sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.5"
+    "@jridgewell/trace-mapping" "^0.3.24"
+
+"@jridgewell/resolve-uri@^3.0.3", "@jridgewell/resolve-uri@^3.1.0":
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz"
+  integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
+
+"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.5.0":
+  version "1.5.5"
+  resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz"
+  integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
+
+"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.23", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25", "@jridgewell/trace-mapping@^0.3.28":
+  version "0.3.31"
+  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz"
+  integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
 
 "@jridgewell/trace-mapping@0.3.9":
   version "0.3.9"
-  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz"
   integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@mongodb-js/saslprep@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz#022fa36620a7287d17acd05c4aae1e5f390d250d"
-  integrity sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==
+"@mongodb-js/saslprep@^1.1.0", "@mongodb-js/saslprep@^1.3.0":
+  version "1.4.6"
+  resolved "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.6.tgz"
+  integrity sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==
   dependencies:
     sparse-bitfield "^3.0.3"
 
+"@noble/hashes@^1.1.5":
+  version "1.8.0"
+  resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz"
+  integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
+
 "@opentelemetry/api-logs@0.207.0":
   version "0.207.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/api-logs/-/api-logs-0.207.0.tgz#ae991c51eedda55af037a3e6fc1ebdb12b289f49"
+  resolved "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.207.0.tgz"
   integrity sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==
   dependencies:
     "@opentelemetry/api" "^1.3.0"
 
 "@opentelemetry/api-logs@0.212.0":
   version "0.212.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/api-logs/-/api-logs-0.212.0.tgz#ec66a0951b84b1f082e13fd8a027b9f9d65a3f7a"
+  resolved "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.212.0.tgz"
   integrity sha512-TEEVrLbNROUkYY51sBJGk7lO/OLjuepch8+hmpM6ffMJQ2z/KVCjdHuCFX6fJj8OkJP2zckPjrJzQtXU3IAsFg==
   dependencies:
     "@opentelemetry/api" "^1.3.0"
 
 "@opentelemetry/api-logs@0.213.0":
   version "0.213.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/api-logs/-/api-logs-0.213.0.tgz#c7abc7d3c4586cfbfd737c0a2fcfb2323a9def75"
+  resolved "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.213.0.tgz"
   integrity sha512-zRM5/Qj6G84Ej3F1yt33xBVY/3tnMxtL1fiDIxYbDWYaZ/eudVw3/PBiZ8G7JwUxXxjW8gU4g6LnOyfGKYHYgw==
   dependencies:
     "@opentelemetry/api" "^1.3.0"
 
-"@opentelemetry/api@^1.3.0", "@opentelemetry/api@^1.9.0":
+"@opentelemetry/api@^1.1.0", "@opentelemetry/api@^1.3.0", "@opentelemetry/api@^1.7.0", "@opentelemetry/api@^1.8", "@opentelemetry/api@^1.9.0", "@opentelemetry/api@>=1.0.0 <1.10.0", "@opentelemetry/api@>=1.3.0 <1.10.0":
   version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.0.tgz#d03eba68273dc0f7509e2a3d5cba21eae10379fe"
+  resolved "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz"
   integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
 
-"@opentelemetry/context-async-hooks@^2.6.0":
+"@opentelemetry/context-async-hooks@^1.30.1 || ^2.1.0", "@opentelemetry/context-async-hooks@^2.6.0":
   version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.0.tgz#6c824e900630b378233c1a78ca7f0dc5a3b460b2"
+  resolved "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.0.tgz"
   integrity sha512-L8UyDwqpTcbkIK5cgwDRDYDoEhQoj8wp8BwsO19w3LB1Z41yEQm2VJyNfAi9DrLP/YTqXqWpKHyZfR9/tFYo1Q==
 
-"@opentelemetry/core@2.6.0", "@opentelemetry/core@^2.0.0", "@opentelemetry/core@^2.6.0":
+"@opentelemetry/core@^1.30.1 || ^2.1.0", "@opentelemetry/core@^2.0.0", "@opentelemetry/core@^2.6.0", "@opentelemetry/core@2.6.0":
   version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-2.6.0.tgz#719c829ed98bd7af808a2d2c83374df1fd1f3c66"
+  resolved "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.0.tgz"
   integrity sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==
   dependencies:
     "@opentelemetry/semantic-conventions" "^1.29.0"
 
 "@opentelemetry/instrumentation-amqplib@0.60.0":
   version "0.60.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.60.0.tgz#a2b2abe3cf433bea166c18a703c8ddf6accf83da"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.60.0.tgz"
   integrity sha512-q/B2IvoVXRm1M00MvhnzpMN6rKYOszPXVsALi6u0ss4AYHe+TidZEtLW9N1ZhrobI1dSriHnBqqtAOZVAv07sg==
   dependencies:
     "@opentelemetry/core" "^2.0.0"
@@ -93,7 +636,7 @@
 
 "@opentelemetry/instrumentation-connect@0.56.0":
   version "0.56.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.56.0.tgz#8d846d2f7cf1f6b2723e5b0ff5595e8d31cb7446"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.56.0.tgz"
   integrity sha512-PKp+sSZ7AfzMvGgO3VCyo1inwNu+q7A1k9X88WK4PQ+S6Hp7eFk8pie+sWHDTaARovmqq5V2osav3lQej2B0nw==
   dependencies:
     "@opentelemetry/core" "^2.0.0"
@@ -103,14 +646,14 @@
 
 "@opentelemetry/instrumentation-dataloader@0.30.0":
   version "0.30.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.30.0.tgz#7fbea57b27165324092639abf090ca3697eb7a80"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.30.0.tgz"
   integrity sha512-MXHP2Q38cd2OhzEBKAIXUi9uBlPEYzF6BNJbyjUXBQ6kLaf93kRC41vNMIz0Nl5mnuwK7fDvKT+/lpx7BXRwdg==
   dependencies:
     "@opentelemetry/instrumentation" "^0.213.0"
 
 "@opentelemetry/instrumentation-express@0.61.0":
   version "0.61.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-express/-/instrumentation-express-0.61.0.tgz#49b4d144ab6e9d6e035941a51f5e573e84e3647f"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.61.0.tgz"
   integrity sha512-Xdmqo9RZuZlL29Flg8QdwrrX7eW1CZ7wFQPKHyXljNymgKhN1MCsYuqQ/7uxavhSKwAl7WxkTzKhnqpUApLMvQ==
   dependencies:
     "@opentelemetry/core" "^2.0.0"
@@ -119,7 +662,7 @@
 
 "@opentelemetry/instrumentation-fs@0.32.0":
   version "0.32.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.32.0.tgz#2010d86da8ab3d543f8e44c8fff81b94f904d91d"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.32.0.tgz"
   integrity sha512-koR6apx0g0wX6RRiPpjA4AFQUQUbXrK16kq4/SZjVp7u5cffJhNkY4TnITxcGA4acGSPYAfx3NHRIv4Khn1axQ==
   dependencies:
     "@opentelemetry/core" "^2.0.0"
@@ -127,21 +670,21 @@
 
 "@opentelemetry/instrumentation-generic-pool@0.56.0":
   version "0.56.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.56.0.tgz#01560f52d5bac6fb6312a1f0bc74bf0939119894"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.56.0.tgz"
   integrity sha512-fg+Jffs6fqrf0uQS0hom7qBFKsbtpBiBl8+Vkc63Gx8xh6pVh+FhagmiO6oM0m3vyb683t1lP7yGYq22SiDnqg==
   dependencies:
     "@opentelemetry/instrumentation" "^0.213.0"
 
 "@opentelemetry/instrumentation-graphql@0.61.0":
   version "0.61.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.61.0.tgz#d1f896095a891c9576967645e7fcba935da82a94"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.61.0.tgz"
   integrity sha512-pUiVASv6nh2XrerTvlbVHh7vKFzscpgwiQ/xvnZuAIzQ5lRjWVdRPUuXbvZJ/Yq79QsE81TZdJ7z9YsXiss1ew==
   dependencies:
     "@opentelemetry/instrumentation" "^0.213.0"
 
 "@opentelemetry/instrumentation-hapi@0.59.0":
   version "0.59.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.59.0.tgz#412ea19e97ead684c5737e1f1aaa19ff940512d3"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.59.0.tgz"
   integrity sha512-33wa4mEr+9+ztwdgLor1SeBu4Opz4IsmpcLETXAd3VmBrOjez8uQtrsOhPCa5Vhbm5gzDlMYTgFRLQzf8/YHFA==
   dependencies:
     "@opentelemetry/core" "^2.0.0"
@@ -150,7 +693,7 @@
 
 "@opentelemetry/instrumentation-http@0.213.0":
   version "0.213.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-http/-/instrumentation-http-0.213.0.tgz#b379d6bcbae43a7d6d54070f3794527021f176c9"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.213.0.tgz"
   integrity sha512-B978Xsm5XEPGhm1P07grDoaOFLHapJPkOG9h016cJsyWWxmiLnPu2M/4Nrm7UCkHSiLnkXgC+zVGUAIahy8EEA==
   dependencies:
     "@opentelemetry/core" "2.6.0"
@@ -160,7 +703,7 @@
 
 "@opentelemetry/instrumentation-ioredis@0.61.0":
   version "0.61.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.61.0.tgz#e862540cbf188d0ca368d3a75020d165cb8beefb"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.61.0.tgz"
   integrity sha512-hsHDadUtAFbws1YSDc1XW0svGFKiUbqv2td1Cby+UAiwvojm1NyBo/taifH0t8CuFZ0x/2SDm0iuTwrM5pnVOg==
   dependencies:
     "@opentelemetry/instrumentation" "^0.213.0"
@@ -169,7 +712,7 @@
 
 "@opentelemetry/instrumentation-kafkajs@0.22.0":
   version "0.22.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.22.0.tgz#a3cf7aca003f96211e514a348b7568799efdfba1"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.22.0.tgz"
   integrity sha512-wJU4IBQMUikdJAcTChLFqK5lo+flo7pahqd8DSLv7uMxsdOdAHj6RzKYAm8pPfUS6ItKYutYyuicwKaFwQKsoA==
   dependencies:
     "@opentelemetry/instrumentation" "^0.213.0"
@@ -177,7 +720,7 @@
 
 "@opentelemetry/instrumentation-knex@0.57.0":
   version "0.57.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.57.0.tgz#d46622a3f82f3df2ba29c64498d6ef828a40457e"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.57.0.tgz"
   integrity sha512-vMCSh8kolEm5rRsc+FZeTZymWmIJwc40hjIKnXH4O0Dv/gAkJJIRXCsPX5cPbe0c0j/34+PsENd0HqKruwhVYw==
   dependencies:
     "@opentelemetry/instrumentation" "^0.213.0"
@@ -185,7 +728,7 @@
 
 "@opentelemetry/instrumentation-koa@0.61.0":
   version "0.61.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.61.0.tgz#c12f57b023834afb1c142c11746d560bcc288b5b"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.61.0.tgz"
   integrity sha512-lvrfWe9ShK/D2X4brmx8ZqqeWPfRl8xekU0FCn7C1dHm5k6+rTOOi36+4fnaHAP8lig9Ux6XQ1D4RNIpPCt1WQ==
   dependencies:
     "@opentelemetry/core" "^2.0.0"
@@ -194,14 +737,14 @@
 
 "@opentelemetry/instrumentation-lru-memoizer@0.57.0":
   version "0.57.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.57.0.tgz#4da92ecd1bc5d5e9c7de28ea14ed57c9f29cfefd"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.57.0.tgz"
   integrity sha512-cEqpUocSKJfwDtLYTTJehRLWzkZ2eoePCxfVIgGkGkb83fMB71O+y4MvRHJPbeV2bdoWdOVrl8uO0+EynWhTEA==
   dependencies:
     "@opentelemetry/instrumentation" "^0.213.0"
 
 "@opentelemetry/instrumentation-mongodb@0.66.0":
   version "0.66.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.66.0.tgz#990bf4571382d3b02a9584927411c92c375d2fd4"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.66.0.tgz"
   integrity sha512-d7m9QnAY+4TCWI4q1QRkfrc6fo/92VwssaB1DzQfXNRvu51b78P+HJlWP7Qg6N6nkwdb9faMZNBCZJfftmszkw==
   dependencies:
     "@opentelemetry/instrumentation" "^0.213.0"
@@ -209,34 +752,34 @@
 
 "@opentelemetry/instrumentation-mongoose@0.59.0":
   version "0.59.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.59.0.tgz#8446ece86df59f09c630e7df6d794c8cd08f58d8"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.59.0.tgz"
   integrity sha512-6/jWU+c1NgznkVLDU/2y0bXV2nJo3o9FWZ9mZ9nN6T/JBNRoMnVXZl2FdBmgH+a5MwaWLs5kmRJTP5oUVGIkPw==
   dependencies:
     "@opentelemetry/core" "^2.0.0"
     "@opentelemetry/instrumentation" "^0.213.0"
     "@opentelemetry/semantic-conventions" "^1.33.0"
 
-"@opentelemetry/instrumentation-mysql2@0.59.0":
-  version "0.59.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.59.0.tgz#938cd4a294b7e4a6e8c3855b8cfe267c8d2e5493"
-  integrity sha512-n9/xrVCRBfG9egVbffnlU1uhr+HX0vF4GgtAB/Bvm48wpFgRidqD8msBMiym1kRYzmpWvJqTxNT47u1MkgBEdw==
-  dependencies:
-    "@opentelemetry/instrumentation" "^0.213.0"
-    "@opentelemetry/semantic-conventions" "^1.33.0"
-    "@opentelemetry/sql-common" "^0.41.2"
-
 "@opentelemetry/instrumentation-mysql@0.59.0":
   version "0.59.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.59.0.tgz#bf43cafbac5928236ea53704a52c718349c22e38"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.59.0.tgz"
   integrity sha512-r+V/Fh0sm7Ga8/zk/TI5H5FQRAjwr0RrpfPf8kNIehlsKf12XnvIaZi8ViZkpX0gyPEpLXqzqWD6QHlgObgzZw==
   dependencies:
     "@opentelemetry/instrumentation" "^0.213.0"
     "@opentelemetry/semantic-conventions" "^1.33.0"
     "@types/mysql" "2.15.27"
 
+"@opentelemetry/instrumentation-mysql2@0.59.0":
+  version "0.59.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.59.0.tgz"
+  integrity sha512-n9/xrVCRBfG9egVbffnlU1uhr+HX0vF4GgtAB/Bvm48wpFgRidqD8msBMiym1kRYzmpWvJqTxNT47u1MkgBEdw==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.213.0"
+    "@opentelemetry/semantic-conventions" "^1.33.0"
+    "@opentelemetry/sql-common" "^0.41.2"
+
 "@opentelemetry/instrumentation-pg@0.65.0":
   version "0.65.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.65.0.tgz#f1f76f8c57c5c6fec68c77ce6ee104fee5de13e1"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.65.0.tgz"
   integrity sha512-W0zpHEIEuyZ8zvb3njaX9AAbHgPYOsSWVOoWmv1sjVRSF6ZpBqtlxBWbU+6hhq1TFWBeWJOXZ8nZS/PUFpLJYQ==
   dependencies:
     "@opentelemetry/core" "^2.0.0"
@@ -248,7 +791,7 @@
 
 "@opentelemetry/instrumentation-redis@0.61.0":
   version "0.61.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.61.0.tgz#b43b9c3b5d0b124f2e60b055e4529a3a4b55dbc4"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.61.0.tgz"
   integrity sha512-JnPexA034/0UJRsvH96B0erQoNOqKJZjE2ZRSw9hiTSC23LzE0nJE/u6D+xqOhgUhRnhhcPHq4MdYtmUdYTF+Q==
   dependencies:
     "@opentelemetry/instrumentation" "^0.213.0"
@@ -257,7 +800,7 @@
 
 "@opentelemetry/instrumentation-tedious@0.32.0":
   version "0.32.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.32.0.tgz#8204a14adb71adcbf7d72705244d606bb69e428a"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.32.0.tgz"
   integrity sha512-BQS6gG8RJ1foEqfEZ+wxoqlwfCAzb1ZVG0ad8Gfe4x8T658HJCLGLd4E4NaoQd8EvPfLqOXgzGaE/2U4ytDSWA==
   dependencies:
     "@opentelemetry/instrumentation" "^0.213.0"
@@ -266,25 +809,16 @@
 
 "@opentelemetry/instrumentation-undici@0.23.0":
   version "0.23.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.23.0.tgz#e328bf6e53847ba7baa2a345d02221cc62917cec"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.23.0.tgz"
   integrity sha512-LL0VySzKVR2cJSFVZaTYpZl1XTpBGnfzoQPe2W7McS2267ldsaEIqtQY6VXs2KCXN0poFjze5110PIpxHDaDGg==
   dependencies:
     "@opentelemetry/core" "^2.0.0"
     "@opentelemetry/instrumentation" "^0.213.0"
     "@opentelemetry/semantic-conventions" "^1.24.0"
 
-"@opentelemetry/instrumentation@0.213.0", "@opentelemetry/instrumentation@^0.213.0":
-  version "0.213.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation/-/instrumentation-0.213.0.tgz#55362569efd0cba00aab9921a78dd20dfddf70b6"
-  integrity sha512-3i9NdkET/KvQomeh7UaR/F4r9P25Rx6ooALlWXPIjypcEOUxksCmVu0zA70NBJWlrMW1rPr/LRidFAflLI+s/w==
-  dependencies:
-    "@opentelemetry/api-logs" "0.213.0"
-    import-in-the-middle "^3.0.0"
-    require-in-the-middle "^8.0.0"
-
 "@opentelemetry/instrumentation@^0.207.0":
   version "0.207.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation/-/instrumentation-0.207.0.tgz#1a5a921c04f171ff28096fa320af713f3c87ec14"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.207.0.tgz"
   integrity sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA==
   dependencies:
     "@opentelemetry/api-logs" "0.207.0"
@@ -293,62 +827,88 @@
 
 "@opentelemetry/instrumentation@^0.212.0":
   version "0.212.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation/-/instrumentation-0.212.0.tgz#238b6e3e2131217ff4acfe7e8e7b6ce1f0ac0ba0"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.212.0.tgz"
   integrity sha512-IyXmpNnifNouMOe0I/gX7ENfv2ZCNdYTF0FpCsoBcpbIHzk81Ww9rQTYTnvghszCg7qGrIhNvWC8dhEifgX9Jg==
   dependencies:
     "@opentelemetry/api-logs" "0.212.0"
     import-in-the-middle "^2.0.6"
     require-in-the-middle "^8.0.0"
 
+"@opentelemetry/instrumentation@^0.213.0", "@opentelemetry/instrumentation@>=0.57.1 <1", "@opentelemetry/instrumentation@0.213.0":
+  version "0.213.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.213.0.tgz"
+  integrity sha512-3i9NdkET/KvQomeh7UaR/F4r9P25Rx6ooALlWXPIjypcEOUxksCmVu0zA70NBJWlrMW1rPr/LRidFAflLI+s/w==
+  dependencies:
+    "@opentelemetry/api-logs" "0.213.0"
+    import-in-the-middle "^3.0.0"
+    require-in-the-middle "^8.0.0"
+
 "@opentelemetry/redis-common@^0.38.2":
   version "0.38.2"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/redis-common/-/redis-common-0.38.2.tgz#cefa4f3e79db1cd54f19e233b7dfb56621143955"
+  resolved "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.38.2.tgz"
   integrity sha512-1BCcU93iwSRZvDAgwUxC/DV4T/406SkMfxGqu5ojc3AvNI+I9GhV7v0J1HljsczuuhcnFLYqD5VmwVXfCGHzxA==
 
-"@opentelemetry/resources@2.6.0", "@opentelemetry/resources@^2.6.0":
+"@opentelemetry/resources@^1.30.1 || ^2.1.0", "@opentelemetry/resources@^2.6.0", "@opentelemetry/resources@2.6.0":
   version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/resources/-/resources-2.6.0.tgz#1a945dbb8986043d8b593c358d5d8e3de6becf5a"
+  resolved "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.0.tgz"
   integrity sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ==
   dependencies:
     "@opentelemetry/core" "2.6.0"
     "@opentelemetry/semantic-conventions" "^1.29.0"
 
-"@opentelemetry/sdk-trace-base@^2.6.0":
+"@opentelemetry/sdk-trace-base@^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base@^2.6.0":
   version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.0.tgz#d7e752a0906f2bcae3c1261e224aef3e3b3746f9"
+  resolved "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.0.tgz"
   integrity sha512-g/OZVkqlxllgFM7qMKqbPV9c1DUPhQ7d4n3pgZFcrnrNft9eJXZM2TNHTPYREJBrtNdRytYyvwjgL5geDKl3EQ==
   dependencies:
     "@opentelemetry/core" "2.6.0"
     "@opentelemetry/resources" "2.6.0"
     "@opentelemetry/semantic-conventions" "^1.29.0"
 
-"@opentelemetry/semantic-conventions@^1.24.0", "@opentelemetry/semantic-conventions@^1.27.0", "@opentelemetry/semantic-conventions@^1.28.0", "@opentelemetry/semantic-conventions@^1.29.0", "@opentelemetry/semantic-conventions@^1.30.0", "@opentelemetry/semantic-conventions@^1.33.0", "@opentelemetry/semantic-conventions@^1.33.1", "@opentelemetry/semantic-conventions@^1.34.0", "@opentelemetry/semantic-conventions@^1.36.0", "@opentelemetry/semantic-conventions@^1.40.0":
+"@opentelemetry/semantic-conventions@^1.24.0", "@opentelemetry/semantic-conventions@^1.27.0", "@opentelemetry/semantic-conventions@^1.28.0", "@opentelemetry/semantic-conventions@^1.29.0", "@opentelemetry/semantic-conventions@^1.30.0", "@opentelemetry/semantic-conventions@^1.33.0", "@opentelemetry/semantic-conventions@^1.33.1", "@opentelemetry/semantic-conventions@^1.34.0", "@opentelemetry/semantic-conventions@^1.36.0", "@opentelemetry/semantic-conventions@^1.39.0", "@opentelemetry/semantic-conventions@^1.40.0":
   version "1.40.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz#10b2944ca559386590683392022a897eefd011d3"
+  resolved "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz"
   integrity sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==
 
 "@opentelemetry/sql-common@^0.41.2":
   version "0.41.2"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/sql-common/-/sql-common-0.41.2.tgz#7f4a14166cfd6c9ffe89096db1cc75eaf6443b19"
+  resolved "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.41.2.tgz"
   integrity sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==
   dependencies:
     "@opentelemetry/core" "^2.0.0"
 
+"@paralleldrive/cuid2@^2.2.2":
+  version "2.3.1"
+  resolved "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz"
+  integrity sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==
+  dependencies:
+    "@noble/hashes" "^1.1.5"
+
+"@pkgjs/parseargs@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz"
+  integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
+
+"@pkgr/core@^0.2.9":
+  version "0.2.9"
+  resolved "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz"
+  integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
+
 "@prisma/instrumentation@7.4.2":
   version "7.4.2"
-  resolved "https://registry.yarnpkg.com/@prisma/instrumentation/-/instrumentation-7.4.2.tgz#b05e814d0647343febd26a8ccb039d27ccc69eca"
+  resolved "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-7.4.2.tgz"
   integrity sha512-r9JfchJF1Ae6yAxcaLu/V1TGqBhAuSDe3mRNOssBfx1rMzfZ4fdNvrgUBwyb/TNTGXFxlH9AZix5P257x07nrg==
   dependencies:
     "@opentelemetry/instrumentation" "^0.207.0"
 
 "@sentry/core@10.45.0":
   version "10.45.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-10.45.0.tgz#4bac78dd4815588d0089e6594ab20da5b5ed467e"
+  resolved "https://registry.npmjs.org/@sentry/core/-/core-10.45.0.tgz"
   integrity sha512-s69UXxvefeQxuZ5nY7/THtTrIEvJxNVCp3ns4kwoCw1qMpgpvn/296WCKVmM7MiwnaAdzEKnAvLAwaxZc2nM7Q==
 
 "@sentry/node-core@10.45.0":
   version "10.45.0"
-  resolved "https://registry.yarnpkg.com/@sentry/node-core/-/node-core-10.45.0.tgz#2cd5eb05cb2f76a12db644565993a70e6c3abe53"
+  resolved "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.45.0.tgz"
   integrity sha512-KQZEvLKM344+EqXiA9HIzWbW5hzq6/9nnFUQ8niaBPoOgR9AiJhrccfIscfgb8vjkriiEtzE03OW/4h1CTgZ3Q==
   dependencies:
     "@sentry/core" "10.45.0"
@@ -357,7 +917,7 @@
 
 "@sentry/node@^10.45.0":
   version "10.45.0"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-10.45.0.tgz#1844dcddf7ec0e4d6722d61340099fb690aa25df"
+  resolved "https://registry.npmjs.org/@sentry/node/-/node-10.45.0.tgz"
   integrity sha512-Kpiq9lRGnJc1ex8SwxOBl+FLQNl4Y137BydVooP7AFiAYZ6ftwHsIEF1bcYXaipHMT1YHS2bdhC2UQaaB2jkuQ==
   dependencies:
     "@fastify/otel" "0.17.1"
@@ -398,39 +958,91 @@
 
 "@sentry/opentelemetry@10.45.0":
   version "10.45.0"
-  resolved "https://registry.yarnpkg.com/@sentry/opentelemetry/-/opentelemetry-10.45.0.tgz#f5040c78e7e46e22d3a45e1777b21d26cbd33e94"
+  resolved "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.45.0.tgz"
   integrity sha512-PmuGO+p/gC3ZQ8ddOeJ5P9ApnTTm35i12Bpuyb13AckCbNSJFvG2ggZda35JQOmiFU0kKYiwkoFAa8Mvj9od3Q==
   dependencies:
     "@sentry/core" "10.45.0"
 
+"@sinclair/typebox@^0.34.0":
+  version "0.34.48"
+  resolved "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz"
+  integrity sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==
+
+"@sinonjs/commons@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz"
+  integrity sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/fake-timers@^15.0.0":
+  version "15.1.1"
+  resolved "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.1.1.tgz"
+  integrity sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==
+  dependencies:
+    "@sinonjs/commons" "^3.0.1"
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.9"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.9.tgz#df4907fc07a886922637b15e02d4cebc4c0021b2"
+  resolved "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz"
   integrity sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==
 
 "@tsconfig/node12@^1.0.7":
   version "1.0.11"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
+  resolved "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz"
   integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
 
 "@tsconfig/node14@^1.0.0":
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
+  resolved "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz"
   integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
 
 "@tsconfig/node16@^1.0.2":
   version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
+  resolved "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz"
   integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
+
+"@types/babel__core@^7.20.5":
+  version "7.20.5"
+  resolved "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz"
+  integrity sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==
+  dependencies:
+    "@babel/parser" "^7.20.7"
+    "@babel/types" "^7.20.7"
+    "@types/babel__generator" "*"
+    "@types/babel__template" "*"
+    "@types/babel__traverse" "*"
+
+"@types/babel__generator@*":
+  version "7.27.0"
+  resolved "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz"
+  integrity sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@types/babel__template@*":
+  version "7.4.4"
+  resolved "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz"
+  integrity sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==
+  dependencies:
+    "@babel/parser" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@types/babel__traverse@*":
+  version "7.28.0"
+  resolved "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz"
+  integrity sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==
+  dependencies:
+    "@babel/types" "^7.28.2"
 
 "@types/bcryptjs@^2.4.6":
   version "2.4.6"
-  resolved "https://registry.yarnpkg.com/@types/bcryptjs/-/bcryptjs-2.4.6.tgz#2b92e3c2121c66eba3901e64faf8bb922ec291fa"
+  resolved "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz"
   integrity sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==
 
 "@types/body-parser@*":
   version "1.19.3"
-  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.3.tgz#fb558014374f7d9e56c8f34bab2042a3a07d25cd"
+  resolved "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.3.tgz"
   integrity sha512-oyl4jvAfTGX9Bt6Or4H9ni1Z447/tQuxnZsytsCaExKlmJiU8sFgnIBRzJUpKwB5eWn9HuBYlUlVA74q/yN0eQ==
   dependencies:
     "@types/connect" "*"
@@ -438,28 +1050,33 @@
 
 "@types/connect@*":
   version "3.4.36"
-  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.36.tgz#e511558c15a39cb29bd5357eebb57bd1459cd1ab"
+  resolved "https://registry.npmjs.org/@types/connect/-/connect-3.4.36.tgz"
   integrity sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==
   dependencies:
     "@types/node" "*"
 
 "@types/connect@3.4.38":
   version "3.4.38"
-  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.38.tgz#5ba7f3bc4fbbdeaff8dded952e5ff2cc53f8d858"
+  resolved "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz"
   integrity sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==
   dependencies:
     "@types/node" "*"
 
+"@types/cookiejar@^2.1.5":
+  version "2.1.5"
+  resolved "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz"
+  integrity sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==
+
 "@types/cors@^2.8.14":
   version "2.8.19"
-  resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.19.tgz#d93ea2673fd8c9f697367f5eeefc2bbfa94f0342"
+  resolved "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz"
   integrity sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==
   dependencies:
     "@types/node" "*"
 
 "@types/express-serve-static-core@^4.17.33":
   version "4.17.37"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.37.tgz#7e4b7b59da9142138a2aaa7621f5abedce8c7320"
+  resolved "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.37.tgz"
   integrity sha512-ZohaCYTgGFcOP7u6aJOhY9uIZQgZ2vxC2yWoArY+FeDXlqeH66ZVBjgvg+RLVAS/DWNq4Ap9ZXu1+SUQiiWYMg==
   dependencies:
     "@types/node" "*"
@@ -467,9 +1084,9 @@
     "@types/range-parser" "*"
     "@types/send" "*"
 
-"@types/express@^4.17.20":
+"@types/express@*", "@types/express@^4.17.20":
   version "4.17.20"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.20.tgz#e7c9b40276d29e38a4e3564d7a3d65911e2aa433"
+  resolved "https://registry.npmjs.org/@types/express/-/express-4.17.20.tgz"
   integrity sha512-rOaqlkgEvOW495xErXMsmyX3WKBInbhG5eqojXYi3cGUaLoRDlXa5d52fkfWZT963AZ3v2eZ4MbKE6WpDAGVsw==
   dependencies:
     "@types/body-parser" "*"
@@ -479,63 +1096,95 @@
 
 "@types/http-errors@*":
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@types/http-errors/-/http-errors-2.0.2.tgz#a86e00bbde8950364f8e7846687259ffcd96e8c2"
+  resolved "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.2.tgz"
   integrity sha512-lPG6KlZs88gef6aD85z3HNkztpj7w2R7HmR3gygjfXCQmsLloWNARFkMuzKiiY8FGdh1XDpgBdrSf4aKDiA7Kg==
+
+"@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.1", "@types/istanbul-lib-coverage@^2.0.6":
+  version "2.0.6"
+  resolved "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz"
+  integrity sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==
+
+"@types/istanbul-lib-report@*":
+  version "3.0.3"
+  resolved "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz"
+  integrity sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==
+  dependencies:
+    "@types/istanbul-lib-coverage" "*"
+
+"@types/istanbul-reports@^3.0.4":
+  version "3.0.4"
+  resolved "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz"
+  integrity sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==
+  dependencies:
+    "@types/istanbul-lib-report" "*"
+
+"@types/jest@^30.0.0":
+  version "30.0.0"
+  resolved "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz"
+  integrity sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==
+  dependencies:
+    expect "^30.0.0"
+    pretty-format "^30.0.0"
 
 "@types/jsonwebtoken@^9.0.4":
   version "9.0.10"
-  resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz#a7932a47177dcd4283b6146f3bd5c26d82647f09"
+  resolved "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz"
   integrity sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==
   dependencies:
     "@types/ms" "*"
     "@types/node" "*"
 
+"@types/methods@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz"
+  integrity sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==
+
 "@types/mime@*":
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.2.tgz#c1ae807f13d308ee7511a5b81c74f327028e66e8"
+  resolved "https://registry.npmjs.org/@types/mime/-/mime-3.0.2.tgz"
   integrity sha512-Wj+fqpTLtTbG7c0tH47dkahefpLKEbB+xAZuLq7b4/IDHPl/n6VoXcyUQ2bypFlbSwvCr0y+bD4euTTqTJsPxQ==
 
 "@types/mime@^1":
   version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.3.tgz#bbe64987e0eb05de150c305005055c7ad784a9ce"
+  resolved "https://registry.npmjs.org/@types/mime/-/mime-1.3.3.tgz"
   integrity sha512-Ys+/St+2VF4+xuY6+kDIXGxbNRO0mesVg0bbxEfB97Od1Vjpjx9KD1qxs64Gcb3CWPirk9Xe+PT4YiiHQ9T+eg==
 
 "@types/ms@*":
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-2.1.0.tgz#052aa67a48eccc4309d7f0191b7e41434b90bb78"
+  resolved "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz"
   integrity sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==
+
+"@types/multer@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/@types/multer/-/multer-2.1.0.tgz"
+  integrity sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==
+  dependencies:
+    "@types/express" "*"
 
 "@types/mysql@2.15.27":
   version "2.15.27"
-  resolved "https://registry.yarnpkg.com/@types/mysql/-/mysql-2.15.27.tgz#fb13b0e8614d39d42f40f381217ec3215915f1e9"
+  resolved "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.27.tgz"
   integrity sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==
   dependencies:
     "@types/node" "*"
 
-"@types/node@*":
-  version "20.8.6"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.8.6.tgz#0dbd4ebcc82ad0128df05d0e6f57e05359ee47fa"
-  integrity sha512-eWO4K2Ji70QzKUqRy6oyJWUeB7+g2cRagT3T/nxYibYcT4y2BDL8lqolRXjTHmkZCdJfIPaY73KbJAZmcryxTQ==
-  dependencies:
-    undici-types "~5.25.1"
-
-"@types/node@^20.8.7":
+"@types/node@*", "@types/node@^20.8.7":
   version "20.8.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.8.7.tgz#ad23827850843de973096edfc5abc9e922492a25"
+  resolved "https://registry.npmjs.org/@types/node/-/node-20.8.7.tgz"
   integrity sha512-21TKHHh3eUHIi2MloeptJWALuCu5H7HQTdTrWIFReA8ad+aggoX+lRes3ex7/FtpC+sVUpFMQ+QTfYr74mruiQ==
   dependencies:
     undici-types "~5.25.1"
 
 "@types/pg-pool@2.0.7":
   version "2.0.7"
-  resolved "https://registry.yarnpkg.com/@types/pg-pool/-/pg-pool-2.0.7.tgz#c17945a74472d9a3beaf8e66d5aa6fc938328734"
+  resolved "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.7.tgz"
   integrity sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==
   dependencies:
     "@types/pg" "*"
 
 "@types/pg@*":
   version "8.20.0"
-  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-8.20.0.tgz#8bd03d3ac6b19143a8de7d66a9d13da32cd91526"
+  resolved "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz"
   integrity sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==
   dependencies:
     "@types/node" "*"
@@ -544,7 +1193,7 @@
 
 "@types/pg@8.15.6":
   version "8.15.6"
-  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-8.15.6.tgz#4df7590b9ac557cbe5479e0074ec1540cbddad9b"
+  resolved "https://registry.npmjs.org/@types/pg/-/pg-8.15.6.tgz"
   integrity sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==
   dependencies:
     "@types/node" "*"
@@ -553,17 +1202,17 @@
 
 "@types/qs@*":
   version "6.9.8"
-  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.8.tgz#f2a7de3c107b89b441e071d5472e6b726b4adf45"
+  resolved "https://registry.npmjs.org/@types/qs/-/qs-6.9.8.tgz"
   integrity sha512-u95svzDlTysU5xecFNTgfFG5RUWu1A9P0VzgpcIiGZA9iraHOdSzcxMxQ55DyeRaGCSxQi7LxXDI4rzq/MYfdg==
 
 "@types/range-parser@*":
   version "1.2.5"
-  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.5.tgz#38bd1733ae299620771bd414837ade2e57757498"
+  resolved "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.5.tgz"
   integrity sha512-xrO9OoVPqFuYyR/loIHjnbvvyRZREYKLjxV4+dY6v3FQR3stQ9ZxIGkaclF7YhI9hfjpuTbu14hZEy94qKLtOA==
 
 "@types/send@*":
   version "0.17.2"
-  resolved "https://registry.yarnpkg.com/@types/send/-/send-0.17.2.tgz#af78a4495e3c2b79bfbdac3955fdd50e03cc98f2"
+  resolved "https://registry.npmjs.org/@types/send/-/send-0.17.2.tgz"
   integrity sha512-aAG6yRf6r0wQ29bkS+x97BIs64ZLxeE/ARwyS6wrldMm3C1MdKwCcnnEwMC1slI8wuxJOpiUH9MioC0A0i+GJw==
   dependencies:
     "@types/mime" "^1"
@@ -571,36 +1220,88 @@
 
 "@types/serve-static@*":
   version "1.15.3"
-  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.15.3.tgz#2cfacfd1fd4520bbc3e292cca432d5e8e2e3ee61"
+  resolved "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.3.tgz"
   integrity sha512-yVRvFsEMrv7s0lGhzrggJjNOSmZCdgCjw9xWrPr/kNNLp6FaDfMC1KaYl3TSJ0c58bECwNBMoQrZJ8hA8E1eFg==
   dependencies:
     "@types/http-errors" "*"
     "@types/mime" "*"
     "@types/node" "*"
 
+"@types/stack-utils@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz"
+  integrity sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==
+
+"@types/superagent@^8.1.0":
+  version "8.1.9"
+  resolved "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz"
+  integrity sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==
+  dependencies:
+    "@types/cookiejar" "^2.1.5"
+    "@types/methods" "^1.1.4"
+    "@types/node" "*"
+    form-data "^4.0.0"
+
+"@types/supertest@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/@types/supertest/-/supertest-7.2.0.tgz"
+  integrity sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==
+  dependencies:
+    "@types/methods" "^1.1.4"
+    "@types/superagent" "^8.1.0"
+
 "@types/tedious@^4.0.14":
   version "4.0.14"
-  resolved "https://registry.yarnpkg.com/@types/tedious/-/tedious-4.0.14.tgz#868118e7a67808258c05158e9cad89ca58a2aec1"
+  resolved "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz"
   integrity sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==
   dependencies:
     "@types/node" "*"
 
 "@types/webidl-conversions@*":
   version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@types/webidl-conversions/-/webidl-conversions-7.0.1.tgz#2b9a2062b39a7272343c185cdb884f2e52188f75"
+  resolved "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.1.tgz"
   integrity sha512-8hKOnOan+Uu+NgMaCouhg3cT9x5fFZ92Jwf+uDLXLu/MFRbXxlWwGeQY7KVHkeSft6RvY+tdxklUBuyY9eIEKg==
+
+"@types/whatwg-url@^13.0.0":
+  version "13.0.0"
+  resolved "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz"
+  integrity sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==
+  dependencies:
+    "@types/webidl-conversions" "*"
 
 "@types/whatwg-url@^8.2.1":
   version "8.2.2"
-  resolved "https://registry.yarnpkg.com/@types/whatwg-url/-/whatwg-url-8.2.2.tgz#749d5b3873e845897ada99be4448041d4cc39e63"
+  resolved "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz"
   integrity sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==
   dependencies:
     "@types/node" "*"
     "@types/webidl-conversions" "*"
 
+"@types/yargs-parser@*":
+  version "21.0.3"
+  resolved "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz"
+  integrity sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==
+
+"@types/yargs@^17.0.33":
+  version "17.0.35"
+  resolved "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz"
+  integrity sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==
+  dependencies:
+    "@types/yargs-parser" "*"
+
+"@ungap/structured-clone@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz"
+  integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
+
+"@unrs/resolver-binding-darwin-arm64@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz"
+  integrity sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==
+
 accepts@~1.3.8:
   version "1.3.8"
-  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
+  resolved "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz"
   integrity sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==
   dependencies:
     mime-types "~2.1.34"
@@ -608,115 +1309,402 @@ accepts@~1.3.8:
 
 acorn-import-attributes@^1.9.5:
   version "1.9.5"
-  resolved "https://registry.yarnpkg.com/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz#7eb1557b1ba05ef18b5ed0ec67591bfab04688ef"
+  resolved "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz"
   integrity sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==
 
 acorn-walk@^8.1.1:
   version "8.2.0"
-  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  resolved "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
-acorn@^8.15.0:
+acorn@^8, acorn@^8.15.0:
   version "8.16.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.16.0.tgz#4ce79c89be40afe7afe8f3adb902a1f1ce9ac08a"
+  resolved "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz"
   integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
 
 acorn@^8.4.1:
   version "8.10.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.10.0.tgz#8be5b3907a67221a81ab23c7889c4c5526b62ec5"
+  resolved "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz"
   integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
 
-anymatch@~3.1.2:
+agent-base@^7.1.2:
+  version "7.1.4"
+  resolved "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz"
+  integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
+
+ansi-escapes@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz"
+  integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
+  dependencies:
+    type-fest "^0.21.3"
+
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
+ansi-regex@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz"
+  integrity sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==
+
+ansi-styles@^4.0.0, ansi-styles@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+  dependencies:
+    color-convert "^2.0.1"
+
+ansi-styles@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
+
+ansi-styles@^6.1.0:
+  version "6.2.3"
+  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz"
+  integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
+
+anymatch@^3.1.3, anymatch@~3.1.2:
   version "3.1.3"
-  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
+  resolved "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz"
   integrity sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+append-field@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz"
+  integrity sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==
+
 arg@^4.1.0:
   version "4.1.3"
-  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  resolved "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz"
   integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
+
+argparse@^1.0.7:
+  version "1.0.10"
+  resolved "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz"
+  integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
+  dependencies:
+    sprintf-js "~1.0.2"
 
 array-flatten@1.1.1:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
+  resolved "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
   integrity sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==
+
+asap@^2.0.0:
+  version "2.0.6"
+  resolved "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz"
+  integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
+
+async-mutex@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz"
+  integrity sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==
+  dependencies:
+    tslib "^2.4.0"
+
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
+b4a@^1.6.4:
+  version "1.8.0"
+  resolved "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz"
+  integrity sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==
+
+"babel-jest@^29.0.0 || ^30.0.0", babel-jest@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz"
+  integrity sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==
+  dependencies:
+    "@jest/transform" "30.3.0"
+    "@types/babel__core" "^7.20.5"
+    babel-plugin-istanbul "^7.0.1"
+    babel-preset-jest "30.3.0"
+    chalk "^4.1.2"
+    graceful-fs "^4.2.11"
+    slash "^3.0.0"
+
+babel-plugin-istanbul@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz"
+  integrity sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@istanbuljs/load-nyc-config" "^1.0.0"
+    "@istanbuljs/schema" "^0.1.3"
+    istanbul-lib-instrument "^6.0.2"
+    test-exclude "^6.0.0"
+
+babel-plugin-jest-hoist@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.3.0.tgz"
+  integrity sha512-+TRkByhsws6sfPjVaitzadk1I0F5sPvOVUH5tyTSzhePpsGIVrdeunHSw/C36QeocS95OOk8lunc4rlu5Anwsg==
+  dependencies:
+    "@types/babel__core" "^7.20.5"
+
+babel-preset-current-node-syntax@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz"
+  integrity sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==
+  dependencies:
+    "@babel/plugin-syntax-async-generators" "^7.8.4"
+    "@babel/plugin-syntax-bigint" "^7.8.3"
+    "@babel/plugin-syntax-class-properties" "^7.12.13"
+    "@babel/plugin-syntax-class-static-block" "^7.14.5"
+    "@babel/plugin-syntax-import-attributes" "^7.24.7"
+    "@babel/plugin-syntax-import-meta" "^7.10.4"
+    "@babel/plugin-syntax-json-strings" "^7.8.3"
+    "@babel/plugin-syntax-logical-assignment-operators" "^7.10.4"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.3"
+    "@babel/plugin-syntax-numeric-separator" "^7.10.4"
+    "@babel/plugin-syntax-object-rest-spread" "^7.8.3"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.8.3"
+    "@babel/plugin-syntax-optional-chaining" "^7.8.3"
+    "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
+    "@babel/plugin-syntax-top-level-await" "^7.14.5"
+
+babel-preset-jest@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.3.0.tgz"
+  integrity sha512-6ZcUbWHC+dMz2vfzdNwi87Z1gQsLNK2uLuK1Q89R11xdvejcivlYYwDlEv0FHX3VwEXpbBQ9uufB/MUNpZGfhQ==
+  dependencies:
+    babel-plugin-jest-hoist "30.3.0"
+    babel-preset-current-node-syntax "^1.2.0"
+
+balanced-match@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
+  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
 balanced-match@^4.0.2:
   version "4.0.4"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
+  resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz"
   integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
+
+bare-events@*, bare-events@^2.5.4, bare-events@^2.7.0:
+  version "2.8.2"
+  resolved "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz"
+  integrity sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==
+
+bare-fs@^4.5.5:
+  version "4.5.6"
+  resolved "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.6.tgz"
+  integrity sha512-1QovqDrR80Pmt5HPAsMsXTCFcDYr+NSUKW6nd6WO5v0JBmnItc/irNRzm2KOQ5oZ69P37y+AMujNyNtG+1Rggw==
+  dependencies:
+    bare-events "^2.5.4"
+    bare-path "^3.0.0"
+    bare-stream "^2.6.4"
+    bare-url "^2.2.2"
+    fast-fifo "^1.3.2"
+
+bare-os@^3.0.1:
+  version "3.8.0"
+  resolved "https://registry.npmjs.org/bare-os/-/bare-os-3.8.0.tgz"
+  integrity sha512-Dc9/SlwfxkXIGYhvMQNUtKaXCaGkZYGcd1vuNUUADVqzu4/vQfvnMkYYOUnt2VwQ2AqKr/8qAVFRtwETljgeFg==
+
+bare-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz"
+  integrity sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==
+  dependencies:
+    bare-os "^3.0.1"
+
+bare-stream@^2.6.4:
+  version "2.10.0"
+  resolved "https://registry.npmjs.org/bare-stream/-/bare-stream-2.10.0.tgz"
+  integrity sha512-DOPZF/DDcDruKDA43cOw6e9Quq5daua7ygcAwJE/pKJsRWhgSSemi7qVNGE5kyDIxIeN1533G/zfbvWX7Wcb9w==
+  dependencies:
+    streamx "^2.25.0"
+    teex "^1.0.1"
+
+bare-url@^2.2.2:
+  version "2.4.0"
+  resolved "https://registry.npmjs.org/bare-url/-/bare-url-2.4.0.tgz"
+  integrity sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==
+  dependencies:
+    bare-path "^3.0.0"
+
+baseline-browser-mapping@^2.9.0:
+  version "2.10.10"
+  resolved "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.10.tgz"
+  integrity sha512-sUoJ3IMxx4AyRqO4MLeHlnGDkyXRoUG0/AI9fjK+vS72ekpV0yWVY7O0BVjmBcRtkNcsAO2QDZ4tdKKGoI6YaQ==
 
 bcryptjs@^2.4.3:
   version "2.4.3"
-  resolved "https://registry.yarnpkg.com/bcryptjs/-/bcryptjs-2.4.3.tgz#9ab5627b93e60621ff7cdac5da9733027df1d0cb"
+  resolved "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz"
   integrity sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==
 
 binary-extensions@^2.0.0:
   version "2.3.0"
-  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"
+  resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz"
   integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
 
-body-parser@1.20.1:
-  version "1.20.1"
-  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.1.tgz#b1812a8912c195cd371a3ee5e66faa2338a5c668"
-  integrity sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==
+body-parser@~1.20.3:
+  version "1.20.4"
+  resolved "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz"
+  integrity sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==
   dependencies:
-    bytes "3.1.2"
-    content-type "~1.0.4"
+    bytes "~3.1.2"
+    content-type "~1.0.5"
     debug "2.6.9"
     depd "2.0.0"
-    destroy "1.2.0"
-    http-errors "2.0.0"
-    iconv-lite "0.4.24"
-    on-finished "2.4.1"
-    qs "6.11.0"
-    raw-body "2.5.1"
+    destroy "~1.2.0"
+    http-errors "~2.0.1"
+    iconv-lite "~0.4.24"
+    on-finished "~2.4.1"
+    qs "~6.14.0"
+    raw-body "~2.5.3"
     type-is "~1.6.18"
-    unpipe "1.0.0"
+    unpipe "~1.0.0"
+
+brace-expansion@^1.1.7:
+  version "1.1.12"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz"
+  integrity sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==
+  dependencies:
+    balanced-match "^1.0.0"
+    concat-map "0.0.1"
+
+brace-expansion@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz"
+  integrity sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==
+  dependencies:
+    balanced-match "^1.0.0"
 
 brace-expansion@^5.0.2:
   version "5.0.4"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.4.tgz#614daaecd0a688f660bbbc909a8748c3d80d4336"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz"
   integrity sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==
   dependencies:
     balanced-match "^4.0.2"
 
 braces@~3.0.2:
   version "3.0.3"
-  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
+  resolved "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz"
   integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
   dependencies:
     fill-range "^7.1.1"
 
+browserslist@^4.24.0, "browserslist@>= 4.21.0":
+  version "4.28.1"
+  resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz"
+  integrity sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==
+  dependencies:
+    baseline-browser-mapping "^2.9.0"
+    caniuse-lite "^1.0.30001759"
+    electron-to-chromium "^1.5.263"
+    node-releases "^2.0.27"
+    update-browserslist-db "^1.2.0"
+
+bs-logger@^0.2.6:
+  version "0.2.6"
+  resolved "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz"
+  integrity sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==
+  dependencies:
+    fast-json-stable-stringify "2.x"
+
+bser@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz"
+  integrity sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==
+  dependencies:
+    node-int64 "^0.4.0"
+
 bson@^5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/bson/-/bson-5.5.0.tgz#a419cc69f368d2def3b8b22ea03ed1c9be40e53f"
-  integrity sha512-B+QB4YmDx9RStKv8LLSl/aVIEV3nYJc3cJNNTK2Cd1TL+7P+cNpw9mAPeCgc5K+j01Dv6sxUzcITXDx7ZU3F0w==
+  version "5.5.1"
+  resolved "https://registry.npmjs.org/bson/-/bson-5.5.1.tgz"
+  integrity sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==
+
+bson@^7.1.1:
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/bson/-/bson-7.2.0.tgz"
+  integrity sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==
+
+buffer-crc32@~0.2.3:
+  version "0.2.13"
+  resolved "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz"
+  integrity sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==
 
 buffer-equal-constant-time@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  resolved "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz"
   integrity sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==
 
-bytes@3.1.2:
+buffer-from@^1.0.0:
+  version "1.1.2"
+
+busboy@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz"
+  integrity sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==
+  dependencies:
+    streamsearch "^1.1.0"
+
+bytes@~3.1.2:
   version "3.1.2"
-  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
+  resolved "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
-call-bind@^1.0.0:
+call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
-  integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
+  resolved "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz"
+  integrity sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==
   dependencies:
-    function-bind "^1.1.1"
-    get-intrinsic "^1.0.2"
+    es-errors "^1.3.0"
+    function-bind "^1.1.2"
+
+call-bound@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz"
+  integrity sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    get-intrinsic "^1.3.0"
+
+callsites@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz"
+  integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
+
+camelcase@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz"
+  integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
+
+camelcase@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz"
+  integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
+
+caniuse-lite@^1.0.30001759:
+  version "1.0.30001781"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz"
+  integrity sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==
+
+chalk@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
+char-regex@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz"
+  integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
 chokidar@^3.5.2:
   version "3.6.0"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
+  resolved "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz"
   integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
   dependencies:
     anymatch "~3.1.2"
@@ -729,36 +1717,119 @@ chokidar@^3.5.2:
   optionalDependencies:
     fsevents "~2.3.2"
 
-cjs-module-lexer@^2.2.0:
+ci-info@^4.2.0:
+  version "4.4.0"
+  resolved "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz"
+  integrity sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==
+
+cjs-module-lexer@^2.1.0, cjs-module-lexer@^2.2.0:
   version "2.2.0"
-  resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz#b3ca5101843389259ade7d88c77bd06ce55849ca"
+  resolved "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz"
   integrity sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==
 
-content-disposition@0.5.4:
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
+    wrap-ansi "^7.0.0"
+
+co@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
+  integrity sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==
+
+collect-v8-coverage@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz"
+  integrity sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==
+
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
+commondir@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz"
+  integrity sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==
+
+component-emitter@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz"
+  integrity sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==
+
+concat-map@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+  integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
+
+concat-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz"
+  integrity sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==
+  dependencies:
+    buffer-from "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.0.2"
+    typedarray "^0.0.6"
+
+content-disposition@~0.5.4:
   version "0.5.4"
-  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.4.tgz#8b82b4efac82512a02bb0b1dcec9d2c5e8eb5bfe"
+  resolved "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz"
   integrity sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==
   dependencies:
     safe-buffer "5.2.1"
 
-content-type@~1.0.4:
+content-type@~1.0.4, content-type@~1.0.5:
   version "1.0.5"
-  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.5.tgz#8b773162656d1d1086784c8f23a54ce6d73d7918"
+  resolved "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz"
   integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
 
-cookie-signature@1.0.6:
+convert-source-map@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz"
+  integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
+
+cookie-signature@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz"
+  integrity sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==
+
+cookie-signature@~1.0.6:
   version "1.0.6"
-  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
+  resolved "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
   integrity sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==
 
-cookie@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
-  integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
+cookie@~0.7.1:
+  version "0.7.2"
+  resolved "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz"
+  integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
+
+cookiejar@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz"
+  integrity sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==
 
 cors@^2.8.5:
   version "2.8.6"
-  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.6.tgz#ff5dd69bd95e547503820d29aba4f8faf8dfec96"
+  resolved "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz"
   integrity sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==
   dependencies:
     object-assign "^4"
@@ -766,230 +1837,588 @@ cors@^2.8.5:
 
 create-require@^1.1.0:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  resolved "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
+cross-spawn@^7.0.3, cross-spawn@^7.0.6:
+  version "7.0.6"
+  resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz"
+  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
+csv-parse@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.npmjs.org/csv-parse/-/csv-parse-6.2.1.tgz"
+  integrity sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ==
+
+debug@^4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.4, debug@^4.3.5, debug@^4.3.7, debug@^4.4.3, debug@4:
+  version "4.4.3"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
 
 debug@2.6.9:
   version "2.6.9"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
 
 debug@4.x:
   version "4.3.4"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
 
-debug@^4, debug@^4.3.5:
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
-  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
-  dependencies:
-    ms "^2.1.3"
+dedent@^1.6.0:
+  version "1.7.2"
+  resolved "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz"
+  integrity sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==
 
-depd@2.0.0:
+deepmerge@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz"
+  integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
+
+depd@~2.0.0, depd@2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
+  resolved "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
-destroy@1.2.0:
+destroy@~1.2.0, destroy@1.2.0:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
+  resolved "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
 
+detect-newline@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz"
+  integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
+
+dezalgo@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz"
+  integrity sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==
+  dependencies:
+    asap "^2.0.0"
+    wrappy "1"
+
 diff@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
-  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
+  version "4.0.4"
+  resolved "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz"
+  integrity sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==
 
 dotenv@^16.3.1:
   version "16.6.1"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.6.1.tgz#773f0e69527a8315c7285d5ee73c4459d20a8020"
+  resolved "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz"
   integrity sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==
+
+dunder-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz"
+  integrity sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==
+  dependencies:
+    call-bind-apply-helpers "^1.0.1"
+    es-errors "^1.3.0"
+    gopd "^1.2.0"
+
+eastasianwidth@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz"
+  integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
 
 ecdsa-sig-formatter@1.0.11:
   version "1.0.11"
-  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  resolved "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz"
   integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
   dependencies:
     safe-buffer "^5.0.1"
 
 ee-first@1.1.1:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
+  resolved "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
-encodeurl@~1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
-  integrity sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==
+electron-to-chromium@^1.5.263:
+  version "1.5.322"
+  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.322.tgz"
+  integrity sha512-vFU34OcrvMcH66T+dYC3G4nURmgfDVewMIu6Q2urXpumAPSMmzvcn04KVVV8Opikq8Vs5nUbO/8laNhNRqSzYw==
+
+emittery@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz"
+  integrity sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==
+
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+emoji-regex@^9.2.2:
+  version "9.2.2"
+  resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz"
+  integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
+
+encodeurl@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz"
+  integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
+
+error-ex@^1.3.1:
+  version "1.3.4"
+  resolved "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz"
+  integrity sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==
+  dependencies:
+    is-arrayish "^0.2.1"
+
+es-define-property@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz"
+  integrity sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==
+
+es-errors@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz"
+  integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
+
+es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz"
+  integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
+  dependencies:
+    es-errors "^1.3.0"
+
+es-set-tostringtag@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz"
+  integrity sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==
+  dependencies:
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.6"
+    has-tostringtag "^1.0.2"
+    hasown "^2.0.2"
+
+escalade@^3.1.1, escalade@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz"
+  integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
 
 escape-html@~1.0.3:
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
+  resolved "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
   integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
+
+escape-string-regexp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz"
+  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
+
+esprima@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz"
+  integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
 etag@~1.8.1:
   version "1.8.1"
-  resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
+  resolved "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
+
+events-universal@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz"
+  integrity sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==
+  dependencies:
+    bare-events "^2.7.0"
+
+execa@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz"
+  integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==
+  dependencies:
+    cross-spawn "^7.0.3"
+    get-stream "^6.0.0"
+    human-signals "^2.1.0"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^4.0.1"
+    onetime "^5.1.2"
+    signal-exit "^3.0.3"
+    strip-final-newline "^2.0.0"
+
+exit-x@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz"
+  integrity sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==
+
+expect@^30.0.0, expect@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz"
+  integrity sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==
+  dependencies:
+    "@jest/expect-utils" "30.3.0"
+    "@jest/get-type" "30.1.0"
+    jest-matcher-utils "30.3.0"
+    jest-message-util "30.3.0"
+    jest-mock "30.3.0"
+    jest-util "30.3.0"
 
 express-validator@^7.0.1:
   version "7.3.1"
-  resolved "https://registry.yarnpkg.com/express-validator/-/express-validator-7.3.1.tgz#7884e452b2318ae9faabc8b28fd41ffa21d00d28"
+  resolved "https://registry.npmjs.org/express-validator/-/express-validator-7.3.1.tgz"
   integrity sha512-IGenaSf+DnWc69lKuqlRE9/i/2t5/16VpH5bXoqdxWz1aCpRvEdrBuu1y95i/iL5QP8ZYVATiwLFhwk3EDl5vg==
   dependencies:
     lodash "^4.17.21"
     validator "~13.15.23"
 
 express@^4.18.2:
-  version "4.18.2"
-  resolved "https://registry.yarnpkg.com/express/-/express-4.18.2.tgz#3fabe08296e930c796c19e3c516979386ba9fd59"
-  integrity sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==
+  version "4.22.1"
+  resolved "https://registry.npmjs.org/express/-/express-4.22.1.tgz"
+  integrity sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==
   dependencies:
     accepts "~1.3.8"
     array-flatten "1.1.1"
-    body-parser "1.20.1"
-    content-disposition "0.5.4"
+    body-parser "~1.20.3"
+    content-disposition "~0.5.4"
     content-type "~1.0.4"
-    cookie "0.5.0"
-    cookie-signature "1.0.6"
+    cookie "~0.7.1"
+    cookie-signature "~1.0.6"
     debug "2.6.9"
     depd "2.0.0"
-    encodeurl "~1.0.2"
+    encodeurl "~2.0.0"
     escape-html "~1.0.3"
     etag "~1.8.1"
-    finalhandler "1.2.0"
-    fresh "0.5.2"
-    http-errors "2.0.0"
-    merge-descriptors "1.0.1"
+    finalhandler "~1.3.1"
+    fresh "~0.5.2"
+    http-errors "~2.0.0"
+    merge-descriptors "1.0.3"
     methods "~1.1.2"
-    on-finished "2.4.1"
+    on-finished "~2.4.1"
     parseurl "~1.3.3"
-    path-to-regexp "0.1.7"
+    path-to-regexp "~0.1.12"
     proxy-addr "~2.0.7"
-    qs "6.11.0"
+    qs "~6.14.0"
     range-parser "~1.2.1"
     safe-buffer "5.2.1"
-    send "0.18.0"
-    serve-static "1.15.0"
+    send "~0.19.0"
+    serve-static "~1.16.2"
     setprototypeof "1.2.0"
-    statuses "2.0.1"
+    statuses "~2.0.1"
     type-is "~1.6.18"
     utils-merge "1.0.1"
     vary "~1.1.2"
 
+fast-fifo@^1.2.0, fast-fifo@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz"
+  integrity sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==
+
+fast-json-stable-stringify@^2.1.0, fast-json-stable-stringify@2.x:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz"
+  integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
+
+fast-safe-stringify@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz"
+  integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
+
+fb-watchman@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz"
+  integrity sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==
+  dependencies:
+    bser "2.1.1"
+
 fill-range@^7.1.1:
   version "7.1.1"
-  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"
+  resolved "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz"
   integrity sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==
   dependencies:
     to-regex-range "^5.0.1"
 
-finalhandler@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.2.0.tgz#7d23fe5731b207b4640e4fcd00aec1f9207a7b32"
-  integrity sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==
+finalhandler@~1.3.1:
+  version "1.3.2"
+  resolved "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz"
+  integrity sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==
   dependencies:
     debug "2.6.9"
-    encodeurl "~1.0.2"
+    encodeurl "~2.0.0"
     escape-html "~1.0.3"
-    on-finished "2.4.1"
+    on-finished "~2.4.1"
     parseurl "~1.3.3"
-    statuses "2.0.1"
+    statuses "~2.0.2"
     unpipe "~1.0.0"
+
+find-cache-dir@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz"
+  integrity sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^3.0.2"
+    pkg-dir "^4.1.0"
+
+find-up@^4.0.0, find-up@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz"
+  integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
+  dependencies:
+    locate-path "^5.0.0"
+    path-exists "^4.0.0"
+
+follow-redirects@^1.15.11:
+  version "1.15.11"
+  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz"
+  integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
+
+foreground-child@^3.1.0:
+  version "3.3.1"
+  resolved "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz"
+  integrity sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==
+  dependencies:
+    cross-spawn "^7.0.6"
+    signal-exit "^4.0.1"
+
+form-data@^4.0.0, form-data@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz"
+  integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.2"
+    mime-types "^2.1.12"
+
+formidable@^3.5.4:
+  version "3.5.4"
+  resolved "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz"
+  integrity sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==
+  dependencies:
+    "@paralleldrive/cuid2" "^2.2.2"
+    dezalgo "^1.0.4"
+    once "^1.4.0"
 
 forwarded-parse@2.1.2:
   version "2.1.2"
-  resolved "https://registry.yarnpkg.com/forwarded-parse/-/forwarded-parse-2.1.2.tgz#08511eddaaa2ddfd56ba11138eee7df117a09325"
+  resolved "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz"
   integrity sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==
 
 forwarded@0.2.0:
   version "0.2.0"
-  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
+  resolved "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz"
   integrity sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==
 
-fresh@0.5.2:
+fresh@~0.5.2:
   version "0.5.2"
-  resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
+  resolved "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz"
   integrity sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
 
-fsevents@~2.3.2:
+fs.realpath@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+  integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
+fsevents@^2.3.3, fsevents@~2.3.2:
   version "2.3.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
-function-bind@^1.1.1:
+function-bind@^1.1.2:
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
+  resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
-get-intrinsic@^1.0.2:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.1.tgz#d295644fed4505fc9cde952c37ee12b477a83d82"
-  integrity sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==
+gensync@^1.0.0-beta.2:
+  version "1.0.0-beta.2"
+  resolved "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz"
+  integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
+
+get-caller-file@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
+get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz"
+  integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
   dependencies:
-    function-bind "^1.1.1"
-    has "^1.0.3"
-    has-proto "^1.0.1"
-    has-symbols "^1.0.3"
+    call-bind-apply-helpers "^1.0.2"
+    es-define-property "^1.0.1"
+    es-errors "^1.3.0"
+    es-object-atoms "^1.1.1"
+    function-bind "^1.1.2"
+    get-proto "^1.0.1"
+    gopd "^1.2.0"
+    has-symbols "^1.1.0"
+    hasown "^2.0.2"
+    math-intrinsics "^1.1.0"
+
+get-package-type@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz"
+  integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
+
+get-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz"
+  integrity sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==
+  dependencies:
+    dunder-proto "^1.0.1"
+    es-object-atoms "^1.0.0"
+
+get-stream@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz"
+  integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
 glob-parent@~5.1.2:
   version "5.1.2"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
+  resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
 
+glob@^10.5.0:
+  version "10.5.0"
+  resolved "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz"
+  integrity sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==
+  dependencies:
+    foreground-child "^3.1.0"
+    jackspeak "^3.1.2"
+    minimatch "^9.0.4"
+    minipass "^7.1.2"
+    package-json-from-dist "^1.0.0"
+    path-scurry "^1.11.1"
+
+glob@^7.1.4:
+  version "7.2.3"
+  resolved "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz"
+  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.1.1"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+gopd@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz"
+  integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
+
+graceful-fs@^4.2.11:
+  version "4.2.11"
+  resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz"
+  integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
+
+handlebars@^4.7.8:
+  version "4.7.8"
+  resolved "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz"
+  integrity sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==
+  dependencies:
+    minimist "^1.2.5"
+    neo-async "^2.6.2"
+    source-map "^0.6.1"
+    wordwrap "^1.0.0"
+  optionalDependencies:
+    uglify-js "^3.1.4"
+
 has-flag@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+  resolved "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz"
   integrity sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==
 
-has-proto@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/has-proto/-/has-proto-1.0.1.tgz#1885c1305538958aff469fef37937c22795408e0"
-  integrity sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
-has-symbols@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
-  integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
+has-symbols@^1.0.3, has-symbols@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz"
+  integrity sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==
 
-has@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/has/-/has-1.0.4.tgz#2eb2860e000011dae4f1406a86fe80e530fb2ec6"
-  integrity sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==
-
-http-errors@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.0.tgz#b7774a1486ef73cf7667ac9ae0858c012c57b9d3"
-  integrity sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==
+has-tostringtag@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz"
+  integrity sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==
   dependencies:
-    depd "2.0.0"
-    inherits "2.0.4"
-    setprototypeof "1.2.0"
-    statuses "2.0.1"
-    toidentifier "1.0.1"
+    has-symbols "^1.0.3"
 
-iconv-lite@0.4.24:
+hasown@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz"
+  integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
+  dependencies:
+    function-bind "^1.1.2"
+
+html-escaper@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz"
+  integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
+
+http-errors@~2.0.0, http-errors@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz"
+  integrity sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==
+  dependencies:
+    depd "~2.0.0"
+    inherits "~2.0.4"
+    setprototypeof "~1.2.0"
+    statuses "~2.0.2"
+    toidentifier "~1.0.1"
+
+https-proxy-agent@^7.0.6:
+  version "7.0.6"
+  resolved "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz"
+  integrity sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==
+  dependencies:
+    agent-base "^7.1.2"
+    debug "4"
+
+human-signals@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz"
+  integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
+
+iconv-lite@~0.4.24:
   version "0.4.24"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
+  resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
 ignore-by-default@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
+  resolved "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz"
   integrity sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==
 
-import-in-the-middle@^2.0.0, import-in-the-middle@^2.0.6:
+import-in-the-middle@^2.0.0:
   version "2.0.6"
-  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz#1972337bfe020d05f6b5e020c13334567436324f"
+  resolved "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz"
+  integrity sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==
+  dependencies:
+    acorn "^8.15.0"
+    acorn-import-attributes "^1.9.5"
+    cjs-module-lexer "^2.2.0"
+    module-details-from-path "^1.0.4"
+
+import-in-the-middle@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz"
   integrity sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==
   dependencies:
     acorn "^8.15.0"
@@ -999,7 +2428,7 @@ import-in-the-middle@^2.0.0, import-in-the-middle@^2.0.6:
 
 import-in-the-middle@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-3.0.0.tgz#720c12b4c07ea58b32a54667e70a022e18cc36a3"
+  resolved "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.0.tgz"
   integrity sha512-OnGy+eYT7wVejH2XWgLRgbmzujhhVIATQH0ztIeRilwHBjTeG3pD+XnH3PKX0r9gJ0BuJmJ68q/oh9qgXnNDQg==
   dependencies:
     acorn "^8.15.0"
@@ -1007,48 +2436,528 @@ import-in-the-middle@^3.0.0:
     cjs-module-lexer "^2.2.0"
     module-details-from-path "^1.0.4"
 
-inherits@2.0.4:
+import-local@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz"
+  integrity sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==
+  dependencies:
+    pkg-dir "^4.2.0"
+    resolve-cwd "^3.0.0"
+
+imurmurhash@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
+  integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
+
+inflight@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
+  integrity sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==
+  dependencies:
+    once "^1.3.0"
+    wrappy "1"
+
+inherits@^2.0.3, inherits@~2.0.4, inherits@2:
   version "2.0.4"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-ip@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ip/-/ip-2.0.0.tgz#4cf4ab182fee2314c75ede1276f8c80b479936da"
-  integrity sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==
+ip-address@^10.0.1:
+  version "10.1.0"
+  resolved "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz"
+  integrity sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==
 
 ipaddr.js@1.9.1:
   version "1.9.1"
-  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
+  resolved "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
+
+is-arrayish@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+  integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
 
 is-binary-path@~2.1.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
+  resolved "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz"
   integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
   dependencies:
     binary-extensions "^2.0.0"
 
 is-extglob@^2.1.1:
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
+  resolved "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
   integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
+
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
+
+is-generator-fn@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz"
+  integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
 is-glob@^4.0.1, is-glob@~4.0.1:
   version "4.0.3"
-  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
+  resolved "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
 
 is-number@^7.0.0:
   version "7.0.0"
-  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
+  resolved "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+
+is-stream@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz"
+  integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
+
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
+  integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+
+istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
+  version "3.2.2"
+  resolved "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz"
+  integrity sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==
+
+istanbul-lib-instrument@^6.0.0, istanbul-lib-instrument@^6.0.2:
+  version "6.0.3"
+  resolved "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz"
+  integrity sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==
+  dependencies:
+    "@babel/core" "^7.23.9"
+    "@babel/parser" "^7.23.9"
+    "@istanbuljs/schema" "^0.1.3"
+    istanbul-lib-coverage "^3.2.0"
+    semver "^7.5.4"
+
+istanbul-lib-report@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz"
+  integrity sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==
+  dependencies:
+    istanbul-lib-coverage "^3.0.0"
+    make-dir "^4.0.0"
+    supports-color "^7.1.0"
+
+istanbul-lib-source-maps@^5.0.0:
+  version "5.0.6"
+  resolved "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz"
+  integrity sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.23"
+    debug "^4.1.1"
+    istanbul-lib-coverage "^3.0.0"
+
+istanbul-reports@^3.1.3:
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz"
+  integrity sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==
+  dependencies:
+    html-escaper "^2.0.0"
+    istanbul-lib-report "^3.0.0"
+
+jackspeak@^3.1.2:
+  version "3.4.3"
+  resolved "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz"
+  integrity sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==
+  dependencies:
+    "@isaacs/cliui" "^8.0.2"
+  optionalDependencies:
+    "@pkgjs/parseargs" "^0.11.0"
+
+jest-changed-files@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.3.0.tgz"
+  integrity sha512-B/7Cny6cV5At6M25EWDgf9S617lHivamL8vl6KEpJqkStauzcG4e+WPfDgMMF+H4FVH4A2PLRyvgDJan4441QA==
+  dependencies:
+    execa "^5.1.1"
+    jest-util "30.3.0"
+    p-limit "^3.1.0"
+
+jest-circus@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/jest-circus/-/jest-circus-30.3.0.tgz"
+  integrity sha512-PyXq5szeSfR/4f1lYqCmmQjh0vqDkURUYi9N6whnHjlRz4IUQfMcXkGLeEoiJtxtyPqgUaUUfyQlApXWBSN1RA==
+  dependencies:
+    "@jest/environment" "30.3.0"
+    "@jest/expect" "30.3.0"
+    "@jest/test-result" "30.3.0"
+    "@jest/types" "30.3.0"
+    "@types/node" "*"
+    chalk "^4.1.2"
+    co "^4.6.0"
+    dedent "^1.6.0"
+    is-generator-fn "^2.1.0"
+    jest-each "30.3.0"
+    jest-matcher-utils "30.3.0"
+    jest-message-util "30.3.0"
+    jest-runtime "30.3.0"
+    jest-snapshot "30.3.0"
+    jest-util "30.3.0"
+    p-limit "^3.1.0"
+    pretty-format "30.3.0"
+    pure-rand "^7.0.0"
+    slash "^3.0.0"
+    stack-utils "^2.0.6"
+
+jest-cli@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/jest-cli/-/jest-cli-30.3.0.tgz"
+  integrity sha512-l6Tqx+j1fDXJEW5bqYykDQQ7mQg+9mhWXtnj+tQZrTWYHyHoi6Be8HPumDSA+UiX2/2buEgjA58iJzdj146uCw==
+  dependencies:
+    "@jest/core" "30.3.0"
+    "@jest/test-result" "30.3.0"
+    "@jest/types" "30.3.0"
+    chalk "^4.1.2"
+    exit-x "^0.2.2"
+    import-local "^3.2.0"
+    jest-config "30.3.0"
+    jest-util "30.3.0"
+    jest-validate "30.3.0"
+    yargs "^17.7.2"
+
+jest-config@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/jest-config/-/jest-config-30.3.0.tgz"
+  integrity sha512-WPMAkMAtNDY9P/oKObtsRG/6KTrhtgPJoBTmk20uDn4Uy6/3EJnnaZJre/FMT1KVRx8cve1r7/FlMIOfRVWL4w==
+  dependencies:
+    "@babel/core" "^7.27.4"
+    "@jest/get-type" "30.1.0"
+    "@jest/pattern" "30.0.1"
+    "@jest/test-sequencer" "30.3.0"
+    "@jest/types" "30.3.0"
+    babel-jest "30.3.0"
+    chalk "^4.1.2"
+    ci-info "^4.2.0"
+    deepmerge "^4.3.1"
+    glob "^10.5.0"
+    graceful-fs "^4.2.11"
+    jest-circus "30.3.0"
+    jest-docblock "30.2.0"
+    jest-environment-node "30.3.0"
+    jest-regex-util "30.0.1"
+    jest-resolve "30.3.0"
+    jest-runner "30.3.0"
+    jest-util "30.3.0"
+    jest-validate "30.3.0"
+    parse-json "^5.2.0"
+    pretty-format "30.3.0"
+    slash "^3.0.0"
+    strip-json-comments "^3.1.1"
+
+jest-diff@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz"
+  integrity sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==
+  dependencies:
+    "@jest/diff-sequences" "30.3.0"
+    "@jest/get-type" "30.1.0"
+    chalk "^4.1.2"
+    pretty-format "30.3.0"
+
+jest-docblock@30.2.0:
+  version "30.2.0"
+  resolved "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.2.0.tgz"
+  integrity sha512-tR/FFgZKS1CXluOQzZvNH3+0z9jXr3ldGSD8bhyuxvlVUwbeLOGynkunvlTMxchC5urrKndYiwCFC0DLVjpOCA==
+  dependencies:
+    detect-newline "^3.1.0"
+
+jest-each@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/jest-each/-/jest-each-30.3.0.tgz"
+  integrity sha512-V8eMndg/aZ+3LnCJgSm13IxS5XSBM22QSZc9BtPK8Dek6pm+hfUNfwBdvsB3d342bo1q7wnSkC38zjX259qZNA==
+  dependencies:
+    "@jest/get-type" "30.1.0"
+    "@jest/types" "30.3.0"
+    chalk "^4.1.2"
+    jest-util "30.3.0"
+    pretty-format "30.3.0"
+
+jest-environment-node@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.3.0.tgz"
+  integrity sha512-4i6HItw/JSiJVsC5q0hnKIe/hbYfZLVG9YJ/0pU9Hz2n/9qZe3Rhn5s5CUZA5ORZlcdT/vmAXRMyONXJwPrmYQ==
+  dependencies:
+    "@jest/environment" "30.3.0"
+    "@jest/fake-timers" "30.3.0"
+    "@jest/types" "30.3.0"
+    "@types/node" "*"
+    jest-mock "30.3.0"
+    jest-util "30.3.0"
+    jest-validate "30.3.0"
+
+jest-haste-map@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.3.0.tgz"
+  integrity sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==
+  dependencies:
+    "@jest/types" "30.3.0"
+    "@types/node" "*"
+    anymatch "^3.1.3"
+    fb-watchman "^2.0.2"
+    graceful-fs "^4.2.11"
+    jest-regex-util "30.0.1"
+    jest-util "30.3.0"
+    jest-worker "30.3.0"
+    picomatch "^4.0.3"
+    walker "^1.0.8"
+  optionalDependencies:
+    fsevents "^2.3.3"
+
+jest-leak-detector@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.3.0.tgz"
+  integrity sha512-cuKmUUGIjfXZAiGJ7TbEMx0bcqNdPPI6P1V+7aF+m/FUJqFDxkFR4JqkTu8ZOiU5AaX/x0hZ20KaaIPXQzbMGQ==
+  dependencies:
+    "@jest/get-type" "30.1.0"
+    pretty-format "30.3.0"
+
+jest-matcher-utils@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz"
+  integrity sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==
+  dependencies:
+    "@jest/get-type" "30.1.0"
+    chalk "^4.1.2"
+    jest-diff "30.3.0"
+    pretty-format "30.3.0"
+
+jest-message-util@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz"
+  integrity sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==
+  dependencies:
+    "@babel/code-frame" "^7.27.1"
+    "@jest/types" "30.3.0"
+    "@types/stack-utils" "^2.0.3"
+    chalk "^4.1.2"
+    graceful-fs "^4.2.11"
+    picomatch "^4.0.3"
+    pretty-format "30.3.0"
+    slash "^3.0.0"
+    stack-utils "^2.0.6"
+
+jest-mock@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz"
+  integrity sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==
+  dependencies:
+    "@jest/types" "30.3.0"
+    "@types/node" "*"
+    jest-util "30.3.0"
+
+jest-pnp-resolver@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz"
+  integrity sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==
+
+jest-regex-util@30.0.1:
+  version "30.0.1"
+  resolved "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz"
+  integrity sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==
+
+jest-resolve-dependencies@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.3.0.tgz"
+  integrity sha512-9ev8s3YN6Hsyz9LV75XUwkCVFlwPbaFn6Wp75qnI0wzAINYWY8Fb3+6y59Rwd3QaS3kKXffHXsZMziMavfz/nw==
+  dependencies:
+    jest-regex-util "30.0.1"
+    jest-snapshot "30.3.0"
+
+jest-resolve@*, jest-resolve@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.3.0.tgz"
+  integrity sha512-NRtTAHQlpd15F9rUR36jqwelbrDV/dY4vzNte3S2kxCKUJRYNd5/6nTSbYiak1VX5g8IoFF23Uj5TURkUW8O5g==
+  dependencies:
+    chalk "^4.1.2"
+    graceful-fs "^4.2.11"
+    jest-haste-map "30.3.0"
+    jest-pnp-resolver "^1.2.3"
+    jest-util "30.3.0"
+    jest-validate "30.3.0"
+    slash "^3.0.0"
+    unrs-resolver "^1.7.11"
+
+jest-runner@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/jest-runner/-/jest-runner-30.3.0.tgz"
+  integrity sha512-gDv6C9LGKWDPLia9TSzZwf4h3kMQCqyTpq+95PODnTRDO0g9os48XIYYkS6D236vjpBir2fF63YmJFtqkS5Duw==
+  dependencies:
+    "@jest/console" "30.3.0"
+    "@jest/environment" "30.3.0"
+    "@jest/test-result" "30.3.0"
+    "@jest/transform" "30.3.0"
+    "@jest/types" "30.3.0"
+    "@types/node" "*"
+    chalk "^4.1.2"
+    emittery "^0.13.1"
+    exit-x "^0.2.2"
+    graceful-fs "^4.2.11"
+    jest-docblock "30.2.0"
+    jest-environment-node "30.3.0"
+    jest-haste-map "30.3.0"
+    jest-leak-detector "30.3.0"
+    jest-message-util "30.3.0"
+    jest-resolve "30.3.0"
+    jest-runtime "30.3.0"
+    jest-util "30.3.0"
+    jest-watcher "30.3.0"
+    jest-worker "30.3.0"
+    p-limit "^3.1.0"
+    source-map-support "0.5.13"
+
+jest-runtime@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.3.0.tgz"
+  integrity sha512-CgC+hIBJbuh78HEffkhNKcbXAytQViplcl8xupqeIWyKQF50kCQA8J7GeJCkjisC6hpnC9Muf8jV5RdtdFbGng==
+  dependencies:
+    "@jest/environment" "30.3.0"
+    "@jest/fake-timers" "30.3.0"
+    "@jest/globals" "30.3.0"
+    "@jest/source-map" "30.0.1"
+    "@jest/test-result" "30.3.0"
+    "@jest/transform" "30.3.0"
+    "@jest/types" "30.3.0"
+    "@types/node" "*"
+    chalk "^4.1.2"
+    cjs-module-lexer "^2.1.0"
+    collect-v8-coverage "^1.0.2"
+    glob "^10.5.0"
+    graceful-fs "^4.2.11"
+    jest-haste-map "30.3.0"
+    jest-message-util "30.3.0"
+    jest-mock "30.3.0"
+    jest-regex-util "30.0.1"
+    jest-resolve "30.3.0"
+    jest-snapshot "30.3.0"
+    jest-util "30.3.0"
+    slash "^3.0.0"
+    strip-bom "^4.0.0"
+
+jest-snapshot@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.3.0.tgz"
+  integrity sha512-f14c7atpb4O2DeNhwcvS810Y63wEn8O1HqK/luJ4F6M4NjvxmAKQwBUWjbExUtMxWJQ0wVgmCKymeJK6NZMnfQ==
+  dependencies:
+    "@babel/core" "^7.27.4"
+    "@babel/generator" "^7.27.5"
+    "@babel/plugin-syntax-jsx" "^7.27.1"
+    "@babel/plugin-syntax-typescript" "^7.27.1"
+    "@babel/types" "^7.27.3"
+    "@jest/expect-utils" "30.3.0"
+    "@jest/get-type" "30.1.0"
+    "@jest/snapshot-utils" "30.3.0"
+    "@jest/transform" "30.3.0"
+    "@jest/types" "30.3.0"
+    babel-preset-current-node-syntax "^1.2.0"
+    chalk "^4.1.2"
+    expect "30.3.0"
+    graceful-fs "^4.2.11"
+    jest-diff "30.3.0"
+    jest-matcher-utils "30.3.0"
+    jest-message-util "30.3.0"
+    jest-util "30.3.0"
+    pretty-format "30.3.0"
+    semver "^7.7.2"
+    synckit "^0.11.8"
+
+"jest-util@^29.0.0 || ^30.0.0", jest-util@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz"
+  integrity sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==
+  dependencies:
+    "@jest/types" "30.3.0"
+    "@types/node" "*"
+    chalk "^4.1.2"
+    ci-info "^4.2.0"
+    graceful-fs "^4.2.11"
+    picomatch "^4.0.3"
+
+jest-validate@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/jest-validate/-/jest-validate-30.3.0.tgz"
+  integrity sha512-I/xzC8h5G+SHCb2P2gWkJYrNiTbeL47KvKeW5EzplkyxzBRBw1ssSHlI/jXec0ukH2q7x2zAWQm7015iusg62Q==
+  dependencies:
+    "@jest/get-type" "30.1.0"
+    "@jest/types" "30.3.0"
+    camelcase "^6.3.0"
+    chalk "^4.1.2"
+    leven "^3.1.0"
+    pretty-format "30.3.0"
+
+jest-watcher@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.3.0.tgz"
+  integrity sha512-PJ1d9ThtTR8aMiBWUdcownq9mDdLXsQzJayTk4kmaBRHKvwNQn+ANveuhEBUyNI2hR1TVhvQ8D5kHubbzBHR/w==
+  dependencies:
+    "@jest/test-result" "30.3.0"
+    "@jest/types" "30.3.0"
+    "@types/node" "*"
+    ansi-escapes "^4.3.2"
+    chalk "^4.1.2"
+    emittery "^0.13.1"
+    jest-util "30.3.0"
+    string-length "^4.0.2"
+
+jest-worker@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/jest-worker/-/jest-worker-30.3.0.tgz"
+  integrity sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==
+  dependencies:
+    "@types/node" "*"
+    "@ungap/structured-clone" "^1.3.0"
+    jest-util "30.3.0"
+    merge-stream "^2.0.0"
+    supports-color "^8.1.1"
+
+"jest@^29.0.0 || ^30.0.0", jest@^30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/jest/-/jest-30.3.0.tgz"
+  integrity sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==
+  dependencies:
+    "@jest/core" "30.3.0"
+    "@jest/types" "30.3.0"
+    import-local "^3.2.0"
+    jest-cli "30.3.0"
+
+js-tokens@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
+  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+
+js-yaml@^3.13.1:
+  version "3.14.2"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz"
+  integrity sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
+jsesc@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz"
+  integrity sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==
+
+json-parse-even-better-errors@^2.3.0:
+  version "2.3.1"
+  resolved "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz"
+  integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
+
+json5@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz"
+  integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
 jsonwebtoken@^9.0.2:
   version "9.0.3"
-  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz#6cd57ab01e9b0ac07cb847d53d3c9b6ee31f7ae2"
+  resolved "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz"
   integrity sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==
   dependencies:
     jws "^4.0.1"
@@ -1064,7 +2973,7 @@ jsonwebtoken@^9.0.2:
 
 jwa@^2.0.1:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/jwa/-/jwa-2.0.1.tgz#bf8176d1ad0cd72e0f3f58338595a13e110bc804"
+  resolved "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz"
   integrity sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==
   dependencies:
     buffer-equal-constant-time "^1.0.1"
@@ -1073,7 +2982,7 @@ jwa@^2.0.1:
 
 jws@^4.0.1:
   version "4.0.1"
-  resolved "https://registry.yarnpkg.com/jws/-/jws-4.0.1.tgz#07edc1be8fac20e677b283ece261498bd38f0690"
+  resolved "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz"
   integrity sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==
   dependencies:
     jwa "^2.0.1"
@@ -1081,115 +2990,257 @@ jws@^4.0.1:
 
 kareem@2.5.1:
   version "2.5.1"
-  resolved "https://registry.yarnpkg.com/kareem/-/kareem-2.5.1.tgz#7b8203e11819a8e77a34b3517d3ead206764d15d"
+  resolved "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz"
   integrity sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA==
+
+leven@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz"
+  integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
+
+lines-and-columns@^1.1.6:
+  version "1.2.4"
+  resolved "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz"
+  integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
+
+locate-path@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz"
+  integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
+  dependencies:
+    p-locate "^4.1.0"
 
 lodash.includes@^4.3.0:
   version "4.3.0"
-  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  resolved "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz"
   integrity sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==
 
 lodash.isboolean@^3.0.3:
   version "3.0.3"
-  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  resolved "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz"
   integrity sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==
 
 lodash.isinteger@^4.0.4:
   version "4.0.4"
-  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  resolved "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz"
   integrity sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==
 
 lodash.isnumber@^3.0.3:
   version "3.0.3"
-  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  resolved "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz"
   integrity sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==
 
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
-  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  resolved "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz"
   integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
 
 lodash.isstring@^4.0.1:
   version "4.0.1"
-  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  resolved "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz"
   integrity sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==
+
+lodash.memoize@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz"
+  integrity sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==
 
 lodash.once@^4.0.0:
   version "4.1.1"
-  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  resolved "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz"
   integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
 
 lodash@^4.17.21:
   version "4.17.23"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.23.tgz#f113b0378386103be4f6893388c73d0bde7f2c5a"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz"
   integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==
 
-make-error@^1.1.1:
+lru-cache@^10.2.0:
+  version "10.4.3"
+  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz"
+  integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
+
+lru-cache@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz"
+  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
+  dependencies:
+    yallist "^3.0.2"
+
+make-dir@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz"
+  integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
+  dependencies:
+    semver "^6.0.0"
+
+make-dir@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz"
+  integrity sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==
+  dependencies:
+    semver "^7.5.3"
+
+make-error@^1.1.1, make-error@^1.3.6:
   version "1.3.6"
-  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  resolved "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
+
+makeerror@1.0.12:
+  version "1.0.12"
+  resolved "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz"
+  integrity sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==
+  dependencies:
+    tmpl "1.0.5"
+
+math-intrinsics@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz"
+  integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
 
 media-typer@0.3.0:
   version "0.3.0"
-  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
+  resolved "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
   integrity sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==
 
 memory-pager@^1.0.2:
   version "1.5.0"
-  resolved "https://registry.yarnpkg.com/memory-pager/-/memory-pager-1.5.0.tgz#d8751655d22d384682741c972f2c3d6dfa3e66b5"
+  resolved "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz"
   integrity sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==
 
-merge-descriptors@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
-  integrity sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==
+merge-descriptors@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz"
+  integrity sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==
 
-methods@~1.1.2:
+merge-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz"
+  integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
+
+methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
+  resolved "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
   integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
 
 mime-db@1.52.0:
   version "1.52.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.12, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
   dependencies:
     mime-db "1.52.0"
 
 mime@1.6.0:
   version "1.6.0"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
+  resolved "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
+
+mime@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz"
+  integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
+
+mimic-fn@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz"
+  integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
 minimatch@^10.2.1, minimatch@^10.2.4:
   version "10.2.4"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.4.tgz#465b3accbd0218b8281f5301e27cedc697f96fde"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz"
   integrity sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==
   dependencies:
     brace-expansion "^5.0.2"
 
+minimatch@^3.0.4, minimatch@^3.1.1:
+  version "3.1.5"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz"
+  integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimatch@^9.0.4:
+  version "9.0.9"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz"
+  integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
+  dependencies:
+    brace-expansion "^2.0.2"
+
+minimist@^1.2.5:
+  version "1.2.8"
+  resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
+  version "7.1.3"
+  resolved "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz"
+  integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
+
 module-details-from-path@^1.0.3, module-details-from-path@^1.0.4:
   version "1.0.4"
-  resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.4.tgz#b662fdcd93f6c83d3f25289da0ce81c8d9685b94"
+  resolved "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz"
   integrity sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==
 
 mongodb-connection-string-url@^2.6.0:
   version "2.6.0"
-  resolved "https://registry.yarnpkg.com/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz#57901bf352372abdde812c81be47b75c6b2ec5cf"
+  resolved "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz"
   integrity sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==
   dependencies:
     "@types/whatwg-url" "^8.2.1"
     whatwg-url "^11.0.0"
 
-mongodb@5.9.0:
-  version "5.9.0"
-  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-5.9.0.tgz#5a22065fa8cfaf1d58bf2e3c451cd2c4bfa983a2"
-  integrity sha512-g+GCMHN1CoRUA+wb1Agv0TI4YTSiWr42B5ulkiAfLLHitGK1R+PkSAf3Lr5rPZwi/3F04LiaZEW0Kxro9Fi2TA==
+mongodb-connection-string-url@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.1.tgz"
+  integrity sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==
+  dependencies:
+    "@types/whatwg-url" "^13.0.0"
+    whatwg-url "^14.1.0"
+
+mongodb-memory-server-core@11.0.1:
+  version "11.0.1"
+  resolved "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-11.0.1.tgz"
+  integrity sha512-IcIb2S9Xf7Lmz43Z1ZujMqNg7PU5Q7yn+4wOnu7l6pfeGPkEmlqzV1hIbroVx8s4vXhPB1oMGC1u8clW7aj3Xw==
+  dependencies:
+    async-mutex "^0.5.0"
+    camelcase "^6.3.0"
+    debug "^4.4.3"
+    find-cache-dir "^3.3.2"
+    follow-redirects "^1.15.11"
+    https-proxy-agent "^7.0.6"
+    mongodb "^7.0.0"
+    new-find-package-json "^2.0.0"
+    semver "^7.7.3"
+    tar-stream "^3.1.7"
+    tslib "^2.8.1"
+    yauzl "^3.2.0"
+
+mongodb-memory-server@^11.0.1:
+  version "11.0.1"
+  resolved "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-11.0.1.tgz"
+  integrity sha512-nUlKovSJZBh7q5hPsewFRam9H66D08Ne18nyknkNalfXMPtK1Og3kOcuqQhcX88x/pghSZPIJHrLbxNFW3OWiw==
+  dependencies:
+    mongodb-memory-server-core "11.0.1"
+    tslib "^2.8.1"
+
+mongodb@^7.0.0:
+  version "7.1.1"
+  resolved "https://registry.npmjs.org/mongodb/-/mongodb-7.1.1.tgz"
+  integrity sha512-067DXiMjcpYQl6bGjWQoTUEE9UoRViTtKFcoqX7z08I+iDZv/emH1g8XEFiO3qiDfXAheT5ozl1VffDTKhIW/w==
+  dependencies:
+    "@mongodb-js/saslprep" "^1.3.0"
+    bson "^7.1.1"
+    mongodb-connection-string-url "^7.0.0"
+
+mongodb@5.9.2:
+  version "5.9.2"
+  resolved "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz"
+  integrity sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ==
   dependencies:
     bson "^5.5.0"
     mongodb-connection-string-url "^2.6.0"
@@ -1198,13 +3249,13 @@ mongodb@5.9.0:
     "@mongodb-js/saslprep" "^1.1.0"
 
 mongoose@^7.6.3:
-  version "7.6.3"
-  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-7.6.3.tgz#b06507dd164ad4426013eeb266d54aa1e5178092"
-  integrity sha512-moYP2qWCOdWRDeBxqB/zYwQmQnTBsF5DoolX5uPyI218BkiA1ujGY27P0NTd4oWIX+LLkZPw0LDzlc/7oh1plg==
+  version "7.8.9"
+  resolved "https://registry.npmjs.org/mongoose/-/mongoose-7.8.9.tgz"
+  integrity sha512-V3GBAJbmOAdzEP8murOvlg7q1szlbe4jTBRyW+JBHRduJBe7F9dk5eyqJDTuYrdBcOOWfLbr6AgXrDK7F0/o5A==
   dependencies:
     bson "^5.5.0"
     kareem "2.5.1"
-    mongodb "5.9.0"
+    mongodb "5.9.2"
     mpath "0.9.0"
     mquery "5.0.0"
     ms "2.1.3"
@@ -1212,39 +3263,81 @@ mongoose@^7.6.3:
 
 mpath@0.9.0:
   version "0.9.0"
-  resolved "https://registry.yarnpkg.com/mpath/-/mpath-0.9.0.tgz#0c122fe107846e31fc58c75b09c35514b3871904"
+  resolved "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz"
   integrity sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==
 
 mquery@5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/mquery/-/mquery-5.0.0.tgz#a95be5dfc610b23862df34a47d3e5d60e110695d"
+  resolved "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz"
   integrity sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==
   dependencies:
     debug "4.x"
 
+ms@^2.1.1, ms@^2.1.3, ms@2.1.3:
+  version "2.1.3"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
 ms@2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
   integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
 
 ms@2.1.2:
   version "2.1.2"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3, ms@^2.1.1, ms@^2.1.3:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
-  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+multer@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz"
+  integrity sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==
+  dependencies:
+    append-field "^1.0.0"
+    busboy "^1.6.0"
+    concat-stream "^2.0.0"
+    type-is "^1.6.18"
+
+napi-postinstall@^0.3.0:
+  version "0.3.4"
+  resolved "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz"
+  integrity sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==
+
+natural-compare@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
+  integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
 negotiator@0.6.3:
   version "0.6.3"
-  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
+  resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
+
+neo-async@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz"
+  integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
+
+new-find-package-json@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/new-find-package-json/-/new-find-package-json-2.0.0.tgz"
+  integrity sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==
+  dependencies:
+    debug "^4.3.4"
+
+node-int64@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz"
+  integrity sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==
+
+node-releases@^2.0.27:
+  version "2.0.36"
+  resolved "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz"
+  integrity sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==
 
 nodemon@^3.0.1:
   version "3.1.14"
-  resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-3.1.14.tgz#8487ca379c515301d221ec007f27f24ecafa2b51"
+  resolved "https://registry.npmjs.org/nodemon/-/nodemon-3.1.14.tgz"
   integrity sha512-jakjZi93UtB3jHMWsXL68FXSAosbLfY0In5gtKq3niLSkrWznrVBzXFNOEMJUfc9+Ke7SHWoAZsiMkNP3vq6Jw==
   dependencies:
     chokidar "^3.5.2"
@@ -1260,49 +3353,139 @@ nodemon@^3.0.1:
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
+  resolved "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
+
+npm-run-path@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz"
+  integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
+  dependencies:
+    path-key "^3.0.0"
 
 object-assign@^4:
   version "4.1.1"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
 
-object-inspect@^1.9.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.0.tgz#42695d3879e1cd5bda6df5062164d80c996e23e2"
-  integrity sha512-HQ4J+ic8hKrgIt3mqk6cVOVrW2ozL4KdvHlqpBv9vDYWx9ysAgENAdvy4FoGF+KFdhR7nQTNm5J0ctAeOwn+3g==
+object-inspect@^1.13.3:
+  version "1.13.4"
+  resolved "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz"
+  integrity sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==
 
-on-finished@2.4.1:
+on-finished@~2.4.1:
   version "2.4.1"
-  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f"
+  resolved "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz"
   integrity sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==
   dependencies:
     ee-first "1.1.1"
 
+once@^1.3.0, once@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+  integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
+  dependencies:
+    wrappy "1"
+
+onetime@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz"
+  integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
+  dependencies:
+    mimic-fn "^2.1.0"
+
+p-limit@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz"
+  integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
+  dependencies:
+    p-try "^2.0.0"
+
+p-limit@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz"
+  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
+  dependencies:
+    yocto-queue "^0.1.0"
+
+p-locate@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz"
+  integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
+  dependencies:
+    p-limit "^2.2.0"
+
+p-try@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz"
+  integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
+
+package-json-from-dist@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz"
+  integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
+
+parse-json@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz"
+  integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    error-ex "^1.3.1"
+    json-parse-even-better-errors "^2.3.0"
+    lines-and-columns "^1.1.6"
+
 parseurl@~1.3.3:
   version "1.3.3"
-  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
+  resolved "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
 
-path-to-regexp@0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
-  integrity sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==
+path-exists@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz"
+  integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
+
+path-is-absolute@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+  integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
+
+path-key@^3.0.0, path-key@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz"
+  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+
+path-scurry@^1.11.1:
+  version "1.11.1"
+  resolved "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz"
+  integrity sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==
+  dependencies:
+    lru-cache "^10.2.0"
+    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
+
+path-to-regexp@~0.1.12:
+  version "0.1.12"
+  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz"
+  integrity sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==
+
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
+  integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
 
 pg-int8@1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
+  resolved "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz"
   integrity sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==
 
 pg-protocol@*:
   version "1.13.0"
-  resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.13.0.tgz#fdaf6d020bca590d58bb991b4b16fc448efe0511"
+  resolved "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz"
   integrity sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==
 
 pg-types@^2.2.0:
   version "2.2.0"
-  resolved "https://registry.yarnpkg.com/pg-types/-/pg-types-2.2.0.tgz#2d0250d636454f7cfa3b6ae0382fdfa8063254a3"
+  resolved "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz"
   integrity sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==
   dependencies:
     pg-int8 "1.0.1"
@@ -1311,36 +3494,72 @@ pg-types@^2.2.0:
     postgres-date "~1.0.4"
     postgres-interval "^1.1.0"
 
-picomatch@^2.0.4, picomatch@^2.2.1:
+picocolors@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
+  integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
+
+picomatch@^2.0.4:
   version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+picomatch@^2.2.1:
+  version "2.3.1"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
+  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+picomatch@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz"
+  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
+
+pirates@^4.0.7:
+  version "4.0.7"
+  resolved "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz"
+  integrity sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==
+
+pkg-dir@^4.1.0, pkg-dir@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz"
+  integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
+  dependencies:
+    find-up "^4.0.0"
 
 postgres-array@~2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/postgres-array/-/postgres-array-2.0.0.tgz#48f8fce054fbc69671999329b8834b772652d82e"
+  resolved "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz"
   integrity sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==
 
 postgres-bytea@~1.0.0:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/postgres-bytea/-/postgres-bytea-1.0.1.tgz#c40b3da0222c500ff1e51c5d7014b60b79697c7a"
+  resolved "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz"
   integrity sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==
 
 postgres-date@~1.0.4:
   version "1.0.7"
-  resolved "https://registry.yarnpkg.com/postgres-date/-/postgres-date-1.0.7.tgz#51bc086006005e5061c591cee727f2531bf641a8"
+  resolved "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz"
   integrity sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==
 
 postgres-interval@^1.1.0:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/postgres-interval/-/postgres-interval-1.2.0.tgz#b460c82cb1587507788819a06aa0fffdb3544695"
+  resolved "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz"
   integrity sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==
   dependencies:
     xtend "^4.0.0"
 
+pretty-format@^30.0.0, pretty-format@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz"
+  integrity sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==
+  dependencies:
+    "@jest/schemas" "30.0.5"
+    ansi-styles "^5.2.0"
+    react-is "^18.3.1"
+
 proxy-addr@~2.0.7:
   version "2.0.7"
-  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
+  resolved "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz"
   integrity sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==
   dependencies:
     forwarded "0.2.0"
@@ -1348,180 +3567,522 @@ proxy-addr@~2.0.7:
 
 pstree.remy@^1.1.8:
   version "1.1.8"
-  resolved "https://registry.yarnpkg.com/pstree.remy/-/pstree.remy-1.1.8.tgz#c242224f4a67c21f686839bbdb4ac282b8373d3a"
+  resolved "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz"
   integrity sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==
 
-punycode@^2.1.1:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
-  integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==
+punycode@^2.1.1, punycode@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz"
+  integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
-qs@6.11.0:
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
-  integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
+pure-rand@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz"
+  integrity sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==
+
+qs@^6.14.1:
+  version "6.15.0"
+  resolved "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz"
+  integrity sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==
   dependencies:
-    side-channel "^1.0.4"
+    side-channel "^1.1.0"
+
+qs@~6.14.0:
+  version "6.14.2"
+  resolved "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz"
+  integrity sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==
+  dependencies:
+    side-channel "^1.1.0"
 
 range-parser@~1.2.1:
   version "1.2.1"
-  resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
+  resolved "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
 
-raw-body@2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.5.1.tgz#fe1b1628b181b700215e5fd42389f98b71392857"
-  integrity sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==
+raw-body@~2.5.3:
+  version "2.5.3"
+  resolved "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz"
+  integrity sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==
   dependencies:
-    bytes "3.1.2"
-    http-errors "2.0.0"
-    iconv-lite "0.4.24"
-    unpipe "1.0.0"
+    bytes "~3.1.2"
+    http-errors "~2.0.1"
+    iconv-lite "~0.4.24"
+    unpipe "~1.0.0"
+
+react-is@^18.3.1:
+  version "18.3.1"
+  resolved "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz"
+  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
+
+readable-stream@^3.0.2:
+  version "3.6.2"
+  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz"
+  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
 
 readdirp@~3.6.0:
   version "3.6.0"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
+  resolved "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz"
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
 
+require-directory@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
+  integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
+
 require-in-the-middle@^8.0.0:
   version "8.0.1"
-  resolved "https://registry.yarnpkg.com/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz#dbde2587f669398626d56b20c868ab87bf01cce4"
+  resolved "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz"
   integrity sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==
   dependencies:
     debug "^4.3.5"
     module-details-from-path "^1.0.3"
 
-safe-buffer@5.2.1, safe-buffer@^5.0.1:
+resolve-cwd@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz"
+  integrity sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==
+  dependencies:
+    resolve-from "^5.0.0"
+
+resolve-from@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz"
+  integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
+
+safe-buffer@^5.0.1, safe-buffer@~5.2.0, safe-buffer@5.2.1:
   version "5.2.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 "safer-buffer@>= 2.1.2 < 3":
   version "2.1.2"
-  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-semver@^7.5.3, semver@^7.5.4:
+semver@^6.0.0:
+  version "6.3.1"
+  resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
+  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+semver@^6.3.1:
+  version "6.3.1"
+  resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
+  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+semver@^7.5.3, semver@^7.5.4, semver@^7.7.2, semver@^7.7.3:
   version "7.7.4"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz"
   integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
 
-send@0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/send/-/send-0.18.0.tgz#670167cc654b05f5aa4a767f9113bb371bc706be"
-  integrity sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==
+send@~0.19.0, send@~0.19.1:
+  version "0.19.2"
+  resolved "https://registry.npmjs.org/send/-/send-0.19.2.tgz"
+  integrity sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==
   dependencies:
     debug "2.6.9"
     depd "2.0.0"
     destroy "1.2.0"
-    encodeurl "~1.0.2"
+    encodeurl "~2.0.0"
     escape-html "~1.0.3"
     etag "~1.8.1"
-    fresh "0.5.2"
-    http-errors "2.0.0"
+    fresh "~0.5.2"
+    http-errors "~2.0.1"
     mime "1.6.0"
     ms "2.1.3"
-    on-finished "2.4.1"
+    on-finished "~2.4.1"
     range-parser "~1.2.1"
-    statuses "2.0.1"
+    statuses "~2.0.2"
 
-serve-static@1.15.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.15.0.tgz#faaef08cffe0a1a62f60cad0c4e513cff0ac9540"
-  integrity sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==
+serve-static@~1.16.2:
+  version "1.16.3"
+  resolved "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz"
+  integrity sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==
   dependencies:
-    encodeurl "~1.0.2"
+    encodeurl "~2.0.0"
     escape-html "~1.0.3"
     parseurl "~1.3.3"
-    send "0.18.0"
+    send "~0.19.1"
 
-setprototypeof@1.2.0:
+setprototypeof@~1.2.0, setprototypeof@1.2.0:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
+  resolved "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-side-channel@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
-  integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
+shebang-command@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
   dependencies:
-    call-bind "^1.0.0"
-    get-intrinsic "^1.0.2"
-    object-inspect "^1.9.0"
+    shebang-regex "^3.0.0"
+
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+
+side-channel-list@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz"
+  integrity sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==
+  dependencies:
+    es-errors "^1.3.0"
+    object-inspect "^1.13.3"
+
+side-channel-map@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz"
+  integrity sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==
+  dependencies:
+    call-bound "^1.0.2"
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.5"
+    object-inspect "^1.13.3"
+
+side-channel-weakmap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz"
+  integrity sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==
+  dependencies:
+    call-bound "^1.0.2"
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.5"
+    object-inspect "^1.13.3"
+    side-channel-map "^1.0.1"
+
+side-channel@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz"
+  integrity sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==
+  dependencies:
+    es-errors "^1.3.0"
+    object-inspect "^1.13.3"
+    side-channel-list "^1.0.0"
+    side-channel-map "^1.0.1"
+    side-channel-weakmap "^1.0.2"
 
 sift@16.0.1:
   version "16.0.1"
-  resolved "https://registry.yarnpkg.com/sift/-/sift-16.0.1.tgz#e9c2ccc72191585008cf3e36fc447b2d2633a053"
+  resolved "https://registry.npmjs.org/sift/-/sift-16.0.1.tgz"
   integrity sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ==
+
+signal-exit@^3.0.3:
+  version "3.0.7"
+  resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz"
+  integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
+
+signal-exit@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
 simple-update-notifier@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz#d70b92bdab7d6d90dfd73931195a30b6e3d7cebb"
+  resolved "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz"
   integrity sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==
   dependencies:
     semver "^7.5.3"
 
+slash@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz"
+  integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+
 smart-buffer@^4.2.0:
   version "4.2.0"
-  resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
+  resolved "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz"
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
 
-socks@^2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/socks/-/socks-2.7.1.tgz#d8e651247178fde79c0663043e07240196857d55"
-  integrity sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==
+socks@^2.7.1, socks@^2.8.6:
+  version "2.8.7"
+  resolved "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz"
+  integrity sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==
   dependencies:
-    ip "^2.0.0"
+    ip-address "^10.0.1"
     smart-buffer "^4.2.0"
+
+source-map-support@0.5.13:
+  version "0.5.13"
+  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz"
+  integrity sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map@^0.6.0, source-map@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 sparse-bitfield@^3.0.3:
   version "3.0.3"
-  resolved "https://registry.yarnpkg.com/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz#ff4ae6e68656056ba4b3e792ab3334d38273ca11"
+  resolved "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz"
   integrity sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==
   dependencies:
     memory-pager "^1.0.2"
 
-statuses@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
-  integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
+sprintf-js@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+  integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
+
+stack-utils@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz"
+  integrity sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==
+  dependencies:
+    escape-string-regexp "^2.0.0"
+
+statuses@~2.0.1, statuses@~2.0.2:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz"
+  integrity sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==
+
+streamsearch@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz"
+  integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
+
+streamx@^2.12.5, streamx@^2.15.0, streamx@^2.25.0:
+  version "2.25.0"
+  resolved "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz"
+  integrity sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==
+  dependencies:
+    events-universal "^1.0.0"
+    fast-fifo "^1.3.2"
+    text-decoder "^1.1.0"
+
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
+
+string-length@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz"
+  integrity sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==
+  dependencies:
+    char-regex "^1.0.2"
+    strip-ansi "^6.0.0"
+
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^5.0.1, string-width@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz"
+  integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
+  dependencies:
+    eastasianwidth "^0.2.0"
+    emoji-regex "^9.2.2"
+    strip-ansi "^7.0.1"
+
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^7.0.1:
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz"
+  integrity sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==
+  dependencies:
+    ansi-regex "^6.2.2"
+
+strip-bom@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz"
+  integrity sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==
+
+strip-final-newline@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz"
+  integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
+
+strip-json-comments@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz"
+  integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+superagent@^10.3.0:
+  version "10.3.0"
+  resolved "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz"
+  integrity sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==
+  dependencies:
+    component-emitter "^1.3.1"
+    cookiejar "^2.1.4"
+    debug "^4.3.7"
+    fast-safe-stringify "^2.1.1"
+    form-data "^4.0.5"
+    formidable "^3.5.4"
+    methods "^1.1.2"
+    mime "2.6.0"
+    qs "^6.14.1"
+
+supertest@^7.2.2:
+  version "7.2.2"
+  resolved "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz"
+  integrity sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==
+  dependencies:
+    cookie-signature "^1.2.2"
+    methods "^1.1.2"
+    superagent "^10.3.0"
 
 supports-color@^5.5.0:
   version "5.5.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
 
+supports-color@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
+
+supports-color@^8.1.1:
+  version "8.1.1"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz"
+  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
+  dependencies:
+    has-flag "^4.0.0"
+
+synckit@^0.11.8:
+  version "0.11.12"
+  resolved "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz"
+  integrity sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==
+  dependencies:
+    "@pkgr/core" "^0.2.9"
+
+tar-stream@^3.1.7:
+  version "3.1.8"
+  resolved "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz"
+  integrity sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==
+  dependencies:
+    b4a "^1.6.4"
+    bare-fs "^4.5.5"
+    fast-fifo "^1.2.0"
+    streamx "^2.15.0"
+
+teex@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz"
+  integrity sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==
+  dependencies:
+    streamx "^2.12.5"
+
+test-exclude@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz"
+  integrity sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==
+  dependencies:
+    "@istanbuljs/schema" "^0.1.2"
+    glob "^7.1.4"
+    minimatch "^3.0.4"
+
+text-decoder@^1.1.0:
+  version "1.2.7"
+  resolved "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz"
+  integrity sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==
+  dependencies:
+    b4a "^1.6.4"
+
+tmpl@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz"
+  integrity sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==
+
 to-regex-range@^5.0.1:
   version "5.0.1"
-  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
+  resolved "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz"
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
 
-toidentifier@1.0.1:
+toidentifier@~1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
+  resolved "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
 touch@^3.1.0:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/touch/-/touch-3.1.1.tgz#097a23d7b161476435e5c1344a95c0f75b4a5694"
+  resolved "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz"
   integrity sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==
 
 tr46@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-3.0.0.tgz#555c4e297a950617e8eeddef633c87d4d9d6cbf9"
+  resolved "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz"
   integrity sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==
   dependencies:
     punycode "^2.1.1"
 
-ts-node@^10.9.1:
+tr46@^5.1.0:
+  version "5.1.1"
+  resolved "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz"
+  integrity sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==
+  dependencies:
+    punycode "^2.3.1"
+
+ts-jest@^29.4.6:
+  version "29.4.6"
+  resolved "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz"
+  integrity sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==
+  dependencies:
+    bs-logger "^0.2.6"
+    fast-json-stable-stringify "^2.1.0"
+    handlebars "^4.7.8"
+    json5 "^2.2.3"
+    lodash.memoize "^4.1.2"
+    make-error "^1.3.6"
+    semver "^7.7.3"
+    type-fest "^4.41.0"
+    yargs-parser "^21.1.1"
+
+ts-node@^10.9.1, ts-node@>=9.0.0:
   version "10.9.1"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
+  resolved "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz"
   integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
   dependencies:
     "@cspotcode/source-map-support" "^0.8.0"
@@ -1538,73 +4099,260 @@ ts-node@^10.9.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-type-is@~1.6.18:
+tslib@^2.4.0, tslib@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
+
+type-detect@4.0.8:
+  version "4.0.8"
+  resolved "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
+
+type-fest@^0.21.3:
+  version "0.21.3"
+  resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz"
+  integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
+
+type-fest@^4.41.0:
+  version "4.41.0"
+  resolved "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz"
+  integrity sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==
+
+type-is@^1.6.18, type-is@~1.6.18:
   version "1.6.18"
-  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
+  resolved "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz"
   integrity sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@^5.2.2:
+typedarray@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+  integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
+
+typescript@^5.2.2, typescript@>=2.7, "typescript@>=4.3 <6":
   version "5.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz"
   integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
+
+uglify-js@^3.1.4:
+  version "3.19.3"
+  resolved "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz"
+  integrity sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==
 
 undefsafe@^2.0.5:
   version "2.0.5"
-  resolved "https://registry.yarnpkg.com/undefsafe/-/undefsafe-2.0.5.tgz#38733b9327bdcd226db889fb723a6efd162e6e2c"
+  resolved "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz"
   integrity sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==
 
 undici-types@~5.25.1:
   version "5.25.3"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.25.3.tgz#e044115914c85f0bcbb229f346ab739f064998c3"
+  resolved "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz"
   integrity sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==
 
-unpipe@1.0.0, unpipe@~1.0.0:
+unpipe@~1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
+  resolved "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
   integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
+
+unrs-resolver@^1.7.11:
+  version "1.11.1"
+  resolved "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz"
+  integrity sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==
+  dependencies:
+    napi-postinstall "^0.3.0"
+  optionalDependencies:
+    "@unrs/resolver-binding-android-arm-eabi" "1.11.1"
+    "@unrs/resolver-binding-android-arm64" "1.11.1"
+    "@unrs/resolver-binding-darwin-arm64" "1.11.1"
+    "@unrs/resolver-binding-darwin-x64" "1.11.1"
+    "@unrs/resolver-binding-freebsd-x64" "1.11.1"
+    "@unrs/resolver-binding-linux-arm-gnueabihf" "1.11.1"
+    "@unrs/resolver-binding-linux-arm-musleabihf" "1.11.1"
+    "@unrs/resolver-binding-linux-arm64-gnu" "1.11.1"
+    "@unrs/resolver-binding-linux-arm64-musl" "1.11.1"
+    "@unrs/resolver-binding-linux-ppc64-gnu" "1.11.1"
+    "@unrs/resolver-binding-linux-riscv64-gnu" "1.11.1"
+    "@unrs/resolver-binding-linux-riscv64-musl" "1.11.1"
+    "@unrs/resolver-binding-linux-s390x-gnu" "1.11.1"
+    "@unrs/resolver-binding-linux-x64-gnu" "1.11.1"
+    "@unrs/resolver-binding-linux-x64-musl" "1.11.1"
+    "@unrs/resolver-binding-wasm32-wasi" "1.11.1"
+    "@unrs/resolver-binding-win32-arm64-msvc" "1.11.1"
+    "@unrs/resolver-binding-win32-ia32-msvc" "1.11.1"
+    "@unrs/resolver-binding-win32-x64-msvc" "1.11.1"
+
+update-browserslist-db@^1.2.0:
+  version "1.2.3"
+  resolved "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz"
+  integrity sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==
+  dependencies:
+    escalade "^3.2.0"
+    picocolors "^1.1.1"
+
+util-deprecate@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+  integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
 utils-merge@1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
+  resolved "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  resolved "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz"
   integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
+
+v8-to-istanbul@^9.0.1:
+  version "9.3.0"
+  resolved "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz"
+  integrity sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.12"
+    "@types/istanbul-lib-coverage" "^2.0.1"
+    convert-source-map "^2.0.0"
 
 validator@~13.15.23:
   version "13.15.26"
-  resolved "https://registry.yarnpkg.com/validator/-/validator-13.15.26.tgz#36c3deeab30e97806a658728a155c66fcaa5b944"
+  resolved "https://registry.npmjs.org/validator/-/validator-13.15.26.tgz"
   integrity sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==
 
 vary@^1, vary@~1.1.2:
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
+  resolved "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
+
+walker@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz"
+  integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
+  dependencies:
+    makeerror "1.0.12"
 
 webidl-conversions@^7.0.0:
   version "7.0.0"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
+  resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz"
   integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
 
 whatwg-url@^11.0.0:
   version "11.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-11.0.0.tgz#0a849eebb5faf2119b901bb76fd795c2848d4018"
+  resolved "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz"
   integrity sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==
   dependencies:
     tr46 "^3.0.0"
     webidl-conversions "^7.0.0"
 
+whatwg-url@^14.1.0:
+  version "14.2.0"
+  resolved "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz"
+  integrity sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==
+  dependencies:
+    tr46 "^5.1.0"
+    webidl-conversions "^7.0.0"
+
+which@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/which/-/which-2.0.2.tgz"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
+  dependencies:
+    isexe "^2.0.0"
+
+wordwrap@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+  integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
+
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz"
+  integrity sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==
+  dependencies:
+    ansi-styles "^6.1.0"
+    string-width "^5.0.1"
+    strip-ansi "^7.0.1"
+
+wrappy@1:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+  integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
+write-file-atomic@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz"
+  integrity sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==
+  dependencies:
+    imurmurhash "^0.1.4"
+    signal-exit "^4.0.1"
+
 xtend@^4.0.0:
   version "4.0.2"
-  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
+  resolved "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
+
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+yallist@^3.0.2:
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz"
+  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yargs-parser@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
+yargs@^17.7.2:
+  version "17.7.2"
+  resolved "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
+
+yauzl@^3.2.0:
+  version "3.2.1"
+  resolved "https://registry.npmjs.org/yauzl/-/yauzl-3.2.1.tgz"
+  integrity sha512-k1isifdbpNSFEHFJ1ZY4YDewv0IH9FR61lDetaRMD3j2ae3bIXGV+7c+LHCqtQGofSd8PIyV4X6+dHMAnSr60A==
+  dependencies:
+    buffer-crc32 "~0.2.3"
+    pend "~1.2.0"
 
 yn@3.1.1:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  resolved "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
+
+yocto-queue@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
+  integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,7 +23,7 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz"
   integrity sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==
 
-"@babel/core@^7.0.0", "@babel/core@^7.0.0 || ^8.0.0-0", "@babel/core@^7.0.0-0", "@babel/core@^7.11.0 || ^8.0.0-0", "@babel/core@^7.11.0 || ^8.0.0-beta.1", "@babel/core@^7.23.9", "@babel/core@^7.27.4", "@babel/core@>=7.0.0-beta.0 <8":
+"@babel/core@^7.23.9", "@babel/core@^7.27.4":
   version "7.29.0"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz"
   integrity sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==
@@ -289,6 +289,28 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
+"@emnapi/core@^1.4.3":
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.9.2.tgz#3870265ecffc7352d01ead62d8d83d8358a2d034"
+  integrity sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==
+  dependencies:
+    "@emnapi/wasi-threads" "1.2.1"
+    tslib "^2.4.0"
+
+"@emnapi/runtime@^1.4.3":
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.9.2.tgz#8b469a3db160817cadb1de9050211a9d1ea84fa2"
+  integrity sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==
+  dependencies:
+    tslib "^2.4.0"
+
+"@emnapi/wasi-threads@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz#28fed21a1ba1ce797c44a070abc94d42f3ae8548"
+  integrity sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==
+  dependencies:
+    tslib "^2.4.0"
+
 "@fastify/otel@0.17.1":
   version "0.17.1"
   resolved "https://registry.npmjs.org/@fastify/otel/-/otel-0.17.1.tgz"
@@ -512,7 +534,7 @@
     jest-haste-map "30.3.0"
     slash "^3.0.0"
 
-"@jest/transform@^29.0.0 || ^30.0.0", "@jest/transform@30.3.0":
+"@jest/transform@30.3.0":
   version "30.3.0"
   resolved "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz"
   integrity sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==
@@ -532,7 +554,7 @@
     slash "^3.0.0"
     write-file-atomic "^5.0.1"
 
-"@jest/types@^29.0.0 || ^30.0.0", "@jest/types@30.3.0":
+"@jest/types@30.3.0":
   version "30.3.0"
   resolved "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz"
   integrity sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==
@@ -571,14 +593,6 @@
   resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
 
-"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.23", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25", "@jridgewell/trace-mapping@^0.3.28":
-  version "0.3.31"
-  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz"
-  integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
-  dependencies:
-    "@jridgewell/resolve-uri" "^3.1.0"
-    "@jridgewell/sourcemap-codec" "^1.4.14"
-
 "@jridgewell/trace-mapping@0.3.9":
   version "0.3.9"
   resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz"
@@ -587,12 +601,29 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.23", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25", "@jridgewell/trace-mapping@^0.3.28":
+  version "0.3.31"
+  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz"
+  integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
+
 "@mongodb-js/saslprep@^1.1.0", "@mongodb-js/saslprep@^1.3.0":
   version "1.4.6"
   resolved "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.6.tgz"
   integrity sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==
   dependencies:
     sparse-bitfield "^3.0.3"
+
+"@napi-rs/wasm-runtime@^0.2.11":
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz#3e78a8b96e6c33a6c517e1894efbd5385a7cb6f2"
+  integrity sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==
+  dependencies:
+    "@emnapi/core" "^1.4.3"
+    "@emnapi/runtime" "^1.4.3"
+    "@tybys/wasm-util" "^0.10.0"
 
 "@noble/ciphers@^1.0.0":
   version "1.3.0"
@@ -625,17 +656,17 @@
   dependencies:
     "@opentelemetry/api" "^1.3.0"
 
-"@opentelemetry/api@^1.1.0", "@opentelemetry/api@^1.3.0", "@opentelemetry/api@^1.7.0", "@opentelemetry/api@^1.8", "@opentelemetry/api@^1.9.0", "@opentelemetry/api@>=1.0.0 <1.10.0", "@opentelemetry/api@>=1.3.0 <1.10.0":
+"@opentelemetry/api@^1.3.0", "@opentelemetry/api@^1.9.0":
   version "1.9.0"
   resolved "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz"
   integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
 
-"@opentelemetry/context-async-hooks@^1.30.1 || ^2.1.0", "@opentelemetry/context-async-hooks@^2.6.0":
+"@opentelemetry/context-async-hooks@^2.6.0":
   version "2.6.0"
   resolved "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.0.tgz"
   integrity sha512-L8UyDwqpTcbkIK5cgwDRDYDoEhQoj8wp8BwsO19w3LB1Z41yEQm2VJyNfAi9DrLP/YTqXqWpKHyZfR9/tFYo1Q==
 
-"@opentelemetry/core@^1.30.1 || ^2.1.0", "@opentelemetry/core@^2.0.0", "@opentelemetry/core@^2.6.0", "@opentelemetry/core@2.6.0":
+"@opentelemetry/core@2.6.0", "@opentelemetry/core@^2.0.0", "@opentelemetry/core@^2.6.0":
   version "2.6.0"
   resolved "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.0.tgz"
   integrity sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==
@@ -776,15 +807,6 @@
     "@opentelemetry/instrumentation" "^0.213.0"
     "@opentelemetry/semantic-conventions" "^1.33.0"
 
-"@opentelemetry/instrumentation-mysql@0.59.0":
-  version "0.59.0"
-  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.59.0.tgz"
-  integrity sha512-r+V/Fh0sm7Ga8/zk/TI5H5FQRAjwr0RrpfPf8kNIehlsKf12XnvIaZi8ViZkpX0gyPEpLXqzqWD6QHlgObgzZw==
-  dependencies:
-    "@opentelemetry/instrumentation" "^0.213.0"
-    "@opentelemetry/semantic-conventions" "^1.33.0"
-    "@types/mysql" "2.15.27"
-
 "@opentelemetry/instrumentation-mysql2@0.59.0":
   version "0.59.0"
   resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.59.0.tgz"
@@ -793,6 +815,15 @@
     "@opentelemetry/instrumentation" "^0.213.0"
     "@opentelemetry/semantic-conventions" "^1.33.0"
     "@opentelemetry/sql-common" "^0.41.2"
+
+"@opentelemetry/instrumentation-mysql@0.59.0":
+  version "0.59.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.59.0.tgz"
+  integrity sha512-r+V/Fh0sm7Ga8/zk/TI5H5FQRAjwr0RrpfPf8kNIehlsKf12XnvIaZi8ViZkpX0gyPEpLXqzqWD6QHlgObgzZw==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.213.0"
+    "@opentelemetry/semantic-conventions" "^1.33.0"
+    "@types/mysql" "2.15.27"
 
 "@opentelemetry/instrumentation-pg@0.65.0":
   version "0.65.0"
@@ -833,6 +864,15 @@
     "@opentelemetry/instrumentation" "^0.213.0"
     "@opentelemetry/semantic-conventions" "^1.24.0"
 
+"@opentelemetry/instrumentation@0.213.0", "@opentelemetry/instrumentation@^0.213.0":
+  version "0.213.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.213.0.tgz"
+  integrity sha512-3i9NdkET/KvQomeh7UaR/F4r9P25Rx6ooALlWXPIjypcEOUxksCmVu0zA70NBJWlrMW1rPr/LRidFAflLI+s/w==
+  dependencies:
+    "@opentelemetry/api-logs" "0.213.0"
+    import-in-the-middle "^3.0.0"
+    require-in-the-middle "^8.0.0"
+
 "@opentelemetry/instrumentation@^0.207.0":
   version "0.207.0"
   resolved "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.207.0.tgz"
@@ -851,21 +891,12 @@
     import-in-the-middle "^2.0.6"
     require-in-the-middle "^8.0.0"
 
-"@opentelemetry/instrumentation@^0.213.0", "@opentelemetry/instrumentation@>=0.57.1 <1", "@opentelemetry/instrumentation@0.213.0":
-  version "0.213.0"
-  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.213.0.tgz"
-  integrity sha512-3i9NdkET/KvQomeh7UaR/F4r9P25Rx6ooALlWXPIjypcEOUxksCmVu0zA70NBJWlrMW1rPr/LRidFAflLI+s/w==
-  dependencies:
-    "@opentelemetry/api-logs" "0.213.0"
-    import-in-the-middle "^3.0.0"
-    require-in-the-middle "^8.0.0"
-
 "@opentelemetry/redis-common@^0.38.2":
   version "0.38.2"
   resolved "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.38.2.tgz"
   integrity sha512-1BCcU93iwSRZvDAgwUxC/DV4T/406SkMfxGqu5ojc3AvNI+I9GhV7v0J1HljsczuuhcnFLYqD5VmwVXfCGHzxA==
 
-"@opentelemetry/resources@^1.30.1 || ^2.1.0", "@opentelemetry/resources@^2.6.0", "@opentelemetry/resources@2.6.0":
+"@opentelemetry/resources@2.6.0", "@opentelemetry/resources@^2.6.0":
   version "2.6.0"
   resolved "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.0.tgz"
   integrity sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ==
@@ -873,7 +904,7 @@
     "@opentelemetry/core" "2.6.0"
     "@opentelemetry/semantic-conventions" "^1.29.0"
 
-"@opentelemetry/sdk-trace-base@^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base@^2.6.0":
+"@opentelemetry/sdk-trace-base@^2.6.0":
   version "2.6.0"
   resolved "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.0.tgz"
   integrity sha512-g/OZVkqlxllgFM7qMKqbPV9c1DUPhQ7d4n3pgZFcrnrNft9eJXZM2TNHTPYREJBrtNdRytYyvwjgL5geDKl3EQ==
@@ -882,7 +913,7 @@
     "@opentelemetry/resources" "2.6.0"
     "@opentelemetry/semantic-conventions" "^1.29.0"
 
-"@opentelemetry/semantic-conventions@^1.24.0", "@opentelemetry/semantic-conventions@^1.27.0", "@opentelemetry/semantic-conventions@^1.28.0", "@opentelemetry/semantic-conventions@^1.29.0", "@opentelemetry/semantic-conventions@^1.30.0", "@opentelemetry/semantic-conventions@^1.33.0", "@opentelemetry/semantic-conventions@^1.33.1", "@opentelemetry/semantic-conventions@^1.34.0", "@opentelemetry/semantic-conventions@^1.36.0", "@opentelemetry/semantic-conventions@^1.39.0", "@opentelemetry/semantic-conventions@^1.40.0":
+"@opentelemetry/semantic-conventions@^1.24.0", "@opentelemetry/semantic-conventions@^1.27.0", "@opentelemetry/semantic-conventions@^1.28.0", "@opentelemetry/semantic-conventions@^1.29.0", "@opentelemetry/semantic-conventions@^1.30.0", "@opentelemetry/semantic-conventions@^1.33.0", "@opentelemetry/semantic-conventions@^1.33.1", "@opentelemetry/semantic-conventions@^1.34.0", "@opentelemetry/semantic-conventions@^1.36.0", "@opentelemetry/semantic-conventions@^1.40.0":
   version "1.40.0"
   resolved "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz"
   integrity sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==
@@ -1025,6 +1056,13 @@
   version "1.0.4"
   resolved "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz"
   integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
+
+"@tybys/wasm-util@^0.10.0":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.1.tgz#ecddd3205cf1e2d5274649ff0eedd2991ed7f414"
+  integrity sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==
+  dependencies:
+    tslib "^2.4.0"
 
 "@types/babel__core@^7.20.5":
   version "7.20.5"
@@ -1330,10 +1368,102 @@
   resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
 
+"@unrs/resolver-binding-android-arm-eabi@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz#9f5b04503088e6a354295e8ea8fe3cb99e43af81"
+  integrity sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==
+
+"@unrs/resolver-binding-android-arm64@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz#7414885431bd7178b989aedc4d25cccb3865bc9f"
+  integrity sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==
+
 "@unrs/resolver-binding-darwin-arm64@1.11.1":
   version "1.11.1"
   resolved "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz"
   integrity sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==
+
+"@unrs/resolver-binding-darwin-x64@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz#fd4d81257b13f4d1a083890a6a17c00de571f0dc"
+  integrity sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==
+
+"@unrs/resolver-binding-freebsd-x64@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz#d2513084d0f37c407757e22f32bd924a78cfd99b"
+  integrity sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==
+
+"@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz#844d2605d057488d77fab09705f2866b86164e0a"
+  integrity sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==
+
+"@unrs/resolver-binding-linux-arm-musleabihf@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz#204892995cefb6bd1d017d52d097193bc61ddad3"
+  integrity sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==
+
+"@unrs/resolver-binding-linux-arm64-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz#023eb0c3aac46066a10be7a3f362e7b34f3bdf9d"
+  integrity sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==
+
+"@unrs/resolver-binding-linux-arm64-musl@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz#9e6f9abb06424e3140a60ac996139786f5d99be0"
+  integrity sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==
+
+"@unrs/resolver-binding-linux-ppc64-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz#b111417f17c9d1b02efbec8e08398f0c5527bb44"
+  integrity sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==
+
+"@unrs/resolver-binding-linux-riscv64-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz#92ffbf02748af3e99873945c9a8a5ead01d508a9"
+  integrity sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==
+
+"@unrs/resolver-binding-linux-riscv64-musl@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz#0bec6f1258fc390e6b305e9ff44256cb207de165"
+  integrity sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==
+
+"@unrs/resolver-binding-linux-s390x-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz#577843a084c5952f5906770633ccfb89dac9bc94"
+  integrity sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==
+
+"@unrs/resolver-binding-linux-x64-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz#36fb318eebdd690f6da32ac5e0499a76fa881935"
+  integrity sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==
+
+"@unrs/resolver-binding-linux-x64-musl@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz#bfb9af75f783f98f6a22c4244214efe4df1853d6"
+  integrity sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==
+
+"@unrs/resolver-binding-wasm32-wasi@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz#752c359dd875684b27429500d88226d7cc72f71d"
+  integrity sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==
+  dependencies:
+    "@napi-rs/wasm-runtime" "^0.2.11"
+
+"@unrs/resolver-binding-win32-arm64-msvc@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz#ce5735e600e4c2fbb409cd051b3b7da4a399af35"
+  integrity sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==
+
+"@unrs/resolver-binding-win32-ia32-msvc@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz#72fc57bc7c64ec5c3de0d64ee0d1810317bc60a6"
+  integrity sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==
+
+"@unrs/resolver-binding-win32-x64-msvc@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz#538b1e103bf8d9864e7b85cc96fa8d6fb6c40777"
+  integrity sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==
 
 accepts@~1.3.8:
   version "1.3.8"
@@ -1353,7 +1483,7 @@ acorn-walk@^8.1.1:
   resolved "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
-acorn@^8, acorn@^8.15.0:
+acorn@^8.15.0:
   version "8.16.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz"
   integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
@@ -1469,7 +1599,7 @@ b4a@^1.6.4:
   resolved "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz"
   integrity sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==
 
-"babel-jest@^29.0.0 || ^30.0.0", babel-jest@30.3.0:
+babel-jest@30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz"
   integrity sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==
@@ -1539,7 +1669,7 @@ balanced-match@^4.0.2:
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz"
   integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
 
-bare-events@*, bare-events@^2.5.4, bare-events@^2.7.0:
+bare-events@^2.5.4, bare-events@^2.7.0:
   version "2.8.2"
   resolved "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz"
   integrity sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==
@@ -1582,15 +1712,15 @@ bare-url@^2.2.2:
   dependencies:
     bare-path "^3.0.0"
 
-base64-js@^1.1.2, base64-js@^1.3.0:
-  version "1.5.1"
-  resolved "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz"
-  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
-
 base64-js@0.0.8:
   version "0.0.8"
   resolved "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
   integrity sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==
+
+base64-js@^1.1.2, base64-js@^1.3.0:
+  version "1.5.1"
+  resolved "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
 baseline-browser-mapping@^2.9.0:
   version "2.10.10"
@@ -1666,7 +1796,7 @@ brotli@^1.3.2:
   dependencies:
     base64-js "^1.1.2"
 
-browserslist@^4.24.0, "browserslist@>= 4.21.0":
+browserslist@^4.24.0:
   version "4.28.1"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz"
   integrity sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==
@@ -1939,19 +2069,19 @@ data-uri-to-buffer@^4.0.0:
   resolved "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz"
   integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
 
-debug@^4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.4, debug@^4.3.5, debug@^4.3.7, debug@^4.4.3, debug@4:
-  version "4.4.3"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
-  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
-  dependencies:
-    ms "^2.1.3"
-
 debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
+
+debug@4, debug@^4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.4, debug@^4.3.5, debug@^4.3.7, debug@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
 
 debug@4.x:
   version "4.3.4"
@@ -1975,12 +2105,12 @@ delayed-stream@~1.0.0:
   resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
-depd@~2.0.0, depd@2.0.0:
+depd@2.0.0, depd@~2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
-destroy@~1.2.0, destroy@1.2.0:
+destroy@1.2.0, destroy@~1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
@@ -2027,7 +2157,7 @@ eastasianwidth@^0.2.0:
   resolved "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz"
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
 
-ecdsa-sig-formatter@^1.0.11, ecdsa-sig-formatter@1.0.11:
+ecdsa-sig-formatter@1.0.11, ecdsa-sig-formatter@^1.0.11:
   version "1.0.11"
   resolved "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz"
   integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
@@ -2150,7 +2280,7 @@ exit-x@^0.2.2:
   resolved "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz"
   integrity sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==
 
-expect@^30.0.0, expect@30.3.0:
+expect@30.3.0, expect@^30.0.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz"
   integrity sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==
@@ -2161,6 +2291,13 @@ expect@^30.0.0, expect@30.3.0:
     jest-message-util "30.3.0"
     jest-mock "30.3.0"
     jest-util "30.3.0"
+
+express-rate-limit@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-8.3.2.tgz#81bbdbf599b7889a5b3cc272ec115aff200011be"
+  integrity sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==
+  dependencies:
+    ip-address "10.1.0"
 
 express-validator@^7.0.1:
   version "7.3.1"
@@ -2222,7 +2359,7 @@ fast-fifo@^1.2.0, fast-fifo@^1.3.2:
   resolved "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz"
   integrity sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==
 
-fast-json-stable-stringify@^2.1.0, fast-json-stable-stringify@2.x:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -2378,7 +2515,7 @@ gaxios@^7.0.0, gaxios@^7.1.4:
     https-proxy-agent "^7.0.1"
     node-fetch "^3.3.2"
 
-gcp-metadata@^7.0.1, gcp-metadata@8.1.2:
+gcp-metadata@8.1.2:
   version "8.1.2"
   resolved "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz"
   integrity sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==
@@ -2474,7 +2611,7 @@ google-auth-library@^10.6.2:
     google-logging-utils "1.1.3"
     jws "^4.0.0"
 
-google-logging-utils@^1.0.0, google-logging-utils@1.1.3:
+google-logging-utils@1.1.3, google-logging-utils@^1.0.0:
   version "1.1.3"
   resolved "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz"
   integrity sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==
@@ -2571,17 +2708,7 @@ ignore-by-default@^1.0.1:
   resolved "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz"
   integrity sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==
 
-import-in-the-middle@^2.0.0:
-  version "2.0.6"
-  resolved "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz"
-  integrity sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==
-  dependencies:
-    acorn "^8.15.0"
-    acorn-import-attributes "^1.9.5"
-    cjs-module-lexer "^2.2.0"
-    module-details-from-path "^1.0.4"
-
-import-in-the-middle@^2.0.6:
+import-in-the-middle@^2.0.0, import-in-the-middle@^2.0.6:
   version "2.0.6"
   resolved "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz"
   integrity sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==
@@ -2622,14 +2749,14 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@^2.0.3, inherits@~2.0.4, inherits@2:
+inherits@2, inherits@^2.0.3, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-ip-address@^10.0.1:
+ip-address@10.1.0, ip-address@^10.0.1:
   version "10.1.0"
-  resolved "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.1.0.tgz#d8dcffb34d0e02eb241427444a6e23f5b0595aa4"
   integrity sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==
 
 ipaddr.js@1.9.1:
@@ -2936,7 +3063,7 @@ jest-resolve-dependencies@30.3.0:
     jest-regex-util "30.0.1"
     jest-snapshot "30.3.0"
 
-jest-resolve@*, jest-resolve@30.3.0:
+jest-resolve@30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.3.0.tgz"
   integrity sha512-NRtTAHQlpd15F9rUR36jqwelbrDV/dY4vzNte3S2kxCKUJRYNd5/6nTSbYiak1VX5g8IoFF23Uj5TURkUW8O5g==
@@ -3033,7 +3160,7 @@ jest-snapshot@30.3.0:
     semver "^7.7.2"
     synckit "^0.11.8"
 
-"jest-util@^29.0.0 || ^30.0.0", jest-util@30.3.0:
+jest-util@30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz"
   integrity sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==
@@ -3082,7 +3209,7 @@ jest-worker@30.3.0:
     merge-stream "^2.0.0"
     supports-color "^8.1.1"
 
-"jest@^29.0.0 || ^30.0.0", jest@^30.3.0:
+jest@^30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/jest/-/jest-30.3.0.tgz"
   integrity sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==
@@ -3421,15 +3548,6 @@ mongodb-memory-server@^11.0.1:
     mongodb-memory-server-core "11.0.1"
     tslib "^2.8.1"
 
-mongodb@^7.0.0:
-  version "7.1.1"
-  resolved "https://registry.npmjs.org/mongodb/-/mongodb-7.1.1.tgz"
-  integrity sha512-067DXiMjcpYQl6bGjWQoTUEE9UoRViTtKFcoqX7z08I+iDZv/emH1g8XEFiO3qiDfXAheT5ozl1VffDTKhIW/w==
-  dependencies:
-    "@mongodb-js/saslprep" "^1.3.0"
-    bson "^7.1.1"
-    mongodb-connection-string-url "^7.0.0"
-
 mongodb@5.9.2:
   version "5.9.2"
   resolved "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz"
@@ -3440,6 +3558,15 @@ mongodb@5.9.2:
     socks "^2.7.1"
   optionalDependencies:
     "@mongodb-js/saslprep" "^1.1.0"
+
+mongodb@^7.0.0:
+  version "7.1.1"
+  resolved "https://registry.npmjs.org/mongodb/-/mongodb-7.1.1.tgz"
+  integrity sha512-067DXiMjcpYQl6bGjWQoTUEE9UoRViTtKFcoqX7z08I+iDZv/emH1g8XEFiO3qiDfXAheT5ozl1VffDTKhIW/w==
+  dependencies:
+    "@mongodb-js/saslprep" "^1.3.0"
+    bson "^7.1.1"
+    mongodb-connection-string-url "^7.0.0"
 
 mongoose@^7.6.3:
   version "7.8.9"
@@ -3466,11 +3593,6 @@ mquery@5.0.0:
   dependencies:
     debug "4.x"
 
-ms@^2.1.1, ms@^2.1.3, ms@2.1.3:
-  version "2.1.3"
-  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
-  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
-
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
@@ -3480,6 +3602,11 @@ ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+ms@2.1.3, ms@^2.1.1, ms@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 multer@^2.1.1:
   version "2.1.1"
@@ -3730,12 +3857,7 @@ picocolors@^1.1.1:
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^2.0.4:
-  version "2.3.1"
-  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
-
-picomatch@^2.2.1:
+picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.3.1"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -3784,7 +3906,7 @@ postgres-interval@^1.1.0:
   dependencies:
     xtend "^4.0.0"
 
-pretty-format@^30.0.0, pretty-format@30.3.0:
+pretty-format@30.3.0, pretty-format@^30.0.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz"
   integrity sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==
@@ -3896,7 +4018,7 @@ restructure@^3.0.0:
   resolved "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz"
   integrity sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==
 
-safe-buffer@^5.0.1, safe-buffer@~5.2.0, safe-buffer@5.2.1:
+safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -3906,12 +4028,7 @@ safe-buffer@^5.0.1, safe-buffer@~5.2.0, safe-buffer@5.2.1:
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-semver@^6.0.0:
-  version "6.3.1"
-  resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
-  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
-
-semver@^6.3.1:
+semver@^6.0.0, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
@@ -3950,7 +4067,7 @@ serve-static@~1.16.2:
     parseurl "~1.3.3"
     send "~0.19.1"
 
-setprototypeof@~1.2.0, setprototypeof@1.2.0:
+setprototypeof@1.2.0, setprototypeof@~1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
@@ -4039,7 +4156,7 @@ smart-buffer@^4.2.0:
   resolved "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz"
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
 
-socks@^2.7.1, socks@^2.8.6:
+socks@^2.7.1:
   version "2.8.7"
   resolved "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz"
   integrity sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==
@@ -4098,13 +4215,6 @@ streamx@^2.12.5, streamx@^2.15.0, streamx@^2.25.0:
     fast-fifo "^1.3.2"
     text-decoder "^1.1.0"
 
-string_decoder@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
-  dependencies:
-    safe-buffer "~5.2.0"
-
 string-length@^4.0.2:
   version "4.0.2"
   resolved "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz"
@@ -4127,16 +4237,7 @@ string-similarity@^4.0.4:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string-width@^4.1.0, string-width@^4.2.0:
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.2.3:
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4153,6 +4254,13 @@ string-width@^5.0.1, string-width@^5.1.2:
     eastasianwidth "^0.2.0"
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
+
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
 
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
@@ -4336,7 +4444,7 @@ ts-jest@^29.4.6:
     type-fest "^4.41.0"
     yargs-parser "^21.1.1"
 
-ts-node@^10.9.1, ts-node@>=9.0.0:
+ts-node@^10.9.1:
   version "10.9.1"
   resolved "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz"
   integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
@@ -4388,7 +4496,7 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^5.2.2, typescript@>=2.7, "typescript@>=4.3 <6":
+typescript@^5.2.2:
   version "5.2.2"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz"
   integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4,7 +4,7 @@
 
 "@anthropic-ai/sdk@^0.80.0":
   version "0.80.0"
-  resolved "https://registry.yarnpkg.com/@anthropic-ai/sdk/-/sdk-0.80.0.tgz#d480aee13b7b1d4faf324845fad7a924eebdaa5b"
+  resolved "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.80.0.tgz"
   integrity sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g==
   dependencies:
     json-schema-to-ts "^3.1.1"
@@ -23,7 +23,7 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz"
   integrity sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==
 
-"@babel/core@^7.23.9", "@babel/core@^7.27.4":
+"@babel/core@^7.0.0", "@babel/core@^7.0.0 || ^8.0.0-0", "@babel/core@^7.0.0-0", "@babel/core@^7.11.0 || ^8.0.0-0", "@babel/core@^7.11.0 || ^8.0.0-beta.1", "@babel/core@^7.23.9", "@babel/core@^7.27.4", "@babel/core@>=7.0.0-beta.0 <8":
   version "7.29.0"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz"
   integrity sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==
@@ -244,7 +244,7 @@
 
 "@babel/runtime@^7.18.3":
   version "7.29.2"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.2.tgz#9a6e2d05f4b6692e1801cd4fb176ad823930ed5e"
+  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz"
   integrity sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==
 
 "@babel/template@^7.28.6":
@@ -288,28 +288,6 @@
   integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
-
-"@emnapi/core@^1.4.3":
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.9.1.tgz#2143069c744ca2442074f8078462e51edd63c7bd"
-  integrity sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==
-  dependencies:
-    "@emnapi/wasi-threads" "1.2.0"
-    tslib "^2.4.0"
-
-"@emnapi/runtime@^1.4.3":
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.9.1.tgz#115ff2a0d589865be6bd8e9d701e499c473f2a8d"
-  integrity sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==
-  dependencies:
-    tslib "^2.4.0"
-
-"@emnapi/wasi-threads@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz#a19d9772cc3d195370bf6e2a805eec40aa75e18e"
-  integrity sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==
-  dependencies:
-    tslib "^2.4.0"
 
 "@fastify/otel@0.17.1":
   version "0.17.1"
@@ -534,7 +512,7 @@
     jest-haste-map "30.3.0"
     slash "^3.0.0"
 
-"@jest/transform@30.3.0":
+"@jest/transform@^29.0.0 || ^30.0.0", "@jest/transform@30.3.0":
   version "30.3.0"
   resolved "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz"
   integrity sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==
@@ -554,7 +532,7 @@
     slash "^3.0.0"
     write-file-atomic "^5.0.1"
 
-"@jest/types@30.3.0":
+"@jest/types@^29.0.0 || ^30.0.0", "@jest/types@30.3.0":
   version "30.3.0"
   resolved "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz"
   integrity sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==
@@ -593,14 +571,6 @@
   resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
 
-"@jridgewell/trace-mapping@0.3.9":
-  version "0.3.9"
-  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz"
-  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
-  dependencies:
-    "@jridgewell/resolve-uri" "^3.0.3"
-    "@jridgewell/sourcemap-codec" "^1.4.10"
-
 "@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.23", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25", "@jridgewell/trace-mapping@^0.3.28":
   version "0.3.31"
   resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz"
@@ -609,6 +579,14 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+
 "@mongodb-js/saslprep@^1.1.0", "@mongodb-js/saslprep@^1.3.0":
   version "1.4.6"
   resolved "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.6.tgz"
@@ -616,16 +594,12 @@
   dependencies:
     sparse-bitfield "^3.0.3"
 
-"@napi-rs/wasm-runtime@^0.2.11":
-  version "0.2.12"
-  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz#3e78a8b96e6c33a6c517e1894efbd5385a7cb6f2"
-  integrity sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==
-  dependencies:
-    "@emnapi/core" "^1.4.3"
-    "@emnapi/runtime" "^1.4.3"
-    "@tybys/wasm-util" "^0.10.0"
+"@noble/ciphers@^1.0.0":
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz"
+  integrity sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==
 
-"@noble/hashes@^1.1.5":
+"@noble/hashes@^1.1.5", "@noble/hashes@^1.6.0":
   version "1.8.0"
   resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz"
   integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
@@ -651,17 +625,17 @@
   dependencies:
     "@opentelemetry/api" "^1.3.0"
 
-"@opentelemetry/api@^1.3.0", "@opentelemetry/api@^1.9.0":
+"@opentelemetry/api@^1.1.0", "@opentelemetry/api@^1.3.0", "@opentelemetry/api@^1.7.0", "@opentelemetry/api@^1.8", "@opentelemetry/api@^1.9.0", "@opentelemetry/api@>=1.0.0 <1.10.0", "@opentelemetry/api@>=1.3.0 <1.10.0":
   version "1.9.0"
   resolved "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz"
   integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
 
-"@opentelemetry/context-async-hooks@^2.6.0":
+"@opentelemetry/context-async-hooks@^1.30.1 || ^2.1.0", "@opentelemetry/context-async-hooks@^2.6.0":
   version "2.6.0"
   resolved "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.0.tgz"
   integrity sha512-L8UyDwqpTcbkIK5cgwDRDYDoEhQoj8wp8BwsO19w3LB1Z41yEQm2VJyNfAi9DrLP/YTqXqWpKHyZfR9/tFYo1Q==
 
-"@opentelemetry/core@2.6.0", "@opentelemetry/core@^2.0.0", "@opentelemetry/core@^2.6.0":
+"@opentelemetry/core@^1.30.1 || ^2.1.0", "@opentelemetry/core@^2.0.0", "@opentelemetry/core@^2.6.0", "@opentelemetry/core@2.6.0":
   version "2.6.0"
   resolved "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.0.tgz"
   integrity sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==
@@ -802,15 +776,6 @@
     "@opentelemetry/instrumentation" "^0.213.0"
     "@opentelemetry/semantic-conventions" "^1.33.0"
 
-"@opentelemetry/instrumentation-mysql2@0.59.0":
-  version "0.59.0"
-  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.59.0.tgz"
-  integrity sha512-n9/xrVCRBfG9egVbffnlU1uhr+HX0vF4GgtAB/Bvm48wpFgRidqD8msBMiym1kRYzmpWvJqTxNT47u1MkgBEdw==
-  dependencies:
-    "@opentelemetry/instrumentation" "^0.213.0"
-    "@opentelemetry/semantic-conventions" "^1.33.0"
-    "@opentelemetry/sql-common" "^0.41.2"
-
 "@opentelemetry/instrumentation-mysql@0.59.0":
   version "0.59.0"
   resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.59.0.tgz"
@@ -819,6 +784,15 @@
     "@opentelemetry/instrumentation" "^0.213.0"
     "@opentelemetry/semantic-conventions" "^1.33.0"
     "@types/mysql" "2.15.27"
+
+"@opentelemetry/instrumentation-mysql2@0.59.0":
+  version "0.59.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.59.0.tgz"
+  integrity sha512-n9/xrVCRBfG9egVbffnlU1uhr+HX0vF4GgtAB/Bvm48wpFgRidqD8msBMiym1kRYzmpWvJqTxNT47u1MkgBEdw==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.213.0"
+    "@opentelemetry/semantic-conventions" "^1.33.0"
+    "@opentelemetry/sql-common" "^0.41.2"
 
 "@opentelemetry/instrumentation-pg@0.65.0":
   version "0.65.0"
@@ -859,15 +833,6 @@
     "@opentelemetry/instrumentation" "^0.213.0"
     "@opentelemetry/semantic-conventions" "^1.24.0"
 
-"@opentelemetry/instrumentation@0.213.0", "@opentelemetry/instrumentation@^0.213.0":
-  version "0.213.0"
-  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.213.0.tgz"
-  integrity sha512-3i9NdkET/KvQomeh7UaR/F4r9P25Rx6ooALlWXPIjypcEOUxksCmVu0zA70NBJWlrMW1rPr/LRidFAflLI+s/w==
-  dependencies:
-    "@opentelemetry/api-logs" "0.213.0"
-    import-in-the-middle "^3.0.0"
-    require-in-the-middle "^8.0.0"
-
 "@opentelemetry/instrumentation@^0.207.0":
   version "0.207.0"
   resolved "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.207.0.tgz"
@@ -886,12 +851,21 @@
     import-in-the-middle "^2.0.6"
     require-in-the-middle "^8.0.0"
 
+"@opentelemetry/instrumentation@^0.213.0", "@opentelemetry/instrumentation@>=0.57.1 <1", "@opentelemetry/instrumentation@0.213.0":
+  version "0.213.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.213.0.tgz"
+  integrity sha512-3i9NdkET/KvQomeh7UaR/F4r9P25Rx6ooALlWXPIjypcEOUxksCmVu0zA70NBJWlrMW1rPr/LRidFAflLI+s/w==
+  dependencies:
+    "@opentelemetry/api-logs" "0.213.0"
+    import-in-the-middle "^3.0.0"
+    require-in-the-middle "^8.0.0"
+
 "@opentelemetry/redis-common@^0.38.2":
   version "0.38.2"
   resolved "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.38.2.tgz"
   integrity sha512-1BCcU93iwSRZvDAgwUxC/DV4T/406SkMfxGqu5ojc3AvNI+I9GhV7v0J1HljsczuuhcnFLYqD5VmwVXfCGHzxA==
 
-"@opentelemetry/resources@2.6.0", "@opentelemetry/resources@^2.6.0":
+"@opentelemetry/resources@^1.30.1 || ^2.1.0", "@opentelemetry/resources@^2.6.0", "@opentelemetry/resources@2.6.0":
   version "2.6.0"
   resolved "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.0.tgz"
   integrity sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ==
@@ -899,7 +873,7 @@
     "@opentelemetry/core" "2.6.0"
     "@opentelemetry/semantic-conventions" "^1.29.0"
 
-"@opentelemetry/sdk-trace-base@^2.6.0":
+"@opentelemetry/sdk-trace-base@^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base@^2.6.0":
   version "2.6.0"
   resolved "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.0.tgz"
   integrity sha512-g/OZVkqlxllgFM7qMKqbPV9c1DUPhQ7d4n3pgZFcrnrNft9eJXZM2TNHTPYREJBrtNdRytYyvwjgL5geDKl3EQ==
@@ -908,7 +882,7 @@
     "@opentelemetry/resources" "2.6.0"
     "@opentelemetry/semantic-conventions" "^1.29.0"
 
-"@opentelemetry/semantic-conventions@^1.24.0", "@opentelemetry/semantic-conventions@^1.27.0", "@opentelemetry/semantic-conventions@^1.28.0", "@opentelemetry/semantic-conventions@^1.29.0", "@opentelemetry/semantic-conventions@^1.30.0", "@opentelemetry/semantic-conventions@^1.33.0", "@opentelemetry/semantic-conventions@^1.33.1", "@opentelemetry/semantic-conventions@^1.34.0", "@opentelemetry/semantic-conventions@^1.36.0", "@opentelemetry/semantic-conventions@^1.40.0":
+"@opentelemetry/semantic-conventions@^1.24.0", "@opentelemetry/semantic-conventions@^1.27.0", "@opentelemetry/semantic-conventions@^1.28.0", "@opentelemetry/semantic-conventions@^1.29.0", "@opentelemetry/semantic-conventions@^1.30.0", "@opentelemetry/semantic-conventions@^1.33.0", "@opentelemetry/semantic-conventions@^1.33.1", "@opentelemetry/semantic-conventions@^1.34.0", "@opentelemetry/semantic-conventions@^1.36.0", "@opentelemetry/semantic-conventions@^1.39.0", "@opentelemetry/semantic-conventions@^1.40.0":
   version "1.40.0"
   resolved "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz"
   integrity sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==
@@ -1025,6 +999,13 @@
   dependencies:
     "@sinonjs/commons" "^3.0.1"
 
+"@swc/helpers@^0.5.12":
+  version "0.5.21"
+  resolved "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz"
+  integrity sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==
+  dependencies:
+    tslib "^2.8.0"
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.9"
   resolved "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz"
@@ -1044,13 +1025,6 @@
   version "1.0.4"
   resolved "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz"
   integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
-
-"@tybys/wasm-util@^0.10.0":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.1.tgz#ecddd3205cf1e2d5274649ff0eedd2991ed7f414"
-  integrity sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==
-  dependencies:
-    tslib "^2.4.0"
 
 "@types/babel__core@^7.20.5":
   version "7.20.5"
@@ -1225,6 +1199,13 @@
   dependencies:
     undici-types "~5.25.1"
 
+"@types/pdfkit@^0.17.5":
+  version "0.17.5"
+  resolved "https://registry.npmjs.org/@types/pdfkit/-/pdfkit-0.17.5.tgz"
+  integrity sha512-T3ZHnvF91HsEco5ClhBCOuBwobZfPcI2jaiSHybkkKYq4KhVIIurod94JVKvDIG0JXT6o3KiERC0X0//m8dyrg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/pg-pool@2.0.7":
   version "2.0.7"
   resolved "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.7.tgz"
@@ -1349,102 +1330,10 @@
   resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
 
-"@unrs/resolver-binding-android-arm-eabi@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz#9f5b04503088e6a354295e8ea8fe3cb99e43af81"
-  integrity sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==
-
-"@unrs/resolver-binding-android-arm64@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz#7414885431bd7178b989aedc4d25cccb3865bc9f"
-  integrity sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==
-
 "@unrs/resolver-binding-darwin-arm64@1.11.1":
   version "1.11.1"
   resolved "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz"
   integrity sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==
-
-"@unrs/resolver-binding-darwin-x64@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz#fd4d81257b13f4d1a083890a6a17c00de571f0dc"
-  integrity sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==
-
-"@unrs/resolver-binding-freebsd-x64@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz#d2513084d0f37c407757e22f32bd924a78cfd99b"
-  integrity sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==
-
-"@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz#844d2605d057488d77fab09705f2866b86164e0a"
-  integrity sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==
-
-"@unrs/resolver-binding-linux-arm-musleabihf@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz#204892995cefb6bd1d017d52d097193bc61ddad3"
-  integrity sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==
-
-"@unrs/resolver-binding-linux-arm64-gnu@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz#023eb0c3aac46066a10be7a3f362e7b34f3bdf9d"
-  integrity sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==
-
-"@unrs/resolver-binding-linux-arm64-musl@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz#9e6f9abb06424e3140a60ac996139786f5d99be0"
-  integrity sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==
-
-"@unrs/resolver-binding-linux-ppc64-gnu@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz#b111417f17c9d1b02efbec8e08398f0c5527bb44"
-  integrity sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==
-
-"@unrs/resolver-binding-linux-riscv64-gnu@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz#92ffbf02748af3e99873945c9a8a5ead01d508a9"
-  integrity sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==
-
-"@unrs/resolver-binding-linux-riscv64-musl@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz#0bec6f1258fc390e6b305e9ff44256cb207de165"
-  integrity sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==
-
-"@unrs/resolver-binding-linux-s390x-gnu@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz#577843a084c5952f5906770633ccfb89dac9bc94"
-  integrity sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==
-
-"@unrs/resolver-binding-linux-x64-gnu@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz#36fb318eebdd690f6da32ac5e0499a76fa881935"
-  integrity sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==
-
-"@unrs/resolver-binding-linux-x64-musl@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz#bfb9af75f783f98f6a22c4244214efe4df1853d6"
-  integrity sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==
-
-"@unrs/resolver-binding-wasm32-wasi@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz#752c359dd875684b27429500d88226d7cc72f71d"
-  integrity sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==
-  dependencies:
-    "@napi-rs/wasm-runtime" "^0.2.11"
-
-"@unrs/resolver-binding-win32-arm64-msvc@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz#ce5735e600e4c2fbb409cd051b3b7da4a399af35"
-  integrity sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==
-
-"@unrs/resolver-binding-win32-ia32-msvc@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz#72fc57bc7c64ec5c3de0d64ee0d1810317bc60a6"
-  integrity sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==
-
-"@unrs/resolver-binding-win32-x64-msvc@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz#538b1e103bf8d9864e7b85cc96fa8d6fb6c40777"
-  integrity sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==
 
 accepts@~1.3.8:
   version "1.3.8"
@@ -1464,7 +1353,7 @@ acorn-walk@^8.1.1:
   resolved "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
-acorn@^8.15.0:
+acorn@^8, acorn@^8.15.0:
   version "8.16.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz"
   integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
@@ -1528,7 +1417,7 @@ append-field@^1.0.0:
 
 apple-signin-auth@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/apple-signin-auth/-/apple-signin-auth-2.0.0.tgz#429a41a9df266eb43f59e7bd0255ff5766cff8ee"
+  resolved "https://registry.npmjs.org/apple-signin-auth/-/apple-signin-auth-2.0.0.tgz"
   integrity sha512-/O5gvAby7OU2K7baYQCzY0e0tCiHzhFkzt9L2v3bMd2I2w0ckCZ/4hdVUOrbolRGMppME+Zo8TAKPVru8aYnzg==
   dependencies:
     jsonwebtoken "^9.0.0"
@@ -1558,7 +1447,7 @@ asap@^2.0.0:
 
 asn1@^0.2.4:
   version "0.2.6"
-  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.6.tgz#0d3a7bb6e64e02a90c0303b31f292868ea09a08d"
+  resolved "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz"
   integrity sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==
   dependencies:
     safer-buffer "~2.1.0"
@@ -1580,7 +1469,7 @@ b4a@^1.6.4:
   resolved "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz"
   integrity sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==
 
-babel-jest@30.3.0:
+"babel-jest@^29.0.0 || ^30.0.0", babel-jest@30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz"
   integrity sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==
@@ -1650,7 +1539,7 @@ balanced-match@^4.0.2:
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz"
   integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
 
-bare-events@^2.5.4, bare-events@^2.7.0:
+bare-events@*, bare-events@^2.5.4, bare-events@^2.7.0:
   version "2.8.2"
   resolved "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz"
   integrity sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==
@@ -1693,10 +1582,15 @@ bare-url@^2.2.2:
   dependencies:
     bare-path "^3.0.0"
 
-base64-js@^1.3.0:
+base64-js@^1.1.2, base64-js@^1.3.0:
   version "1.5.1"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  resolved "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
+base64-js@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
+  integrity sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==
 
 baseline-browser-mapping@^2.9.0:
   version "2.10.10"
@@ -1710,7 +1604,7 @@ bcryptjs@^2.4.3:
 
 bignumber.js@^9.0.0:
   version "9.3.1"
-  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.3.1.tgz#759c5aaddf2ffdc4f154f7b493e1c8770f88c4d7"
+  resolved "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz"
   integrity sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==
 
 binary-extensions@^2.0.0:
@@ -1765,7 +1659,14 @@ braces@~3.0.2:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.24.0:
+brotli@^1.3.2:
+  version "1.3.3"
+  resolved "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz"
+  integrity sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==
+  dependencies:
+    base64-js "^1.1.2"
+
+browserslist@^4.24.0, "browserslist@>= 4.21.0":
   version "4.28.1"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz"
   integrity sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==
@@ -1910,6 +1811,11 @@ cliui@^8.0.1:
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
+clone@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz"
+  integrity sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
@@ -2030,8 +1936,15 @@ csv-parse@^6.2.1:
 
 data-uri-to-buffer@^4.0.0:
   version "4.0.1"
-  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
+  resolved "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz"
   integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
+
+debug@^4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.4, debug@^4.3.5, debug@^4.3.7, debug@^4.4.3, debug@4:
+  version "4.4.3"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
 
 debug@2.6.9:
   version "2.6.9"
@@ -2039,13 +1952,6 @@ debug@2.6.9:
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
-
-debug@4, debug@^4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.4, debug@^4.3.5, debug@^4.3.7, debug@^4.4.3:
-  version "4.4.3"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
-  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
-  dependencies:
-    ms "^2.1.3"
 
 debug@4.x:
   version "4.3.4"
@@ -2069,12 +1975,12 @@ delayed-stream@~1.0.0:
   resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
-depd@2.0.0, depd@~2.0.0:
+depd@~2.0.0, depd@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
-destroy@1.2.0, destroy@~1.2.0:
+destroy@~1.2.0, destroy@1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
@@ -2091,6 +1997,11 @@ dezalgo@^1.0.4:
   dependencies:
     asap "^2.0.0"
     wrappy "1"
+
+dfa@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz"
+  integrity sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==
 
 diff@^4.0.1:
   version "4.0.4"
@@ -2116,7 +2027,7 @@ eastasianwidth@^0.2.0:
   resolved "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz"
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
 
-ecdsa-sig-formatter@1.0.11, ecdsa-sig-formatter@^1.0.11:
+ecdsa-sig-formatter@^1.0.11, ecdsa-sig-formatter@1.0.11:
   version "1.0.11"
   resolved "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz"
   integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
@@ -2239,7 +2150,7 @@ exit-x@^0.2.2:
   resolved "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz"
   integrity sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==
 
-expect@30.3.0, expect@^30.0.0:
+expect@^30.0.0, expect@30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz"
   integrity sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==
@@ -2298,15 +2209,20 @@ express@^4.18.2:
 
 extend@^3.0.2:
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  resolved "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+
+fast-deep-equal@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-fifo@^1.2.0, fast-fifo@^1.3.2:
   version "1.3.2"
   resolved "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz"
   integrity sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==
 
-fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.1.0:
+fast-json-stable-stringify@^2.1.0, fast-json-stable-stringify@2.x:
   version "2.1.0"
   resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -2325,7 +2241,7 @@ fb-watchman@^2.0.2:
 
 fetch-blob@^3.1.2, fetch-blob@^3.1.4:
   version "3.2.0"
-  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
+  resolved "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz"
   integrity sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==
   dependencies:
     node-domexception "^1.0.0"
@@ -2373,6 +2289,21 @@ follow-redirects@^1.15.11:
   resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz"
   integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
 
+fontkit@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz"
+  integrity sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==
+  dependencies:
+    "@swc/helpers" "^0.5.12"
+    brotli "^1.3.2"
+    clone "^2.1.2"
+    dfa "^1.2.0"
+    fast-deep-equal "^3.1.3"
+    restructure "^3.0.0"
+    tiny-inflate "^1.0.3"
+    unicode-properties "^1.4.0"
+    unicode-trie "^2.0.0"
+
 foreground-child@^3.1.0:
   version "3.3.1"
   resolved "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz"
@@ -2394,7 +2325,7 @@ form-data@^4.0.0, form-data@^4.0.5:
 
 formdata-polyfill@^4.0.10:
   version "4.0.10"
-  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
+  resolved "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz"
   integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
   dependencies:
     fetch-blob "^3.1.2"
@@ -2440,16 +2371,16 @@ function-bind@^1.1.2:
 
 gaxios@^7.0.0, gaxios@^7.1.4:
   version "7.1.4"
-  resolved "https://registry.yarnpkg.com/gaxios/-/gaxios-7.1.4.tgz#33a5b78e2c5c01cf5a5d17f58dd188839867fc9c"
+  resolved "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz"
   integrity sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==
   dependencies:
     extend "^3.0.2"
     https-proxy-agent "^7.0.1"
     node-fetch "^3.3.2"
 
-gcp-metadata@8.1.2:
+gcp-metadata@^7.0.1, gcp-metadata@8.1.2:
   version "8.1.2"
-  resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-8.1.2.tgz#e62e3373ddf41fc727ccc31c55c687b798bee898"
+  resolved "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz"
   integrity sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==
   dependencies:
     gaxios "^7.0.0"
@@ -2533,7 +2464,7 @@ glob@^7.1.4:
 
 google-auth-library@^10.6.2:
   version "10.6.2"
-  resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-10.6.2.tgz#44557c536aec626b7cda48a85b5d026e2c9b74c4"
+  resolved "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz"
   integrity sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==
   dependencies:
     base64-js "^1.3.0"
@@ -2543,9 +2474,9 @@ google-auth-library@^10.6.2:
     google-logging-utils "1.1.3"
     jws "^4.0.0"
 
-google-logging-utils@1.1.3, google-logging-utils@^1.0.0:
+google-logging-utils@^1.0.0, google-logging-utils@1.1.3:
   version "1.1.3"
-  resolved "https://registry.yarnpkg.com/google-logging-utils/-/google-logging-utils-1.1.3.tgz#17b71f1f95d266d2ddd356b8f00178433f041b17"
+  resolved "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz"
   integrity sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==
 
 gopd@^1.2.0:
@@ -2640,7 +2571,17 @@ ignore-by-default@^1.0.1:
   resolved "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz"
   integrity sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==
 
-import-in-the-middle@^2.0.0, import-in-the-middle@^2.0.6:
+import-in-the-middle@^2.0.0:
+  version "2.0.6"
+  resolved "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz"
+  integrity sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==
+  dependencies:
+    acorn "^8.15.0"
+    acorn-import-attributes "^1.9.5"
+    cjs-module-lexer "^2.2.0"
+    module-details-from-path "^1.0.4"
+
+import-in-the-middle@^2.0.6:
   version "2.0.6"
   resolved "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz"
   integrity sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==
@@ -2681,7 +2622,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3, inherits@~2.0.4:
+inherits@^2.0.3, inherits@~2.0.4, inherits@2:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -2995,7 +2936,7 @@ jest-resolve-dependencies@30.3.0:
     jest-regex-util "30.0.1"
     jest-snapshot "30.3.0"
 
-jest-resolve@30.3.0:
+jest-resolve@*, jest-resolve@30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.3.0.tgz"
   integrity sha512-NRtTAHQlpd15F9rUR36jqwelbrDV/dY4vzNte3S2kxCKUJRYNd5/6nTSbYiak1VX5g8IoFF23Uj5TURkUW8O5g==
@@ -3092,7 +3033,7 @@ jest-snapshot@30.3.0:
     semver "^7.7.2"
     synckit "^0.11.8"
 
-jest-util@30.3.0:
+"jest-util@^29.0.0 || ^30.0.0", jest-util@30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz"
   integrity sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==
@@ -3141,7 +3082,7 @@ jest-worker@30.3.0:
     merge-stream "^2.0.0"
     supports-color "^8.1.1"
 
-jest@^30.3.0:
+"jest@^29.0.0 || ^30.0.0", jest@^30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/jest/-/jest-30.3.0.tgz"
   integrity sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==
@@ -3150,6 +3091,11 @@ jest@^30.3.0:
     "@jest/types" "30.3.0"
     import-local "^3.2.0"
     jest-cli "30.3.0"
+
+js-md5@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz"
+  integrity sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -3171,7 +3117,7 @@ jsesc@^3.0.2:
 
 json-bigint@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/json-bigint/-/json-bigint-1.0.0.tgz#ae547823ac0cad8398667f8cd9ef4730f5b01ff1"
+  resolved "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz"
   integrity sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==
   dependencies:
     bignumber.js "^9.0.0"
@@ -3183,7 +3129,7 @@ json-parse-even-better-errors@^2.3.0:
 
 json-schema-to-ts@^3.1.1:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz#81f3acaf5a34736492f6f5f51870ef9ece1ca853"
+  resolved "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz"
   integrity sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==
   dependencies:
     "@babel/runtime" "^7.18.3"
@@ -3236,6 +3182,14 @@ leven@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz"
   integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
+
+linebreak@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz"
+  integrity sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==
+  dependencies:
+    base64-js "0.0.8"
+    unicode-trie "^2.0.0"
 
 lines-and-columns@^1.1.6:
   version "1.2.4"
@@ -3467,6 +3421,15 @@ mongodb-memory-server@^11.0.1:
     mongodb-memory-server-core "11.0.1"
     tslib "^2.8.1"
 
+mongodb@^7.0.0:
+  version "7.1.1"
+  resolved "https://registry.npmjs.org/mongodb/-/mongodb-7.1.1.tgz"
+  integrity sha512-067DXiMjcpYQl6bGjWQoTUEE9UoRViTtKFcoqX7z08I+iDZv/emH1g8XEFiO3qiDfXAheT5ozl1VffDTKhIW/w==
+  dependencies:
+    "@mongodb-js/saslprep" "^1.3.0"
+    bson "^7.1.1"
+    mongodb-connection-string-url "^7.0.0"
+
 mongodb@5.9.2:
   version "5.9.2"
   resolved "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz"
@@ -3477,15 +3440,6 @@ mongodb@5.9.2:
     socks "^2.7.1"
   optionalDependencies:
     "@mongodb-js/saslprep" "^1.1.0"
-
-mongodb@^7.0.0:
-  version "7.1.1"
-  resolved "https://registry.npmjs.org/mongodb/-/mongodb-7.1.1.tgz"
-  integrity sha512-067DXiMjcpYQl6bGjWQoTUEE9UoRViTtKFcoqX7z08I+iDZv/emH1g8XEFiO3qiDfXAheT5ozl1VffDTKhIW/w==
-  dependencies:
-    "@mongodb-js/saslprep" "^1.3.0"
-    bson "^7.1.1"
-    mongodb-connection-string-url "^7.0.0"
 
 mongoose@^7.6.3:
   version "7.8.9"
@@ -3512,6 +3466,11 @@ mquery@5.0.0:
   dependencies:
     debug "4.x"
 
+ms@^2.1.1, ms@^2.1.3, ms@2.1.3:
+  version "2.1.3"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
@@ -3521,11 +3480,6 @@ ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
-
-ms@2.1.3, ms@^2.1.1, ms@^2.1.3:
-  version "2.1.3"
-  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
-  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 multer@^2.1.1:
   version "2.1.1"
@@ -3566,12 +3520,12 @@ new-find-package-json@^2.0.0:
 
 node-domexception@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
+  resolved "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz"
   integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
 
 node-fetch@^3.3.2:
   version "3.3.2"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.3.2.tgz#d1e889bacdf733b4ff3b2b243eb7a12866a0b78b"
+  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz"
   integrity sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==
   dependencies:
     data-uri-to-buffer "^4.0.0"
@@ -3590,7 +3544,7 @@ node-releases@^2.0.27:
 
 node-rsa@^1.1.1:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/node-rsa/-/node-rsa-1.1.1.tgz#efd9ad382097782f506153398496f79e4464434d"
+  resolved "https://registry.npmjs.org/node-rsa/-/node-rsa-1.1.1.tgz"
   integrity sha512-Jd4cvbJMryN21r5HgxQOpMEqv+ooke/korixNNK3mGqfGJmy0M77WDDzo/05969+OkMy3XW1UuZsSmW9KQm7Fw==
   dependencies:
     asn1 "^0.2.4"
@@ -3685,6 +3639,11 @@ package-json-from-dist@^1.0.0:
   resolved "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz"
   integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
 
+pako@^0.2.5:
+  version "0.2.9"
+  resolved "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz"
+  integrity sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==
+
 parse-json@^5.2.0:
   version "5.2.0"
   resolved "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz"
@@ -3728,6 +3687,18 @@ path-to-regexp@~0.1.12:
   resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz"
   integrity sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==
 
+pdfkit@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.npmjs.org/pdfkit/-/pdfkit-0.18.0.tgz"
+  integrity sha512-NvUwSDZ0eYEzqAiWwVQkRkjYUkZ48kcsHuCO31ykqPPIVkwoSDjDGiwIgHHNtsiwls3z3P/zy4q00hl2chg2Ug==
+  dependencies:
+    "@noble/ciphers" "^1.0.0"
+    "@noble/hashes" "^1.6.0"
+    fontkit "^2.0.4"
+    js-md5 "^0.8.3"
+    linebreak "^1.1.0"
+    png-js "^1.0.0"
+
 pend@~1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
@@ -3759,7 +3730,12 @@ picocolors@^1.1.1:
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^2.0.4, picomatch@^2.2.1:
+picomatch@^2.0.4:
+  version "2.3.1"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
+  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+picomatch@^2.2.1:
   version "2.3.1"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -3780,6 +3756,11 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+png-js@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz"
+  integrity sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g==
 
 postgres-array@~2.0.0:
   version "2.0.0"
@@ -3803,7 +3784,7 @@ postgres-interval@^1.1.0:
   dependencies:
     xtend "^4.0.0"
 
-pretty-format@30.3.0, pretty-format@^30.0.0:
+pretty-format@^30.0.0, pretty-format@30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz"
   integrity sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==
@@ -3910,7 +3891,12 @@ resolve-from@^5.0.0:
   resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
-safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@~5.2.0:
+restructure@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz"
+  integrity sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==
+
+safe-buffer@^5.0.1, safe-buffer@~5.2.0, safe-buffer@5.2.1:
   version "5.2.1"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -3920,7 +3906,12 @@ safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@~5.2.0:
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-semver@^6.0.0, semver@^6.3.1:
+semver@^6.0.0:
+  version "6.3.1"
+  resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
+  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
@@ -3959,7 +3950,7 @@ serve-static@~1.16.2:
     parseurl "~1.3.3"
     send "~0.19.1"
 
-setprototypeof@1.2.0, setprototypeof@~1.2.0:
+setprototypeof@~1.2.0, setprototypeof@1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
@@ -4048,7 +4039,7 @@ smart-buffer@^4.2.0:
   resolved "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz"
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
 
-socks@^2.7.1:
+socks@^2.7.1, socks@^2.8.6:
   version "2.8.7"
   resolved "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz"
   integrity sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==
@@ -4107,6 +4098,13 @@ streamx@^2.12.5, streamx@^2.15.0, streamx@^2.25.0:
     fast-fifo "^1.3.2"
     text-decoder "^1.1.0"
 
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
+
 string-length@^4.0.2:
   version "4.0.2"
   resolved "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz"
@@ -4129,7 +4127,16 @@ string-similarity@^4.0.4:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+string-width@^4.1.0, string-width@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4146,13 +4153,6 @@ string-width@^5.0.1, string-width@^5.1.2:
     eastasianwidth "^0.2.0"
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
-
-string_decoder@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
-  dependencies:
-    safe-buffer "~5.2.0"
 
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
@@ -4275,6 +4275,11 @@ text-decoder@^1.1.0:
   dependencies:
     b4a "^1.6.4"
 
+tiny-inflate@^1.0.0, tiny-inflate@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz"
+  integrity sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==
+
 tmpl@1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz"
@@ -4313,7 +4318,7 @@ tr46@^5.1.0:
 
 ts-algebra@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ts-algebra/-/ts-algebra-2.0.0.tgz#4e3e0953878f26518fce7f6bb115064a65388b7a"
+  resolved "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz"
   integrity sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==
 
 ts-jest@^29.4.6:
@@ -4331,7 +4336,7 @@ ts-jest@^29.4.6:
     type-fest "^4.41.0"
     yargs-parser "^21.1.1"
 
-ts-node@^10.9.1:
+ts-node@^10.9.1, ts-node@>=9.0.0:
   version "10.9.1"
   resolved "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz"
   integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
@@ -4350,7 +4355,7 @@ ts-node@^10.9.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-tslib@^2.4.0, tslib@^2.8.1:
+tslib@^2.4.0, tslib@^2.8.0, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -4383,7 +4388,7 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^5.2.2:
+typescript@^5.2.2, typescript@>=2.7, "typescript@>=4.3 <6":
   version "5.2.2"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz"
   integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
@@ -4402,6 +4407,22 @@ undici-types@~5.25.1:
   version "5.25.3"
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz"
   integrity sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==
+
+unicode-properties@^1.4.0:
+  version "1.4.1"
+  resolved "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz"
+  integrity sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==
+  dependencies:
+    base64-js "^1.3.0"
+    unicode-trie "^2.0.0"
+
+unicode-trie@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz"
+  integrity sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==
+  dependencies:
+    pako "^0.2.5"
+    tiny-inflate "^1.0.0"
 
 unpipe@~1.0.0:
   version "1.0.0"
@@ -4486,7 +4507,7 @@ walker@^1.0.8:
 
 web-streams-polyfill@^3.0.3:
   version "3.3.3"
-  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz#2073b91a2fdb1fbfbd401e7de0ac9f8214cecb4b"
+  resolved "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz"
   integrity sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==
 
 webidl-conversions@^7.0.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1526,6 +1526,14 @@ append-field@^1.0.0:
   resolved "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz"
   integrity sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==
 
+apple-signin-auth@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/apple-signin-auth/-/apple-signin-auth-2.0.0.tgz#429a41a9df266eb43f59e7bd0255ff5766cff8ee"
+  integrity sha512-/O5gvAby7OU2K7baYQCzY0e0tCiHzhFkzt9L2v3bMd2I2w0ckCZ/4hdVUOrbolRGMppME+Zo8TAKPVru8aYnzg==
+  dependencies:
+    jsonwebtoken "^9.0.0"
+    node-rsa "^1.1.1"
+
 arg@^4.1.0:
   version "4.1.3"
   resolved "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz"
@@ -1547,6 +1555,13 @@ asap@^2.0.0:
   version "2.0.6"
   resolved "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz"
   integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
+
+asn1@^0.2.4:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.6.tgz#0d3a7bb6e64e02a90c0303b31f292868ea09a08d"
+  integrity sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==
+  dependencies:
+    safer-buffer "~2.1.0"
 
 async-mutex@^0.5.0:
   version "0.5.0"
@@ -3179,7 +3194,7 @@ json5@^2.2.3:
   resolved "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-jsonwebtoken@^9.0.2:
+jsonwebtoken@^9.0.0, jsonwebtoken@^9.0.2:
   version "9.0.3"
   resolved "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz"
   integrity sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==
@@ -3573,6 +3588,13 @@ node-releases@^2.0.27:
   resolved "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz"
   integrity sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==
 
+node-rsa@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/node-rsa/-/node-rsa-1.1.1.tgz#efd9ad382097782f506153398496f79e4464434d"
+  integrity sha512-Jd4cvbJMryN21r5HgxQOpMEqv+ooke/korixNNK3mGqfGJmy0M77WDDzo/05969+OkMy3XW1UuZsSmW9KQm7Fw==
+  dependencies:
+    asn1 "^0.2.4"
+
 nodemon@^3.0.1:
   version "3.1.14"
   resolved "https://registry.npmjs.org/nodemon/-/nodemon-3.1.14.tgz"
@@ -3893,7 +3915,7 @@ safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@~5.2.0:
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
-"safer-buffer@>= 2.1.2 < 3":
+"safer-buffer@>= 2.1.2 < 3", safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,6 +9,16 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
+"@fastify/otel@0.17.1":
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/@fastify/otel/-/otel-0.17.1.tgz#a7f13edc40dbc2e0c2a59d54e388f11e4d2235ce"
+  integrity sha512-K4wyxfUZx2ux5o+b6BtTqouYFVILohLZmSbA2tKUueJstNcBnoGPVhllCaOvbQ3ZrXdUxUC/fyrSWSCqHhdOPg==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.212.0"
+    "@opentelemetry/semantic-conventions" "^1.28.0"
+    minimatch "^10.2.4"
+
 "@jridgewell/resolve-uri@^3.0.3":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz#c08679063f279615a3326583ba3a90d1d82cc721"
@@ -33,6 +43,365 @@
   integrity sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==
   dependencies:
     sparse-bitfield "^3.0.3"
+
+"@opentelemetry/api-logs@0.207.0":
+  version "0.207.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api-logs/-/api-logs-0.207.0.tgz#ae991c51eedda55af037a3e6fc1ebdb12b289f49"
+  integrity sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==
+  dependencies:
+    "@opentelemetry/api" "^1.3.0"
+
+"@opentelemetry/api-logs@0.212.0":
+  version "0.212.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api-logs/-/api-logs-0.212.0.tgz#ec66a0951b84b1f082e13fd8a027b9f9d65a3f7a"
+  integrity sha512-TEEVrLbNROUkYY51sBJGk7lO/OLjuepch8+hmpM6ffMJQ2z/KVCjdHuCFX6fJj8OkJP2zckPjrJzQtXU3IAsFg==
+  dependencies:
+    "@opentelemetry/api" "^1.3.0"
+
+"@opentelemetry/api-logs@0.213.0":
+  version "0.213.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api-logs/-/api-logs-0.213.0.tgz#c7abc7d3c4586cfbfd737c0a2fcfb2323a9def75"
+  integrity sha512-zRM5/Qj6G84Ej3F1yt33xBVY/3tnMxtL1fiDIxYbDWYaZ/eudVw3/PBiZ8G7JwUxXxjW8gU4g6LnOyfGKYHYgw==
+  dependencies:
+    "@opentelemetry/api" "^1.3.0"
+
+"@opentelemetry/api@^1.3.0", "@opentelemetry/api@^1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.0.tgz#d03eba68273dc0f7509e2a3d5cba21eae10379fe"
+  integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
+
+"@opentelemetry/context-async-hooks@^2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.0.tgz#6c824e900630b378233c1a78ca7f0dc5a3b460b2"
+  integrity sha512-L8UyDwqpTcbkIK5cgwDRDYDoEhQoj8wp8BwsO19w3LB1Z41yEQm2VJyNfAi9DrLP/YTqXqWpKHyZfR9/tFYo1Q==
+
+"@opentelemetry/core@2.6.0", "@opentelemetry/core@^2.0.0", "@opentelemetry/core@^2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-2.6.0.tgz#719c829ed98bd7af808a2d2c83374df1fd1f3c66"
+  integrity sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==
+  dependencies:
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/instrumentation-amqplib@0.60.0":
+  version "0.60.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.60.0.tgz#a2b2abe3cf433bea166c18a703c8ddf6accf83da"
+  integrity sha512-q/B2IvoVXRm1M00MvhnzpMN6rKYOszPXVsALi6u0ss4AYHe+TidZEtLW9N1ZhrobI1dSriHnBqqtAOZVAv07sg==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.213.0"
+    "@opentelemetry/semantic-conventions" "^1.33.0"
+
+"@opentelemetry/instrumentation-connect@0.56.0":
+  version "0.56.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.56.0.tgz#8d846d2f7cf1f6b2723e5b0ff5595e8d31cb7446"
+  integrity sha512-PKp+sSZ7AfzMvGgO3VCyo1inwNu+q7A1k9X88WK4PQ+S6Hp7eFk8pie+sWHDTaARovmqq5V2osav3lQej2B0nw==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.213.0"
+    "@opentelemetry/semantic-conventions" "^1.27.0"
+    "@types/connect" "3.4.38"
+
+"@opentelemetry/instrumentation-dataloader@0.30.0":
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.30.0.tgz#7fbea57b27165324092639abf090ca3697eb7a80"
+  integrity sha512-MXHP2Q38cd2OhzEBKAIXUi9uBlPEYzF6BNJbyjUXBQ6kLaf93kRC41vNMIz0Nl5mnuwK7fDvKT+/lpx7BXRwdg==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.213.0"
+
+"@opentelemetry/instrumentation-express@0.61.0":
+  version "0.61.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-express/-/instrumentation-express-0.61.0.tgz#49b4d144ab6e9d6e035941a51f5e573e84e3647f"
+  integrity sha512-Xdmqo9RZuZlL29Flg8QdwrrX7eW1CZ7wFQPKHyXljNymgKhN1MCsYuqQ/7uxavhSKwAl7WxkTzKhnqpUApLMvQ==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.213.0"
+    "@opentelemetry/semantic-conventions" "^1.27.0"
+
+"@opentelemetry/instrumentation-fs@0.32.0":
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.32.0.tgz#2010d86da8ab3d543f8e44c8fff81b94f904d91d"
+  integrity sha512-koR6apx0g0wX6RRiPpjA4AFQUQUbXrK16kq4/SZjVp7u5cffJhNkY4TnITxcGA4acGSPYAfx3NHRIv4Khn1axQ==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.213.0"
+
+"@opentelemetry/instrumentation-generic-pool@0.56.0":
+  version "0.56.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.56.0.tgz#01560f52d5bac6fb6312a1f0bc74bf0939119894"
+  integrity sha512-fg+Jffs6fqrf0uQS0hom7qBFKsbtpBiBl8+Vkc63Gx8xh6pVh+FhagmiO6oM0m3vyb683t1lP7yGYq22SiDnqg==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.213.0"
+
+"@opentelemetry/instrumentation-graphql@0.61.0":
+  version "0.61.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.61.0.tgz#d1f896095a891c9576967645e7fcba935da82a94"
+  integrity sha512-pUiVASv6nh2XrerTvlbVHh7vKFzscpgwiQ/xvnZuAIzQ5lRjWVdRPUuXbvZJ/Yq79QsE81TZdJ7z9YsXiss1ew==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.213.0"
+
+"@opentelemetry/instrumentation-hapi@0.59.0":
+  version "0.59.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.59.0.tgz#412ea19e97ead684c5737e1f1aaa19ff940512d3"
+  integrity sha512-33wa4mEr+9+ztwdgLor1SeBu4Opz4IsmpcLETXAd3VmBrOjez8uQtrsOhPCa5Vhbm5gzDlMYTgFRLQzf8/YHFA==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.213.0"
+    "@opentelemetry/semantic-conventions" "^1.27.0"
+
+"@opentelemetry/instrumentation-http@0.213.0":
+  version "0.213.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-http/-/instrumentation-http-0.213.0.tgz#b379d6bcbae43a7d6d54070f3794527021f176c9"
+  integrity sha512-B978Xsm5XEPGhm1P07grDoaOFLHapJPkOG9h016cJsyWWxmiLnPu2M/4Nrm7UCkHSiLnkXgC+zVGUAIahy8EEA==
+  dependencies:
+    "@opentelemetry/core" "2.6.0"
+    "@opentelemetry/instrumentation" "0.213.0"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+    forwarded-parse "2.1.2"
+
+"@opentelemetry/instrumentation-ioredis@0.61.0":
+  version "0.61.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.61.0.tgz#e862540cbf188d0ca368d3a75020d165cb8beefb"
+  integrity sha512-hsHDadUtAFbws1YSDc1XW0svGFKiUbqv2td1Cby+UAiwvojm1NyBo/taifH0t8CuFZ0x/2SDm0iuTwrM5pnVOg==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.213.0"
+    "@opentelemetry/redis-common" "^0.38.2"
+    "@opentelemetry/semantic-conventions" "^1.33.0"
+
+"@opentelemetry/instrumentation-kafkajs@0.22.0":
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.22.0.tgz#a3cf7aca003f96211e514a348b7568799efdfba1"
+  integrity sha512-wJU4IBQMUikdJAcTChLFqK5lo+flo7pahqd8DSLv7uMxsdOdAHj6RzKYAm8pPfUS6ItKYutYyuicwKaFwQKsoA==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.213.0"
+    "@opentelemetry/semantic-conventions" "^1.30.0"
+
+"@opentelemetry/instrumentation-knex@0.57.0":
+  version "0.57.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.57.0.tgz#d46622a3f82f3df2ba29c64498d6ef828a40457e"
+  integrity sha512-vMCSh8kolEm5rRsc+FZeTZymWmIJwc40hjIKnXH4O0Dv/gAkJJIRXCsPX5cPbe0c0j/34+PsENd0HqKruwhVYw==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.213.0"
+    "@opentelemetry/semantic-conventions" "^1.33.1"
+
+"@opentelemetry/instrumentation-koa@0.61.0":
+  version "0.61.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.61.0.tgz#c12f57b023834afb1c142c11746d560bcc288b5b"
+  integrity sha512-lvrfWe9ShK/D2X4brmx8ZqqeWPfRl8xekU0FCn7C1dHm5k6+rTOOi36+4fnaHAP8lig9Ux6XQ1D4RNIpPCt1WQ==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.213.0"
+    "@opentelemetry/semantic-conventions" "^1.36.0"
+
+"@opentelemetry/instrumentation-lru-memoizer@0.57.0":
+  version "0.57.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.57.0.tgz#4da92ecd1bc5d5e9c7de28ea14ed57c9f29cfefd"
+  integrity sha512-cEqpUocSKJfwDtLYTTJehRLWzkZ2eoePCxfVIgGkGkb83fMB71O+y4MvRHJPbeV2bdoWdOVrl8uO0+EynWhTEA==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.213.0"
+
+"@opentelemetry/instrumentation-mongodb@0.66.0":
+  version "0.66.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.66.0.tgz#990bf4571382d3b02a9584927411c92c375d2fd4"
+  integrity sha512-d7m9QnAY+4TCWI4q1QRkfrc6fo/92VwssaB1DzQfXNRvu51b78P+HJlWP7Qg6N6nkwdb9faMZNBCZJfftmszkw==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.213.0"
+    "@opentelemetry/semantic-conventions" "^1.33.0"
+
+"@opentelemetry/instrumentation-mongoose@0.59.0":
+  version "0.59.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.59.0.tgz#8446ece86df59f09c630e7df6d794c8cd08f58d8"
+  integrity sha512-6/jWU+c1NgznkVLDU/2y0bXV2nJo3o9FWZ9mZ9nN6T/JBNRoMnVXZl2FdBmgH+a5MwaWLs5kmRJTP5oUVGIkPw==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.213.0"
+    "@opentelemetry/semantic-conventions" "^1.33.0"
+
+"@opentelemetry/instrumentation-mysql2@0.59.0":
+  version "0.59.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.59.0.tgz#938cd4a294b7e4a6e8c3855b8cfe267c8d2e5493"
+  integrity sha512-n9/xrVCRBfG9egVbffnlU1uhr+HX0vF4GgtAB/Bvm48wpFgRidqD8msBMiym1kRYzmpWvJqTxNT47u1MkgBEdw==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.213.0"
+    "@opentelemetry/semantic-conventions" "^1.33.0"
+    "@opentelemetry/sql-common" "^0.41.2"
+
+"@opentelemetry/instrumentation-mysql@0.59.0":
+  version "0.59.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.59.0.tgz#bf43cafbac5928236ea53704a52c718349c22e38"
+  integrity sha512-r+V/Fh0sm7Ga8/zk/TI5H5FQRAjwr0RrpfPf8kNIehlsKf12XnvIaZi8ViZkpX0gyPEpLXqzqWD6QHlgObgzZw==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.213.0"
+    "@opentelemetry/semantic-conventions" "^1.33.0"
+    "@types/mysql" "2.15.27"
+
+"@opentelemetry/instrumentation-pg@0.65.0":
+  version "0.65.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.65.0.tgz#f1f76f8c57c5c6fec68c77ce6ee104fee5de13e1"
+  integrity sha512-W0zpHEIEuyZ8zvb3njaX9AAbHgPYOsSWVOoWmv1sjVRSF6ZpBqtlxBWbU+6hhq1TFWBeWJOXZ8nZS/PUFpLJYQ==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.213.0"
+    "@opentelemetry/semantic-conventions" "^1.34.0"
+    "@opentelemetry/sql-common" "^0.41.2"
+    "@types/pg" "8.15.6"
+    "@types/pg-pool" "2.0.7"
+
+"@opentelemetry/instrumentation-redis@0.61.0":
+  version "0.61.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.61.0.tgz#b43b9c3b5d0b124f2e60b055e4529a3a4b55dbc4"
+  integrity sha512-JnPexA034/0UJRsvH96B0erQoNOqKJZjE2ZRSw9hiTSC23LzE0nJE/u6D+xqOhgUhRnhhcPHq4MdYtmUdYTF+Q==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.213.0"
+    "@opentelemetry/redis-common" "^0.38.2"
+    "@opentelemetry/semantic-conventions" "^1.27.0"
+
+"@opentelemetry/instrumentation-tedious@0.32.0":
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.32.0.tgz#8204a14adb71adcbf7d72705244d606bb69e428a"
+  integrity sha512-BQS6gG8RJ1foEqfEZ+wxoqlwfCAzb1ZVG0ad8Gfe4x8T658HJCLGLd4E4NaoQd8EvPfLqOXgzGaE/2U4ytDSWA==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.213.0"
+    "@opentelemetry/semantic-conventions" "^1.33.0"
+    "@types/tedious" "^4.0.14"
+
+"@opentelemetry/instrumentation-undici@0.23.0":
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.23.0.tgz#e328bf6e53847ba7baa2a345d02221cc62917cec"
+  integrity sha512-LL0VySzKVR2cJSFVZaTYpZl1XTpBGnfzoQPe2W7McS2267ldsaEIqtQY6VXs2KCXN0poFjze5110PIpxHDaDGg==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+    "@opentelemetry/instrumentation" "^0.213.0"
+    "@opentelemetry/semantic-conventions" "^1.24.0"
+
+"@opentelemetry/instrumentation@0.213.0", "@opentelemetry/instrumentation@^0.213.0":
+  version "0.213.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation/-/instrumentation-0.213.0.tgz#55362569efd0cba00aab9921a78dd20dfddf70b6"
+  integrity sha512-3i9NdkET/KvQomeh7UaR/F4r9P25Rx6ooALlWXPIjypcEOUxksCmVu0zA70NBJWlrMW1rPr/LRidFAflLI+s/w==
+  dependencies:
+    "@opentelemetry/api-logs" "0.213.0"
+    import-in-the-middle "^3.0.0"
+    require-in-the-middle "^8.0.0"
+
+"@opentelemetry/instrumentation@^0.207.0":
+  version "0.207.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation/-/instrumentation-0.207.0.tgz#1a5a921c04f171ff28096fa320af713f3c87ec14"
+  integrity sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA==
+  dependencies:
+    "@opentelemetry/api-logs" "0.207.0"
+    import-in-the-middle "^2.0.0"
+    require-in-the-middle "^8.0.0"
+
+"@opentelemetry/instrumentation@^0.212.0":
+  version "0.212.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation/-/instrumentation-0.212.0.tgz#238b6e3e2131217ff4acfe7e8e7b6ce1f0ac0ba0"
+  integrity sha512-IyXmpNnifNouMOe0I/gX7ENfv2ZCNdYTF0FpCsoBcpbIHzk81Ww9rQTYTnvghszCg7qGrIhNvWC8dhEifgX9Jg==
+  dependencies:
+    "@opentelemetry/api-logs" "0.212.0"
+    import-in-the-middle "^2.0.6"
+    require-in-the-middle "^8.0.0"
+
+"@opentelemetry/redis-common@^0.38.2":
+  version "0.38.2"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/redis-common/-/redis-common-0.38.2.tgz#cefa4f3e79db1cd54f19e233b7dfb56621143955"
+  integrity sha512-1BCcU93iwSRZvDAgwUxC/DV4T/406SkMfxGqu5ojc3AvNI+I9GhV7v0J1HljsczuuhcnFLYqD5VmwVXfCGHzxA==
+
+"@opentelemetry/resources@2.6.0", "@opentelemetry/resources@^2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/resources/-/resources-2.6.0.tgz#1a945dbb8986043d8b593c358d5d8e3de6becf5a"
+  integrity sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ==
+  dependencies:
+    "@opentelemetry/core" "2.6.0"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/sdk-trace-base@^2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.0.tgz#d7e752a0906f2bcae3c1261e224aef3e3b3746f9"
+  integrity sha512-g/OZVkqlxllgFM7qMKqbPV9c1DUPhQ7d4n3pgZFcrnrNft9eJXZM2TNHTPYREJBrtNdRytYyvwjgL5geDKl3EQ==
+  dependencies:
+    "@opentelemetry/core" "2.6.0"
+    "@opentelemetry/resources" "2.6.0"
+    "@opentelemetry/semantic-conventions" "^1.29.0"
+
+"@opentelemetry/semantic-conventions@^1.24.0", "@opentelemetry/semantic-conventions@^1.27.0", "@opentelemetry/semantic-conventions@^1.28.0", "@opentelemetry/semantic-conventions@^1.29.0", "@opentelemetry/semantic-conventions@^1.30.0", "@opentelemetry/semantic-conventions@^1.33.0", "@opentelemetry/semantic-conventions@^1.33.1", "@opentelemetry/semantic-conventions@^1.34.0", "@opentelemetry/semantic-conventions@^1.36.0", "@opentelemetry/semantic-conventions@^1.40.0":
+  version "1.40.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz#10b2944ca559386590683392022a897eefd011d3"
+  integrity sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==
+
+"@opentelemetry/sql-common@^0.41.2":
+  version "0.41.2"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sql-common/-/sql-common-0.41.2.tgz#7f4a14166cfd6c9ffe89096db1cc75eaf6443b19"
+  integrity sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==
+  dependencies:
+    "@opentelemetry/core" "^2.0.0"
+
+"@prisma/instrumentation@7.4.2":
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/@prisma/instrumentation/-/instrumentation-7.4.2.tgz#b05e814d0647343febd26a8ccb039d27ccc69eca"
+  integrity sha512-r9JfchJF1Ae6yAxcaLu/V1TGqBhAuSDe3mRNOssBfx1rMzfZ4fdNvrgUBwyb/TNTGXFxlH9AZix5P257x07nrg==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.207.0"
+
+"@sentry/core@10.45.0":
+  version "10.45.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-10.45.0.tgz#4bac78dd4815588d0089e6594ab20da5b5ed467e"
+  integrity sha512-s69UXxvefeQxuZ5nY7/THtTrIEvJxNVCp3ns4kwoCw1qMpgpvn/296WCKVmM7MiwnaAdzEKnAvLAwaxZc2nM7Q==
+
+"@sentry/node-core@10.45.0":
+  version "10.45.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node-core/-/node-core-10.45.0.tgz#2cd5eb05cb2f76a12db644565993a70e6c3abe53"
+  integrity sha512-KQZEvLKM344+EqXiA9HIzWbW5hzq6/9nnFUQ8niaBPoOgR9AiJhrccfIscfgb8vjkriiEtzE03OW/4h1CTgZ3Q==
+  dependencies:
+    "@sentry/core" "10.45.0"
+    "@sentry/opentelemetry" "10.45.0"
+    import-in-the-middle "^3.0.0"
+
+"@sentry/node@^10.45.0":
+  version "10.45.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-10.45.0.tgz#1844dcddf7ec0e4d6722d61340099fb690aa25df"
+  integrity sha512-Kpiq9lRGnJc1ex8SwxOBl+FLQNl4Y137BydVooP7AFiAYZ6ftwHsIEF1bcYXaipHMT1YHS2bdhC2UQaaB2jkuQ==
+  dependencies:
+    "@fastify/otel" "0.17.1"
+    "@opentelemetry/api" "^1.9.0"
+    "@opentelemetry/context-async-hooks" "^2.6.0"
+    "@opentelemetry/core" "^2.6.0"
+    "@opentelemetry/instrumentation" "^0.213.0"
+    "@opentelemetry/instrumentation-amqplib" "0.60.0"
+    "@opentelemetry/instrumentation-connect" "0.56.0"
+    "@opentelemetry/instrumentation-dataloader" "0.30.0"
+    "@opentelemetry/instrumentation-express" "0.61.0"
+    "@opentelemetry/instrumentation-fs" "0.32.0"
+    "@opentelemetry/instrumentation-generic-pool" "0.56.0"
+    "@opentelemetry/instrumentation-graphql" "0.61.0"
+    "@opentelemetry/instrumentation-hapi" "0.59.0"
+    "@opentelemetry/instrumentation-http" "0.213.0"
+    "@opentelemetry/instrumentation-ioredis" "0.61.0"
+    "@opentelemetry/instrumentation-kafkajs" "0.22.0"
+    "@opentelemetry/instrumentation-knex" "0.57.0"
+    "@opentelemetry/instrumentation-koa" "0.61.0"
+    "@opentelemetry/instrumentation-lru-memoizer" "0.57.0"
+    "@opentelemetry/instrumentation-mongodb" "0.66.0"
+    "@opentelemetry/instrumentation-mongoose" "0.59.0"
+    "@opentelemetry/instrumentation-mysql" "0.59.0"
+    "@opentelemetry/instrumentation-mysql2" "0.59.0"
+    "@opentelemetry/instrumentation-pg" "0.65.0"
+    "@opentelemetry/instrumentation-redis" "0.61.0"
+    "@opentelemetry/instrumentation-tedious" "0.32.0"
+    "@opentelemetry/instrumentation-undici" "0.23.0"
+    "@opentelemetry/resources" "^2.6.0"
+    "@opentelemetry/sdk-trace-base" "^2.6.0"
+    "@opentelemetry/semantic-conventions" "^1.40.0"
+    "@prisma/instrumentation" "7.4.2"
+    "@sentry/core" "10.45.0"
+    "@sentry/node-core" "10.45.0"
+    "@sentry/opentelemetry" "10.45.0"
+    import-in-the-middle "^3.0.0"
+
+"@sentry/opentelemetry@10.45.0":
+  version "10.45.0"
+  resolved "https://registry.yarnpkg.com/@sentry/opentelemetry/-/opentelemetry-10.45.0.tgz#f5040c78e7e46e22d3a45e1777b21d26cbd33e94"
+  integrity sha512-PmuGO+p/gC3ZQ8ddOeJ5P9ApnTTm35i12Bpuyb13AckCbNSJFvG2ggZda35JQOmiFU0kKYiwkoFAa8Mvj9od3Q==
+  dependencies:
+    "@sentry/core" "10.45.0"
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.9"
@@ -71,6 +440,13 @@
   version "3.4.36"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.36.tgz#e511558c15a39cb29bd5357eebb57bd1459cd1ab"
   integrity sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==
+  dependencies:
+    "@types/node" "*"
+
+"@types/connect@3.4.38":
+  version "3.4.38"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.38.tgz#5ba7f3bc4fbbdeaff8dded952e5ff2cc53f8d858"
+  integrity sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==
   dependencies:
     "@types/node" "*"
 
@@ -129,6 +505,13 @@
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-2.1.0.tgz#052aa67a48eccc4309d7f0191b7e41434b90bb78"
   integrity sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==
 
+"@types/mysql@2.15.27":
+  version "2.15.27"
+  resolved "https://registry.yarnpkg.com/@types/mysql/-/mysql-2.15.27.tgz#fb13b0e8614d39d42f40f381217ec3215915f1e9"
+  integrity sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*":
   version "20.8.6"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.8.6.tgz#0dbd4ebcc82ad0128df05d0e6f57e05359ee47fa"
@@ -142,6 +525,31 @@
   integrity sha512-21TKHHh3eUHIi2MloeptJWALuCu5H7HQTdTrWIFReA8ad+aggoX+lRes3ex7/FtpC+sVUpFMQ+QTfYr74mruiQ==
   dependencies:
     undici-types "~5.25.1"
+
+"@types/pg-pool@2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/pg-pool/-/pg-pool-2.0.7.tgz#c17945a74472d9a3beaf8e66d5aa6fc938328734"
+  integrity sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==
+  dependencies:
+    "@types/pg" "*"
+
+"@types/pg@*":
+  version "8.20.0"
+  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-8.20.0.tgz#8bd03d3ac6b19143a8de7d66a9d13da32cd91526"
+  integrity sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==
+  dependencies:
+    "@types/node" "*"
+    pg-protocol "*"
+    pg-types "^2.2.0"
+
+"@types/pg@8.15.6":
+  version "8.15.6"
+  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-8.15.6.tgz#4df7590b9ac557cbe5479e0074ec1540cbddad9b"
+  integrity sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==
+  dependencies:
+    "@types/node" "*"
+    pg-protocol "*"
+    pg-types "^2.2.0"
 
 "@types/qs@*":
   version "6.9.8"
@@ -170,6 +578,13 @@
     "@types/mime" "*"
     "@types/node" "*"
 
+"@types/tedious@^4.0.14":
+  version "4.0.14"
+  resolved "https://registry.yarnpkg.com/@types/tedious/-/tedious-4.0.14.tgz#868118e7a67808258c05158e9cad89ca58a2aec1"
+  integrity sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/webidl-conversions@*":
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/@types/webidl-conversions/-/webidl-conversions-7.0.1.tgz#2b9a2062b39a7272343c185cdb884f2e52188f75"
@@ -191,10 +606,20 @@ accepts@~1.3.8:
     mime-types "~2.1.34"
     negotiator "0.6.3"
 
+acorn-import-attributes@^1.9.5:
+  version "1.9.5"
+  resolved "https://registry.yarnpkg.com/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz#7eb1557b1ba05ef18b5ed0ec67591bfab04688ef"
+  integrity sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==
+
 acorn-walk@^8.1.1:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
+acorn@^8.15.0:
+  version "8.16.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.16.0.tgz#4ce79c89be40afe7afe8f3adb902a1f1ce9ac08a"
+  integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
 
 acorn@^8.4.1:
   version "8.10.0"
@@ -304,6 +729,11 @@ chokidar@^3.5.2:
   optionalDependencies:
     fsevents "~2.3.2"
 
+cjs-module-lexer@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz#b3ca5101843389259ade7d88c77bd06ce55849ca"
+  integrity sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==
+
 content-disposition@0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.4.tgz#8b82b4efac82512a02bb0b1dcec9d2c5e8eb5bfe"
@@ -353,7 +783,7 @@ debug@4.x:
   dependencies:
     ms "2.1.2"
 
-debug@^4:
+debug@^4, debug@^4.3.5:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -472,6 +902,11 @@ finalhandler@1.2.0:
     statuses "2.0.1"
     unpipe "~1.0.0"
 
+forwarded-parse@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/forwarded-parse/-/forwarded-parse-2.1.2.tgz#08511eddaaa2ddfd56ba11138eee7df117a09325"
+  integrity sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==
+
 forwarded@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
@@ -551,6 +986,26 @@ ignore-by-default@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
   integrity sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==
+
+import-in-the-middle@^2.0.0, import-in-the-middle@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz#1972337bfe020d05f6b5e020c13334567436324f"
+  integrity sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==
+  dependencies:
+    acorn "^8.15.0"
+    acorn-import-attributes "^1.9.5"
+    cjs-module-lexer "^2.2.0"
+    module-details-from-path "^1.0.4"
+
+import-in-the-middle@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-3.0.0.tgz#720c12b4c07ea58b32a54667e70a022e18cc36a3"
+  integrity sha512-OnGy+eYT7wVejH2XWgLRgbmzujhhVIATQH0ztIeRilwHBjTeG3pD+XnH3PKX0r9gJ0BuJmJ68q/oh9qgXnNDQg==
+  dependencies:
+    acorn "^8.15.0"
+    acorn-import-attributes "^1.9.5"
+    cjs-module-lexer "^2.2.0"
+    module-details-from-path "^1.0.4"
 
 inherits@2.0.4:
   version "2.0.4"
@@ -711,12 +1166,17 @@ mime@1.6.0:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
-minimatch@^10.2.1:
+minimatch@^10.2.1, minimatch@^10.2.4:
   version "10.2.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.4.tgz#465b3accbd0218b8281f5301e27cedc697f96fde"
   integrity sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==
   dependencies:
     brace-expansion "^5.0.2"
+
+module-details-from-path@^1.0.3, module-details-from-path@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.4.tgz#b662fdcd93f6c83d3f25289da0ce81c8d9685b94"
+  integrity sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==
 
 mongodb-connection-string-url@^2.6.0:
   version "2.6.0"
@@ -830,10 +1290,53 @@ path-to-regexp@0.1.7:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==
 
+pg-int8@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
+  integrity sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==
+
+pg-protocol@*:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.13.0.tgz#fdaf6d020bca590d58bb991b4b16fc448efe0511"
+  integrity sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==
+
+pg-types@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/pg-types/-/pg-types-2.2.0.tgz#2d0250d636454f7cfa3b6ae0382fdfa8063254a3"
+  integrity sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==
+  dependencies:
+    pg-int8 "1.0.1"
+    postgres-array "~2.0.0"
+    postgres-bytea "~1.0.0"
+    postgres-date "~1.0.4"
+    postgres-interval "^1.1.0"
+
 picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+postgres-array@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/postgres-array/-/postgres-array-2.0.0.tgz#48f8fce054fbc69671999329b8834b772652d82e"
+  integrity sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==
+
+postgres-bytea@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/postgres-bytea/-/postgres-bytea-1.0.1.tgz#c40b3da0222c500ff1e51c5d7014b60b79697c7a"
+  integrity sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==
+
+postgres-date@~1.0.4:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/postgres-date/-/postgres-date-1.0.7.tgz#51bc086006005e5061c591cee727f2531bf641a8"
+  integrity sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==
+
+postgres-interval@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/postgres-interval/-/postgres-interval-1.2.0.tgz#b460c82cb1587507788819a06aa0fffdb3544695"
+  integrity sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==
+  dependencies:
+    xtend "^4.0.0"
 
 proxy-addr@~2.0.7:
   version "2.0.7"
@@ -881,6 +1384,14 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+require-in-the-middle@^8.0.0:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz#dbde2587f669398626d56b20c868ab87bf01cce4"
+  integrity sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==
+  dependencies:
+    debug "^4.3.5"
+    module-details-from-path "^1.0.3"
 
 safe-buffer@5.2.1, safe-buffer@^5.0.1:
   version "5.2.1"
@@ -1087,6 +1598,11 @@ whatwg-url@^11.0.0:
   dependencies:
     tr46 "^3.0.0"
     webidl-conversions "^7.0.0"
+
+xtend@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
+  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 yn@3.1.1:
   version "3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,7 +16,7 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz"
   integrity sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==
 
-"@babel/core@^7.23.9", "@babel/core@^7.27.4":
+"@babel/core@^7.0.0", "@babel/core@^7.0.0 || ^8.0.0-0", "@babel/core@^7.0.0-0", "@babel/core@^7.11.0 || ^8.0.0-0", "@babel/core@^7.11.0 || ^8.0.0-beta.1", "@babel/core@^7.23.9", "@babel/core@^7.27.4", "@babel/core@>=7.0.0-beta.0 <8":
   version "7.29.0"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz"
   integrity sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==
@@ -277,28 +277,6 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@emnapi/core@^1.4.3":
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.9.1.tgz#2143069c744ca2442074f8078462e51edd63c7bd"
-  integrity sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==
-  dependencies:
-    "@emnapi/wasi-threads" "1.2.0"
-    tslib "^2.4.0"
-
-"@emnapi/runtime@^1.4.3":
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.9.1.tgz#115ff2a0d589865be6bd8e9d701e499c473f2a8d"
-  integrity sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==
-  dependencies:
-    tslib "^2.4.0"
-
-"@emnapi/wasi-threads@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz#a19d9772cc3d195370bf6e2a805eec40aa75e18e"
-  integrity sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==
-  dependencies:
-    tslib "^2.4.0"
-
 "@fastify/otel@0.17.1":
   version "0.17.1"
   resolved "https://registry.npmjs.org/@fastify/otel/-/otel-0.17.1.tgz"
@@ -522,7 +500,7 @@
     jest-haste-map "30.3.0"
     slash "^3.0.0"
 
-"@jest/transform@30.3.0":
+"@jest/transform@^29.0.0 || ^30.0.0", "@jest/transform@30.3.0":
   version "30.3.0"
   resolved "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz"
   integrity sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==
@@ -542,7 +520,7 @@
     slash "^3.0.0"
     write-file-atomic "^5.0.1"
 
-"@jest/types@30.3.0":
+"@jest/types@^29.0.0 || ^30.0.0", "@jest/types@30.3.0":
   version "30.3.0"
   resolved "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz"
   integrity sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==
@@ -581,14 +559,6 @@
   resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
 
-"@jridgewell/trace-mapping@0.3.9":
-  version "0.3.9"
-  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz"
-  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
-  dependencies:
-    "@jridgewell/resolve-uri" "^3.0.3"
-    "@jridgewell/sourcemap-codec" "^1.4.10"
-
 "@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.23", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25", "@jridgewell/trace-mapping@^0.3.28":
   version "0.3.31"
   resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz"
@@ -597,21 +567,20 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+
 "@mongodb-js/saslprep@^1.1.0", "@mongodb-js/saslprep@^1.3.0":
   version "1.4.6"
   resolved "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.6.tgz"
   integrity sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==
   dependencies:
     sparse-bitfield "^3.0.3"
-
-"@napi-rs/wasm-runtime@^0.2.11":
-  version "0.2.12"
-  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz#3e78a8b96e6c33a6c517e1894efbd5385a7cb6f2"
-  integrity sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==
-  dependencies:
-    "@emnapi/core" "^1.4.3"
-    "@emnapi/runtime" "^1.4.3"
-    "@tybys/wasm-util" "^0.10.0"
 
 "@noble/hashes@^1.1.5":
   version "1.8.0"
@@ -639,17 +608,17 @@
   dependencies:
     "@opentelemetry/api" "^1.3.0"
 
-"@opentelemetry/api@^1.3.0", "@opentelemetry/api@^1.9.0":
+"@opentelemetry/api@^1.1.0", "@opentelemetry/api@^1.3.0", "@opentelemetry/api@^1.7.0", "@opentelemetry/api@^1.8", "@opentelemetry/api@^1.9.0", "@opentelemetry/api@>=1.0.0 <1.10.0", "@opentelemetry/api@>=1.3.0 <1.10.0":
   version "1.9.0"
   resolved "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz"
   integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
 
-"@opentelemetry/context-async-hooks@^2.6.0":
+"@opentelemetry/context-async-hooks@^1.30.1 || ^2.1.0", "@opentelemetry/context-async-hooks@^2.6.0":
   version "2.6.0"
   resolved "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.0.tgz"
   integrity sha512-L8UyDwqpTcbkIK5cgwDRDYDoEhQoj8wp8BwsO19w3LB1Z41yEQm2VJyNfAi9DrLP/YTqXqWpKHyZfR9/tFYo1Q==
 
-"@opentelemetry/core@2.6.0", "@opentelemetry/core@^2.0.0", "@opentelemetry/core@^2.6.0":
+"@opentelemetry/core@^1.30.1 || ^2.1.0", "@opentelemetry/core@^2.0.0", "@opentelemetry/core@^2.6.0", "@opentelemetry/core@2.6.0":
   version "2.6.0"
   resolved "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.0.tgz"
   integrity sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==
@@ -790,15 +759,6 @@
     "@opentelemetry/instrumentation" "^0.213.0"
     "@opentelemetry/semantic-conventions" "^1.33.0"
 
-"@opentelemetry/instrumentation-mysql2@0.59.0":
-  version "0.59.0"
-  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.59.0.tgz"
-  integrity sha512-n9/xrVCRBfG9egVbffnlU1uhr+HX0vF4GgtAB/Bvm48wpFgRidqD8msBMiym1kRYzmpWvJqTxNT47u1MkgBEdw==
-  dependencies:
-    "@opentelemetry/instrumentation" "^0.213.0"
-    "@opentelemetry/semantic-conventions" "^1.33.0"
-    "@opentelemetry/sql-common" "^0.41.2"
-
 "@opentelemetry/instrumentation-mysql@0.59.0":
   version "0.59.0"
   resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.59.0.tgz"
@@ -807,6 +767,15 @@
     "@opentelemetry/instrumentation" "^0.213.0"
     "@opentelemetry/semantic-conventions" "^1.33.0"
     "@types/mysql" "2.15.27"
+
+"@opentelemetry/instrumentation-mysql2@0.59.0":
+  version "0.59.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.59.0.tgz"
+  integrity sha512-n9/xrVCRBfG9egVbffnlU1uhr+HX0vF4GgtAB/Bvm48wpFgRidqD8msBMiym1kRYzmpWvJqTxNT47u1MkgBEdw==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.213.0"
+    "@opentelemetry/semantic-conventions" "^1.33.0"
+    "@opentelemetry/sql-common" "^0.41.2"
 
 "@opentelemetry/instrumentation-pg@0.65.0":
   version "0.65.0"
@@ -847,15 +816,6 @@
     "@opentelemetry/instrumentation" "^0.213.0"
     "@opentelemetry/semantic-conventions" "^1.24.0"
 
-"@opentelemetry/instrumentation@0.213.0", "@opentelemetry/instrumentation@^0.213.0":
-  version "0.213.0"
-  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.213.0.tgz"
-  integrity sha512-3i9NdkET/KvQomeh7UaR/F4r9P25Rx6ooALlWXPIjypcEOUxksCmVu0zA70NBJWlrMW1rPr/LRidFAflLI+s/w==
-  dependencies:
-    "@opentelemetry/api-logs" "0.213.0"
-    import-in-the-middle "^3.0.0"
-    require-in-the-middle "^8.0.0"
-
 "@opentelemetry/instrumentation@^0.207.0":
   version "0.207.0"
   resolved "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.207.0.tgz"
@@ -874,12 +834,21 @@
     import-in-the-middle "^2.0.6"
     require-in-the-middle "^8.0.0"
 
+"@opentelemetry/instrumentation@^0.213.0", "@opentelemetry/instrumentation@>=0.57.1 <1", "@opentelemetry/instrumentation@0.213.0":
+  version "0.213.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.213.0.tgz"
+  integrity sha512-3i9NdkET/KvQomeh7UaR/F4r9P25Rx6ooALlWXPIjypcEOUxksCmVu0zA70NBJWlrMW1rPr/LRidFAflLI+s/w==
+  dependencies:
+    "@opentelemetry/api-logs" "0.213.0"
+    import-in-the-middle "^3.0.0"
+    require-in-the-middle "^8.0.0"
+
 "@opentelemetry/redis-common@^0.38.2":
   version "0.38.2"
   resolved "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.38.2.tgz"
   integrity sha512-1BCcU93iwSRZvDAgwUxC/DV4T/406SkMfxGqu5ojc3AvNI+I9GhV7v0J1HljsczuuhcnFLYqD5VmwVXfCGHzxA==
 
-"@opentelemetry/resources@2.6.0", "@opentelemetry/resources@^2.6.0":
+"@opentelemetry/resources@^1.30.1 || ^2.1.0", "@opentelemetry/resources@^2.6.0", "@opentelemetry/resources@2.6.0":
   version "2.6.0"
   resolved "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.0.tgz"
   integrity sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ==
@@ -887,7 +856,7 @@
     "@opentelemetry/core" "2.6.0"
     "@opentelemetry/semantic-conventions" "^1.29.0"
 
-"@opentelemetry/sdk-trace-base@^2.6.0":
+"@opentelemetry/sdk-trace-base@^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base@^2.6.0":
   version "2.6.0"
   resolved "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.0.tgz"
   integrity sha512-g/OZVkqlxllgFM7qMKqbPV9c1DUPhQ7d4n3pgZFcrnrNft9eJXZM2TNHTPYREJBrtNdRytYyvwjgL5geDKl3EQ==
@@ -896,7 +865,7 @@
     "@opentelemetry/resources" "2.6.0"
     "@opentelemetry/semantic-conventions" "^1.29.0"
 
-"@opentelemetry/semantic-conventions@^1.24.0", "@opentelemetry/semantic-conventions@^1.27.0", "@opentelemetry/semantic-conventions@^1.28.0", "@opentelemetry/semantic-conventions@^1.29.0", "@opentelemetry/semantic-conventions@^1.30.0", "@opentelemetry/semantic-conventions@^1.33.0", "@opentelemetry/semantic-conventions@^1.33.1", "@opentelemetry/semantic-conventions@^1.34.0", "@opentelemetry/semantic-conventions@^1.36.0", "@opentelemetry/semantic-conventions@^1.40.0":
+"@opentelemetry/semantic-conventions@^1.24.0", "@opentelemetry/semantic-conventions@^1.27.0", "@opentelemetry/semantic-conventions@^1.28.0", "@opentelemetry/semantic-conventions@^1.29.0", "@opentelemetry/semantic-conventions@^1.30.0", "@opentelemetry/semantic-conventions@^1.33.0", "@opentelemetry/semantic-conventions@^1.33.1", "@opentelemetry/semantic-conventions@^1.34.0", "@opentelemetry/semantic-conventions@^1.36.0", "@opentelemetry/semantic-conventions@^1.39.0", "@opentelemetry/semantic-conventions@^1.40.0":
   version "1.40.0"
   resolved "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz"
   integrity sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==
@@ -1032,13 +1001,6 @@
   version "1.0.4"
   resolved "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz"
   integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
-
-"@tybys/wasm-util@^0.10.0":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.1.tgz#ecddd3205cf1e2d5274649ff0eedd2991ed7f414"
-  integrity sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==
-  dependencies:
-    tslib "^2.4.0"
 
 "@types/babel__core@^7.20.5":
   version "7.20.5"
@@ -1270,6 +1232,11 @@
   resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz"
   integrity sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==
 
+"@types/string-similarity@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.npmjs.org/@types/string-similarity/-/string-similarity-4.0.2.tgz"
+  integrity sha512-LkJQ/jsXtCVMK+sKYAmX/8zEq+/46f1PTQw7YtmQwb74jemS1SlNLmARM2Zml9DgdDTWKAtc5L13WorpHPDjDA==
+
 "@types/superagent@^8.1.0":
   version "8.1.9"
   resolved "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz"
@@ -1332,102 +1299,10 @@
   resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
 
-"@unrs/resolver-binding-android-arm-eabi@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz#9f5b04503088e6a354295e8ea8fe3cb99e43af81"
-  integrity sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==
-
-"@unrs/resolver-binding-android-arm64@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz#7414885431bd7178b989aedc4d25cccb3865bc9f"
-  integrity sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==
-
 "@unrs/resolver-binding-darwin-arm64@1.11.1":
   version "1.11.1"
   resolved "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz"
   integrity sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==
-
-"@unrs/resolver-binding-darwin-x64@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz#fd4d81257b13f4d1a083890a6a17c00de571f0dc"
-  integrity sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==
-
-"@unrs/resolver-binding-freebsd-x64@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz#d2513084d0f37c407757e22f32bd924a78cfd99b"
-  integrity sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==
-
-"@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz#844d2605d057488d77fab09705f2866b86164e0a"
-  integrity sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==
-
-"@unrs/resolver-binding-linux-arm-musleabihf@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz#204892995cefb6bd1d017d52d097193bc61ddad3"
-  integrity sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==
-
-"@unrs/resolver-binding-linux-arm64-gnu@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz#023eb0c3aac46066a10be7a3f362e7b34f3bdf9d"
-  integrity sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==
-
-"@unrs/resolver-binding-linux-arm64-musl@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz#9e6f9abb06424e3140a60ac996139786f5d99be0"
-  integrity sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==
-
-"@unrs/resolver-binding-linux-ppc64-gnu@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz#b111417f17c9d1b02efbec8e08398f0c5527bb44"
-  integrity sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==
-
-"@unrs/resolver-binding-linux-riscv64-gnu@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz#92ffbf02748af3e99873945c9a8a5ead01d508a9"
-  integrity sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==
-
-"@unrs/resolver-binding-linux-riscv64-musl@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz#0bec6f1258fc390e6b305e9ff44256cb207de165"
-  integrity sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==
-
-"@unrs/resolver-binding-linux-s390x-gnu@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz#577843a084c5952f5906770633ccfb89dac9bc94"
-  integrity sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==
-
-"@unrs/resolver-binding-linux-x64-gnu@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz#36fb318eebdd690f6da32ac5e0499a76fa881935"
-  integrity sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==
-
-"@unrs/resolver-binding-linux-x64-musl@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz#bfb9af75f783f98f6a22c4244214efe4df1853d6"
-  integrity sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==
-
-"@unrs/resolver-binding-wasm32-wasi@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz#752c359dd875684b27429500d88226d7cc72f71d"
-  integrity sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==
-  dependencies:
-    "@napi-rs/wasm-runtime" "^0.2.11"
-
-"@unrs/resolver-binding-win32-arm64-msvc@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz#ce5735e600e4c2fbb409cd051b3b7da4a399af35"
-  integrity sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==
-
-"@unrs/resolver-binding-win32-ia32-msvc@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz#72fc57bc7c64ec5c3de0d64ee0d1810317bc60a6"
-  integrity sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==
-
-"@unrs/resolver-binding-win32-x64-msvc@1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz#538b1e103bf8d9864e7b85cc96fa8d6fb6c40777"
-  integrity sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==
 
 accepts@~1.3.8:
   version "1.3.8"
@@ -1447,7 +1322,7 @@ acorn-walk@^8.1.1:
   resolved "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
-acorn@^8.15.0:
+acorn@^8, acorn@^8.15.0:
   version "8.16.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz"
   integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
@@ -1548,7 +1423,7 @@ b4a@^1.6.4:
   resolved "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz"
   integrity sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==
 
-babel-jest@30.3.0:
+"babel-jest@^29.0.0 || ^30.0.0", babel-jest@30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz"
   integrity sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==
@@ -1618,7 +1493,7 @@ balanced-match@^4.0.2:
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz"
   integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
 
-bare-events@^2.5.4, bare-events@^2.7.0:
+bare-events@*, bare-events@^2.5.4, bare-events@^2.7.0:
   version "2.8.2"
   resolved "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz"
   integrity sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==
@@ -1723,7 +1598,7 @@ braces@~3.0.2:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.24.0:
+browserslist@^4.24.0, "browserslist@>= 4.21.0":
   version "4.28.1"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz"
   integrity sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==
@@ -1770,7 +1645,7 @@ buffer-equal-constant-time@^1.0.1:
 
 buffer-from@^1.0.0:
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
+  resolved "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
 busboy@^1.6.0:
@@ -1983,8 +1858,15 @@ cross-spawn@^7.0.3, cross-spawn@^7.0.6:
 
 csv-parse@^6.2.1:
   version "6.2.1"
-  resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-6.2.1.tgz#325c5adb126b1ad07fa68077c3dc739ccfc12cf5"
+  resolved "https://registry.npmjs.org/csv-parse/-/csv-parse-6.2.1.tgz"
   integrity sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ==
+
+debug@^4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.4, debug@^4.3.5, debug@^4.3.7, debug@^4.4.3, debug@4:
+  version "4.4.3"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
 
 debug@2.6.9:
   version "2.6.9"
@@ -1992,13 +1874,6 @@ debug@2.6.9:
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
-
-debug@4, debug@^4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.4, debug@^4.3.5, debug@^4.3.7, debug@^4.4.3:
-  version "4.4.3"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
-  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
-  dependencies:
-    ms "^2.1.3"
 
 debug@4.x:
   version "4.3.4"
@@ -2022,12 +1897,12 @@ delayed-stream@~1.0.0:
   resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
-depd@2.0.0, depd@~2.0.0:
+depd@~2.0.0, depd@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
-destroy@1.2.0, destroy@~1.2.0:
+destroy@~1.2.0, destroy@1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
@@ -2192,7 +2067,7 @@ exit-x@^0.2.2:
   resolved "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz"
   integrity sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==
 
-expect@30.3.0, expect@^30.0.0:
+expect@^30.0.0, expect@30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz"
   integrity sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==
@@ -2254,7 +2129,7 @@ fast-fifo@^1.2.0, fast-fifo@^1.3.2:
   resolved "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz"
   integrity sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==
 
-fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.1.0:
+fast-json-stable-stringify@^2.1.0, fast-json-stable-stringify@2.x:
   version "2.1.0"
   resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -2538,7 +2413,17 @@ ignore-by-default@^1.0.1:
   resolved "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz"
   integrity sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==
 
-import-in-the-middle@^2.0.0, import-in-the-middle@^2.0.6:
+import-in-the-middle@^2.0.0:
+  version "2.0.6"
+  resolved "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz"
+  integrity sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==
+  dependencies:
+    acorn "^8.15.0"
+    acorn-import-attributes "^1.9.5"
+    cjs-module-lexer "^2.2.0"
+    module-details-from-path "^1.0.4"
+
+import-in-the-middle@^2.0.6:
   version "2.0.6"
   resolved "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz"
   integrity sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==
@@ -2579,7 +2464,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3, inherits@~2.0.4:
+inherits@^2.0.3, inherits@~2.0.4, inherits@2:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -2893,7 +2778,7 @@ jest-resolve-dependencies@30.3.0:
     jest-regex-util "30.0.1"
     jest-snapshot "30.3.0"
 
-jest-resolve@30.3.0:
+jest-resolve@*, jest-resolve@30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.3.0.tgz"
   integrity sha512-NRtTAHQlpd15F9rUR36jqwelbrDV/dY4vzNte3S2kxCKUJRYNd5/6nTSbYiak1VX5g8IoFF23Uj5TURkUW8O5g==
@@ -2990,7 +2875,7 @@ jest-snapshot@30.3.0:
     semver "^7.7.2"
     synckit "^0.11.8"
 
-jest-util@30.3.0:
+"jest-util@^29.0.0 || ^30.0.0", jest-util@30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz"
   integrity sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==
@@ -3039,7 +2924,7 @@ jest-worker@30.3.0:
     merge-stream "^2.0.0"
     supports-color "^8.1.1"
 
-jest@^30.3.0:
+"jest@^29.0.0 || ^30.0.0", jest@^30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/jest/-/jest-30.3.0.tgz"
   integrity sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==
@@ -3350,6 +3235,15 @@ mongodb-memory-server@^11.0.1:
     mongodb-memory-server-core "11.0.1"
     tslib "^2.8.1"
 
+mongodb@^7.0.0:
+  version "7.1.1"
+  resolved "https://registry.npmjs.org/mongodb/-/mongodb-7.1.1.tgz"
+  integrity sha512-067DXiMjcpYQl6bGjWQoTUEE9UoRViTtKFcoqX7z08I+iDZv/emH1g8XEFiO3qiDfXAheT5ozl1VffDTKhIW/w==
+  dependencies:
+    "@mongodb-js/saslprep" "^1.3.0"
+    bson "^7.1.1"
+    mongodb-connection-string-url "^7.0.0"
+
 mongodb@5.9.2:
   version "5.9.2"
   resolved "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz"
@@ -3360,15 +3254,6 @@ mongodb@5.9.2:
     socks "^2.7.1"
   optionalDependencies:
     "@mongodb-js/saslprep" "^1.1.0"
-
-mongodb@^7.0.0:
-  version "7.1.1"
-  resolved "https://registry.npmjs.org/mongodb/-/mongodb-7.1.1.tgz"
-  integrity sha512-067DXiMjcpYQl6bGjWQoTUEE9UoRViTtKFcoqX7z08I+iDZv/emH1g8XEFiO3qiDfXAheT5ozl1VffDTKhIW/w==
-  dependencies:
-    "@mongodb-js/saslprep" "^1.3.0"
-    bson "^7.1.1"
-    mongodb-connection-string-url "^7.0.0"
 
 mongoose@^7.6.3:
   version "7.8.9"
@@ -3395,6 +3280,11 @@ mquery@5.0.0:
   dependencies:
     debug "4.x"
 
+ms@^2.1.1, ms@^2.1.3, ms@2.1.3:
+  version "2.1.3"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
@@ -3405,14 +3295,9 @@ ms@2.1.2:
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3, ms@^2.1.1, ms@^2.1.3:
-  version "2.1.3"
-  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
-  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
-
 multer@^2.1.1:
   version "2.1.1"
-  resolved "https://registry.yarnpkg.com/multer/-/multer-2.1.1.tgz#122d819244fbdfee1efddd9147426691014385b7"
+  resolved "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz"
   integrity sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==
   dependencies:
     append-field "^1.0.0"
@@ -3621,7 +3506,12 @@ picocolors@^1.1.1:
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^2.0.4, picomatch@^2.2.1:
+picomatch@^2.0.4:
+  version "2.3.1"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
+  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+picomatch@^2.2.1:
   version "2.3.1"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -3665,7 +3555,7 @@ postgres-interval@^1.1.0:
   dependencies:
     xtend "^4.0.0"
 
-pretty-format@30.3.0, pretty-format@^30.0.0:
+pretty-format@^30.0.0, pretty-format@30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz"
   integrity sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==
@@ -3772,7 +3662,7 @@ resolve-from@^5.0.0:
   resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
-safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@~5.2.0:
+safe-buffer@^5.0.1, safe-buffer@~5.2.0, safe-buffer@5.2.1:
   version "5.2.1"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -3782,7 +3672,12 @@ safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@~5.2.0:
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-semver@^6.0.0, semver@^6.3.1:
+semver@^6.0.0:
+  version "6.3.1"
+  resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
+  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
@@ -3821,7 +3716,7 @@ serve-static@~1.16.2:
     parseurl "~1.3.3"
     send "~0.19.1"
 
-setprototypeof@1.2.0, setprototypeof@~1.2.0:
+setprototypeof@~1.2.0, setprototypeof@1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
@@ -3910,7 +3805,7 @@ smart-buffer@^4.2.0:
   resolved "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz"
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
 
-socks@^2.7.1:
+socks@^2.7.1, socks@^2.8.6:
   version "2.8.7"
   resolved "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz"
   integrity sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==
@@ -3969,6 +3864,13 @@ streamx@^2.12.5, streamx@^2.15.0, streamx@^2.25.0:
     fast-fifo "^1.3.2"
     text-decoder "^1.1.0"
 
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
+
 string-length@^4.0.2:
   version "4.0.2"
   resolved "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz"
@@ -3976,6 +3878,11 @@ string-length@^4.0.2:
   dependencies:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
+
+string-similarity@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.npmjs.org/string-similarity/-/string-similarity-4.0.4.tgz"
+  integrity sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==
 
 "string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
@@ -3986,7 +3893,16 @@ string-length@^4.0.2:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+string-width@^4.1.0, string-width@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4003,13 +3919,6 @@ string-width@^5.0.1, string-width@^5.1.2:
     eastasianwidth "^0.2.0"
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
-
-string_decoder@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
-  dependencies:
-    safe-buffer "~5.2.0"
 
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
@@ -4183,7 +4092,7 @@ ts-jest@^29.4.6:
     type-fest "^4.41.0"
     yargs-parser "^21.1.1"
 
-ts-node@^10.9.1:
+ts-node@^10.9.1, ts-node@>=9.0.0:
   version "10.9.1"
   resolved "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz"
   integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
@@ -4235,7 +4144,7 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^5.2.2:
+typescript@^5.2.2, typescript@>=2.7, "typescript@>=4.3 <6":
   version "5.2.2"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz"
   integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,7 +16,7 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz"
   integrity sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==
 
-"@babel/core@^7.0.0", "@babel/core@^7.0.0 || ^8.0.0-0", "@babel/core@^7.0.0-0", "@babel/core@^7.11.0 || ^8.0.0-0", "@babel/core@^7.11.0 || ^8.0.0-beta.1", "@babel/core@^7.23.9", "@babel/core@^7.27.4", "@babel/core@>=7.0.0-beta.0 <8":
+"@babel/core@^7.23.9", "@babel/core@^7.27.4":
   version "7.29.0"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz"
   integrity sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==
@@ -277,6 +277,28 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
+"@emnapi/core@^1.4.3":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.9.1.tgz#2143069c744ca2442074f8078462e51edd63c7bd"
+  integrity sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==
+  dependencies:
+    "@emnapi/wasi-threads" "1.2.0"
+    tslib "^2.4.0"
+
+"@emnapi/runtime@^1.4.3":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.9.1.tgz#115ff2a0d589865be6bd8e9d701e499c473f2a8d"
+  integrity sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==
+  dependencies:
+    tslib "^2.4.0"
+
+"@emnapi/wasi-threads@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz#a19d9772cc3d195370bf6e2a805eec40aa75e18e"
+  integrity sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==
+  dependencies:
+    tslib "^2.4.0"
+
 "@fastify/otel@0.17.1":
   version "0.17.1"
   resolved "https://registry.npmjs.org/@fastify/otel/-/otel-0.17.1.tgz"
@@ -500,7 +522,7 @@
     jest-haste-map "30.3.0"
     slash "^3.0.0"
 
-"@jest/transform@^29.0.0 || ^30.0.0", "@jest/transform@30.3.0":
+"@jest/transform@30.3.0":
   version "30.3.0"
   resolved "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz"
   integrity sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==
@@ -520,7 +542,7 @@
     slash "^3.0.0"
     write-file-atomic "^5.0.1"
 
-"@jest/types@^29.0.0 || ^30.0.0", "@jest/types@30.3.0":
+"@jest/types@30.3.0":
   version "30.3.0"
   resolved "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz"
   integrity sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==
@@ -559,14 +581,6 @@
   resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
 
-"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.23", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25", "@jridgewell/trace-mapping@^0.3.28":
-  version "0.3.31"
-  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz"
-  integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
-  dependencies:
-    "@jridgewell/resolve-uri" "^3.1.0"
-    "@jridgewell/sourcemap-codec" "^1.4.14"
-
 "@jridgewell/trace-mapping@0.3.9":
   version "0.3.9"
   resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz"
@@ -575,12 +589,29 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.23", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25", "@jridgewell/trace-mapping@^0.3.28":
+  version "0.3.31"
+  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz"
+  integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
+
 "@mongodb-js/saslprep@^1.1.0", "@mongodb-js/saslprep@^1.3.0":
   version "1.4.6"
   resolved "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.6.tgz"
   integrity sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==
   dependencies:
     sparse-bitfield "^3.0.3"
+
+"@napi-rs/wasm-runtime@^0.2.11":
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz#3e78a8b96e6c33a6c517e1894efbd5385a7cb6f2"
+  integrity sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==
+  dependencies:
+    "@emnapi/core" "^1.4.3"
+    "@emnapi/runtime" "^1.4.3"
+    "@tybys/wasm-util" "^0.10.0"
 
 "@noble/hashes@^1.1.5":
   version "1.8.0"
@@ -608,17 +639,17 @@
   dependencies:
     "@opentelemetry/api" "^1.3.0"
 
-"@opentelemetry/api@^1.1.0", "@opentelemetry/api@^1.3.0", "@opentelemetry/api@^1.7.0", "@opentelemetry/api@^1.8", "@opentelemetry/api@^1.9.0", "@opentelemetry/api@>=1.0.0 <1.10.0", "@opentelemetry/api@>=1.3.0 <1.10.0":
+"@opentelemetry/api@^1.3.0", "@opentelemetry/api@^1.9.0":
   version "1.9.0"
   resolved "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz"
   integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
 
-"@opentelemetry/context-async-hooks@^1.30.1 || ^2.1.0", "@opentelemetry/context-async-hooks@^2.6.0":
+"@opentelemetry/context-async-hooks@^2.6.0":
   version "2.6.0"
   resolved "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.0.tgz"
   integrity sha512-L8UyDwqpTcbkIK5cgwDRDYDoEhQoj8wp8BwsO19w3LB1Z41yEQm2VJyNfAi9DrLP/YTqXqWpKHyZfR9/tFYo1Q==
 
-"@opentelemetry/core@^1.30.1 || ^2.1.0", "@opentelemetry/core@^2.0.0", "@opentelemetry/core@^2.6.0", "@opentelemetry/core@2.6.0":
+"@opentelemetry/core@2.6.0", "@opentelemetry/core@^2.0.0", "@opentelemetry/core@^2.6.0":
   version "2.6.0"
   resolved "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.0.tgz"
   integrity sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==
@@ -759,15 +790,6 @@
     "@opentelemetry/instrumentation" "^0.213.0"
     "@opentelemetry/semantic-conventions" "^1.33.0"
 
-"@opentelemetry/instrumentation-mysql@0.59.0":
-  version "0.59.0"
-  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.59.0.tgz"
-  integrity sha512-r+V/Fh0sm7Ga8/zk/TI5H5FQRAjwr0RrpfPf8kNIehlsKf12XnvIaZi8ViZkpX0gyPEpLXqzqWD6QHlgObgzZw==
-  dependencies:
-    "@opentelemetry/instrumentation" "^0.213.0"
-    "@opentelemetry/semantic-conventions" "^1.33.0"
-    "@types/mysql" "2.15.27"
-
 "@opentelemetry/instrumentation-mysql2@0.59.0":
   version "0.59.0"
   resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.59.0.tgz"
@@ -776,6 +798,15 @@
     "@opentelemetry/instrumentation" "^0.213.0"
     "@opentelemetry/semantic-conventions" "^1.33.0"
     "@opentelemetry/sql-common" "^0.41.2"
+
+"@opentelemetry/instrumentation-mysql@0.59.0":
+  version "0.59.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.59.0.tgz"
+  integrity sha512-r+V/Fh0sm7Ga8/zk/TI5H5FQRAjwr0RrpfPf8kNIehlsKf12XnvIaZi8ViZkpX0gyPEpLXqzqWD6QHlgObgzZw==
+  dependencies:
+    "@opentelemetry/instrumentation" "^0.213.0"
+    "@opentelemetry/semantic-conventions" "^1.33.0"
+    "@types/mysql" "2.15.27"
 
 "@opentelemetry/instrumentation-pg@0.65.0":
   version "0.65.0"
@@ -816,6 +847,15 @@
     "@opentelemetry/instrumentation" "^0.213.0"
     "@opentelemetry/semantic-conventions" "^1.24.0"
 
+"@opentelemetry/instrumentation@0.213.0", "@opentelemetry/instrumentation@^0.213.0":
+  version "0.213.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.213.0.tgz"
+  integrity sha512-3i9NdkET/KvQomeh7UaR/F4r9P25Rx6ooALlWXPIjypcEOUxksCmVu0zA70NBJWlrMW1rPr/LRidFAflLI+s/w==
+  dependencies:
+    "@opentelemetry/api-logs" "0.213.0"
+    import-in-the-middle "^3.0.0"
+    require-in-the-middle "^8.0.0"
+
 "@opentelemetry/instrumentation@^0.207.0":
   version "0.207.0"
   resolved "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.207.0.tgz"
@@ -834,21 +874,12 @@
     import-in-the-middle "^2.0.6"
     require-in-the-middle "^8.0.0"
 
-"@opentelemetry/instrumentation@^0.213.0", "@opentelemetry/instrumentation@>=0.57.1 <1", "@opentelemetry/instrumentation@0.213.0":
-  version "0.213.0"
-  resolved "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.213.0.tgz"
-  integrity sha512-3i9NdkET/KvQomeh7UaR/F4r9P25Rx6ooALlWXPIjypcEOUxksCmVu0zA70NBJWlrMW1rPr/LRidFAflLI+s/w==
-  dependencies:
-    "@opentelemetry/api-logs" "0.213.0"
-    import-in-the-middle "^3.0.0"
-    require-in-the-middle "^8.0.0"
-
 "@opentelemetry/redis-common@^0.38.2":
   version "0.38.2"
   resolved "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.38.2.tgz"
   integrity sha512-1BCcU93iwSRZvDAgwUxC/DV4T/406SkMfxGqu5ojc3AvNI+I9GhV7v0J1HljsczuuhcnFLYqD5VmwVXfCGHzxA==
 
-"@opentelemetry/resources@^1.30.1 || ^2.1.0", "@opentelemetry/resources@^2.6.0", "@opentelemetry/resources@2.6.0":
+"@opentelemetry/resources@2.6.0", "@opentelemetry/resources@^2.6.0":
   version "2.6.0"
   resolved "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.0.tgz"
   integrity sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ==
@@ -856,7 +887,7 @@
     "@opentelemetry/core" "2.6.0"
     "@opentelemetry/semantic-conventions" "^1.29.0"
 
-"@opentelemetry/sdk-trace-base@^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base@^2.6.0":
+"@opentelemetry/sdk-trace-base@^2.6.0":
   version "2.6.0"
   resolved "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.0.tgz"
   integrity sha512-g/OZVkqlxllgFM7qMKqbPV9c1DUPhQ7d4n3pgZFcrnrNft9eJXZM2TNHTPYREJBrtNdRytYyvwjgL5geDKl3EQ==
@@ -865,7 +896,7 @@
     "@opentelemetry/resources" "2.6.0"
     "@opentelemetry/semantic-conventions" "^1.29.0"
 
-"@opentelemetry/semantic-conventions@^1.24.0", "@opentelemetry/semantic-conventions@^1.27.0", "@opentelemetry/semantic-conventions@^1.28.0", "@opentelemetry/semantic-conventions@^1.29.0", "@opentelemetry/semantic-conventions@^1.30.0", "@opentelemetry/semantic-conventions@^1.33.0", "@opentelemetry/semantic-conventions@^1.33.1", "@opentelemetry/semantic-conventions@^1.34.0", "@opentelemetry/semantic-conventions@^1.36.0", "@opentelemetry/semantic-conventions@^1.39.0", "@opentelemetry/semantic-conventions@^1.40.0":
+"@opentelemetry/semantic-conventions@^1.24.0", "@opentelemetry/semantic-conventions@^1.27.0", "@opentelemetry/semantic-conventions@^1.28.0", "@opentelemetry/semantic-conventions@^1.29.0", "@opentelemetry/semantic-conventions@^1.30.0", "@opentelemetry/semantic-conventions@^1.33.0", "@opentelemetry/semantic-conventions@^1.33.1", "@opentelemetry/semantic-conventions@^1.34.0", "@opentelemetry/semantic-conventions@^1.36.0", "@opentelemetry/semantic-conventions@^1.40.0":
   version "1.40.0"
   resolved "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz"
   integrity sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==
@@ -1001,6 +1032,13 @@
   version "1.0.4"
   resolved "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz"
   integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
+
+"@tybys/wasm-util@^0.10.0":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.1.tgz#ecddd3205cf1e2d5274649ff0eedd2991ed7f414"
+  integrity sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==
+  dependencies:
+    tslib "^2.4.0"
 
 "@types/babel__core@^7.20.5":
   version "7.20.5"
@@ -1294,10 +1332,102 @@
   resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
 
+"@unrs/resolver-binding-android-arm-eabi@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz#9f5b04503088e6a354295e8ea8fe3cb99e43af81"
+  integrity sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==
+
+"@unrs/resolver-binding-android-arm64@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz#7414885431bd7178b989aedc4d25cccb3865bc9f"
+  integrity sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==
+
 "@unrs/resolver-binding-darwin-arm64@1.11.1":
   version "1.11.1"
   resolved "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz"
   integrity sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==
+
+"@unrs/resolver-binding-darwin-x64@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz#fd4d81257b13f4d1a083890a6a17c00de571f0dc"
+  integrity sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==
+
+"@unrs/resolver-binding-freebsd-x64@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz#d2513084d0f37c407757e22f32bd924a78cfd99b"
+  integrity sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==
+
+"@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz#844d2605d057488d77fab09705f2866b86164e0a"
+  integrity sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==
+
+"@unrs/resolver-binding-linux-arm-musleabihf@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz#204892995cefb6bd1d017d52d097193bc61ddad3"
+  integrity sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==
+
+"@unrs/resolver-binding-linux-arm64-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz#023eb0c3aac46066a10be7a3f362e7b34f3bdf9d"
+  integrity sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==
+
+"@unrs/resolver-binding-linux-arm64-musl@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz#9e6f9abb06424e3140a60ac996139786f5d99be0"
+  integrity sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==
+
+"@unrs/resolver-binding-linux-ppc64-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz#b111417f17c9d1b02efbec8e08398f0c5527bb44"
+  integrity sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==
+
+"@unrs/resolver-binding-linux-riscv64-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz#92ffbf02748af3e99873945c9a8a5ead01d508a9"
+  integrity sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==
+
+"@unrs/resolver-binding-linux-riscv64-musl@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz#0bec6f1258fc390e6b305e9ff44256cb207de165"
+  integrity sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==
+
+"@unrs/resolver-binding-linux-s390x-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz#577843a084c5952f5906770633ccfb89dac9bc94"
+  integrity sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==
+
+"@unrs/resolver-binding-linux-x64-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz#36fb318eebdd690f6da32ac5e0499a76fa881935"
+  integrity sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==
+
+"@unrs/resolver-binding-linux-x64-musl@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz#bfb9af75f783f98f6a22c4244214efe4df1853d6"
+  integrity sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==
+
+"@unrs/resolver-binding-wasm32-wasi@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz#752c359dd875684b27429500d88226d7cc72f71d"
+  integrity sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==
+  dependencies:
+    "@napi-rs/wasm-runtime" "^0.2.11"
+
+"@unrs/resolver-binding-win32-arm64-msvc@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz#ce5735e600e4c2fbb409cd051b3b7da4a399af35"
+  integrity sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==
+
+"@unrs/resolver-binding-win32-ia32-msvc@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz#72fc57bc7c64ec5c3de0d64ee0d1810317bc60a6"
+  integrity sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==
+
+"@unrs/resolver-binding-win32-x64-msvc@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz#538b1e103bf8d9864e7b85cc96fa8d6fb6c40777"
+  integrity sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==
 
 accepts@~1.3.8:
   version "1.3.8"
@@ -1317,7 +1447,7 @@ acorn-walk@^8.1.1:
   resolved "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
-acorn@^8, acorn@^8.15.0:
+acorn@^8.15.0:
   version "8.16.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz"
   integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
@@ -1418,7 +1548,7 @@ b4a@^1.6.4:
   resolved "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz"
   integrity sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==
 
-"babel-jest@^29.0.0 || ^30.0.0", babel-jest@30.3.0:
+babel-jest@30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz"
   integrity sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==
@@ -1488,7 +1618,7 @@ balanced-match@^4.0.2:
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz"
   integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
 
-bare-events@*, bare-events@^2.5.4, bare-events@^2.7.0:
+bare-events@^2.5.4, bare-events@^2.7.0:
   version "2.8.2"
   resolved "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz"
   integrity sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==
@@ -1593,7 +1723,7 @@ braces@~3.0.2:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.24.0, "browserslist@>= 4.21.0":
+browserslist@^4.24.0:
   version "4.28.1"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz"
   integrity sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==
@@ -1640,6 +1770,8 @@ buffer-equal-constant-time@^1.0.1:
 
 buffer-from@^1.0.0:
   version "1.1.2"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
+  integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
 busboy@^1.6.0:
   version "1.6.0"
@@ -1851,15 +1983,8 @@ cross-spawn@^7.0.3, cross-spawn@^7.0.6:
 
 csv-parse@^6.2.1:
   version "6.2.1"
-  resolved "https://registry.npmjs.org/csv-parse/-/csv-parse-6.2.1.tgz"
+  resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-6.2.1.tgz#325c5adb126b1ad07fa68077c3dc739ccfc12cf5"
   integrity sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ==
-
-debug@^4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.4, debug@^4.3.5, debug@^4.3.7, debug@^4.4.3, debug@4:
-  version "4.4.3"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
-  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
-  dependencies:
-    ms "^2.1.3"
 
 debug@2.6.9:
   version "2.6.9"
@@ -1867,6 +1992,13 @@ debug@2.6.9:
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
+
+debug@4, debug@^4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.4, debug@^4.3.5, debug@^4.3.7, debug@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
 
 debug@4.x:
   version "4.3.4"
@@ -1890,12 +2022,12 @@ delayed-stream@~1.0.0:
   resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
-depd@~2.0.0, depd@2.0.0:
+depd@2.0.0, depd@~2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
-destroy@~1.2.0, destroy@1.2.0:
+destroy@1.2.0, destroy@~1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
@@ -2060,7 +2192,7 @@ exit-x@^0.2.2:
   resolved "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz"
   integrity sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==
 
-expect@^30.0.0, expect@30.3.0:
+expect@30.3.0, expect@^30.0.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz"
   integrity sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==
@@ -2122,7 +2254,7 @@ fast-fifo@^1.2.0, fast-fifo@^1.3.2:
   resolved "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz"
   integrity sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==
 
-fast-json-stable-stringify@^2.1.0, fast-json-stable-stringify@2.x:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -2406,17 +2538,7 @@ ignore-by-default@^1.0.1:
   resolved "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz"
   integrity sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==
 
-import-in-the-middle@^2.0.0:
-  version "2.0.6"
-  resolved "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz"
-  integrity sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==
-  dependencies:
-    acorn "^8.15.0"
-    acorn-import-attributes "^1.9.5"
-    cjs-module-lexer "^2.2.0"
-    module-details-from-path "^1.0.4"
-
-import-in-the-middle@^2.0.6:
+import-in-the-middle@^2.0.0, import-in-the-middle@^2.0.6:
   version "2.0.6"
   resolved "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz"
   integrity sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==
@@ -2457,7 +2579,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@^2.0.3, inherits@~2.0.4, inherits@2:
+inherits@2, inherits@^2.0.3, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -2771,7 +2893,7 @@ jest-resolve-dependencies@30.3.0:
     jest-regex-util "30.0.1"
     jest-snapshot "30.3.0"
 
-jest-resolve@*, jest-resolve@30.3.0:
+jest-resolve@30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.3.0.tgz"
   integrity sha512-NRtTAHQlpd15F9rUR36jqwelbrDV/dY4vzNte3S2kxCKUJRYNd5/6nTSbYiak1VX5g8IoFF23Uj5TURkUW8O5g==
@@ -2868,7 +2990,7 @@ jest-snapshot@30.3.0:
     semver "^7.7.2"
     synckit "^0.11.8"
 
-"jest-util@^29.0.0 || ^30.0.0", jest-util@30.3.0:
+jest-util@30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz"
   integrity sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==
@@ -2917,7 +3039,7 @@ jest-worker@30.3.0:
     merge-stream "^2.0.0"
     supports-color "^8.1.1"
 
-"jest@^29.0.0 || ^30.0.0", jest@^30.3.0:
+jest@^30.3.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/jest/-/jest-30.3.0.tgz"
   integrity sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==
@@ -3228,15 +3350,6 @@ mongodb-memory-server@^11.0.1:
     mongodb-memory-server-core "11.0.1"
     tslib "^2.8.1"
 
-mongodb@^7.0.0:
-  version "7.1.1"
-  resolved "https://registry.npmjs.org/mongodb/-/mongodb-7.1.1.tgz"
-  integrity sha512-067DXiMjcpYQl6bGjWQoTUEE9UoRViTtKFcoqX7z08I+iDZv/emH1g8XEFiO3qiDfXAheT5ozl1VffDTKhIW/w==
-  dependencies:
-    "@mongodb-js/saslprep" "^1.3.0"
-    bson "^7.1.1"
-    mongodb-connection-string-url "^7.0.0"
-
 mongodb@5.9.2:
   version "5.9.2"
   resolved "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz"
@@ -3247,6 +3360,15 @@ mongodb@5.9.2:
     socks "^2.7.1"
   optionalDependencies:
     "@mongodb-js/saslprep" "^1.1.0"
+
+mongodb@^7.0.0:
+  version "7.1.1"
+  resolved "https://registry.npmjs.org/mongodb/-/mongodb-7.1.1.tgz"
+  integrity sha512-067DXiMjcpYQl6bGjWQoTUEE9UoRViTtKFcoqX7z08I+iDZv/emH1g8XEFiO3qiDfXAheT5ozl1VffDTKhIW/w==
+  dependencies:
+    "@mongodb-js/saslprep" "^1.3.0"
+    bson "^7.1.1"
+    mongodb-connection-string-url "^7.0.0"
 
 mongoose@^7.6.3:
   version "7.8.9"
@@ -3273,11 +3395,6 @@ mquery@5.0.0:
   dependencies:
     debug "4.x"
 
-ms@^2.1.1, ms@^2.1.3, ms@2.1.3:
-  version "2.1.3"
-  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
-  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
-
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
@@ -3288,9 +3405,14 @@ ms@2.1.2:
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
+ms@2.1.3, ms@^2.1.1, ms@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
 multer@^2.1.1:
   version "2.1.1"
-  resolved "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz"
+  resolved "https://registry.yarnpkg.com/multer/-/multer-2.1.1.tgz#122d819244fbdfee1efddd9147426691014385b7"
   integrity sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==
   dependencies:
     append-field "^1.0.0"
@@ -3499,12 +3621,7 @@ picocolors@^1.1.1:
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^2.0.4:
-  version "2.3.1"
-  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
-
-picomatch@^2.2.1:
+picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.3.1"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -3548,7 +3665,7 @@ postgres-interval@^1.1.0:
   dependencies:
     xtend "^4.0.0"
 
-pretty-format@^30.0.0, pretty-format@30.3.0:
+pretty-format@30.3.0, pretty-format@^30.0.0:
   version "30.3.0"
   resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz"
   integrity sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==
@@ -3655,7 +3772,7 @@ resolve-from@^5.0.0:
   resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
-safe-buffer@^5.0.1, safe-buffer@~5.2.0, safe-buffer@5.2.1:
+safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -3665,12 +3782,7 @@ safe-buffer@^5.0.1, safe-buffer@~5.2.0, safe-buffer@5.2.1:
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-semver@^6.0.0:
-  version "6.3.1"
-  resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
-  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
-
-semver@^6.3.1:
+semver@^6.0.0, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
@@ -3709,7 +3821,7 @@ serve-static@~1.16.2:
     parseurl "~1.3.3"
     send "~0.19.1"
 
-setprototypeof@~1.2.0, setprototypeof@1.2.0:
+setprototypeof@1.2.0, setprototypeof@~1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
@@ -3798,7 +3910,7 @@ smart-buffer@^4.2.0:
   resolved "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz"
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
 
-socks@^2.7.1, socks@^2.8.6:
+socks@^2.7.1:
   version "2.8.7"
   resolved "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz"
   integrity sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==
@@ -3857,13 +3969,6 @@ streamx@^2.12.5, streamx@^2.15.0, streamx@^2.25.0:
     fast-fifo "^1.3.2"
     text-decoder "^1.1.0"
 
-string_decoder@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
-  dependencies:
-    safe-buffer "~5.2.0"
-
 string-length@^4.0.2:
   version "4.0.2"
   resolved "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz"
@@ -3881,16 +3986,7 @@ string-length@^4.0.2:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string-width@^4.1.0, string-width@^4.2.0:
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.2.3:
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3907,6 +4003,13 @@ string-width@^5.0.1, string-width@^5.1.2:
     eastasianwidth "^0.2.0"
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
+
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
 
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
@@ -4080,7 +4183,7 @@ ts-jest@^29.4.6:
     type-fest "^4.41.0"
     yargs-parser "^21.1.1"
 
-ts-node@^10.9.1, ts-node@>=9.0.0:
+ts-node@^10.9.1:
   version "10.9.1"
   resolved "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz"
   integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
@@ -4132,7 +4235,7 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^5.2.2, typescript@>=2.7, "typescript@>=4.3 <6":
+typescript@^5.2.2:
   version "5.2.2"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz"
   integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==


### PR DESCRIPTION
## What
Changed amount validation from `.isNumeric()` to `.isFloat({ gt: 0 })` on all expense and recurring expense routes (POST and PUT). Also tightened `originalAmount` validation on the expenses route.

## Why
Closes #152

Users could submit `amount: 0` or `amount: -50` which corrupts budget calculations, reports, and summary cards.

## Acceptance Criteria
- [x] `POST /api/expenses` rejects `amount <= 0` with a clear error message
- [x] `PUT /api/expenses/:id` rejects `amount <= 0` with a clear error message
- [x] `POST /api/recurring` rejects `amount <= 0` with a clear error message
- [x] `PUT /api/recurring/:id` rejects `amount <= 0` with a clear error message
- [x] Validation uses `.isFloat({ gt: 0 })`
- [x] `originalAmount` validation also rejects `<= 0` when present
- [x] Existing tests still pass; added tests for zero/negative rejection

## Test Plan
1. Run `npx jest __tests__/expenses-integration.test.ts __tests__/recurring.test.ts`
2. All 47 tests pass including 7 new tests for zero/negative/originalAmount rejection
3. `yarn build` passes clean