### PR TITLE
test: fix CORS test for multi-origin support

### DIFF
--- a/__tests__/app.test.ts
+++ b/__tests__/app.test.ts
@@ -25,10 +25,29 @@ describe('GET /health', () => {
 describe('App bootstrap', () => {
   it('sets up CORS middleware correctly', async () => {
     const res = await request(app)
-      .get('/health');
+      .get('/health')
+      .set('Origin', 'http://localhost:3000');
 
     expect(res.status).toBe(200);
-    expect(res.headers['access-control-allow-origin']).toBeDefined();
+    expect(res.headers['access-control-allow-origin']).toBe('http://localhost:3000');
+  });
+
+  it('blocks unknown origins', async () => {
+    const res = await request(app)
+      .options('/health')
+      .set('Origin', 'https://evil.example.com')
+      .set('Access-Control-Request-Method', 'GET');
+
+    expect(res.status).toBe(500);
+  });
+
+  it('allows localhost:3002 for local dev', async () => {
+    const res = await request(app)
+      .get('/health')
+      .set('Origin', 'http://localhost:3002');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['access-control-allow-origin']).toBe('http://localhost:3002');
   });
 
   it('sets up express.json() middleware', async () => {


### PR DESCRIPTION
## Summary
- Send `Origin: http://localhost:3000` in CORS test so the header is actually set
- Add test for localhost:3002 being allowed
- Add test that unknown origins are blocked

Pre-existing failures (export, net-worth, weekly-digest) are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)