### PR TITLE
fix: support multiple CORS origins for local dev (#166)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -39,8 +39,20 @@ const app = express();
 const PORT = process.env.PORT || 3001;
 const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017/money-flow';
 
+const DEV_ORIGINS = ['http://localhost:3000', 'http://localhost:3002'];
+const allowedOrigins = new Set<string>([
+  ...DEV_ORIGINS,
+  ...(process.env.FRONTEND_URL ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean),
+]);
+
 app.use(cors({
-  origin: process.env.FRONTEND_URL || 'http://localhost:3000',
+  origin: (origin, cb) => {
+    if (!origin || allowedOrigins.has(origin)) return cb(null, true);
+    cb(new Error(`CORS: origin ${origin} not allowed`));
+  },
   credentials: true,
 }));
 app.use(express.json());


### PR DESCRIPTION
## Summary
- CORS now accepts a comma-separated `FRONTEND_URL` list
- `localhost:3000` and `localhost:3002` always allowed (dev ergonomics)
- Production Vercel URL continues to work via `FRONTEND_URL` env var on Railway

## Test plan
- [ ] `POST /auth/register` from `localhost:3002` succeeds (no CORS error)
- [ ] Production frontend still works
- [ ] `npx tsc --noEmit` passes ✅

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)