### PR TITLE
ops: add fly.toml for Fly.io backend deployment (#169)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,9 @@ APPLE_CLIENT_ID=your-apple-services-id
 # Anthropic API (optional - required for receipt OCR scanning)
 ANTHROPIC_API_KEY=your-anthropic-api-key
 
+# Groq API (optional - AI fallback for NLP transaction parser; regex still works without it)
+GROQ_API_KEY=your-groq-api-key
+
 # Sentry error tracking (optional - errors are not reported if unset)
 SENTRY_DSN=https://your-dsn@o0.ingest.sentry.io/0
 

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,27 @@
+app = "money-flow-backend"
+primary_region = "sjc"
+
+[build]
+  target = "prod"
+
+[env]
+  NODE_ENV = "production"
+  PORT = "3001"
+
+[http_service]
+  internal_port = 3001
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+  [[http_service.checks]]
+    grace_period = "10s"
+    interval = "30s"
+    method = "GET"
+    path = "/health"
+    timeout = "5s"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "256mb"


### PR DESCRIPTION
## Summary
- Adds `fly.toml` to the repo — the Fly app `money-flow-backend.fly.dev` has been running on this exact config since the Railway→Fly migration on May 17, but the file was never committed.
- Documents `GROQ_API_KEY` in `.env.example` (optional — AI fallback for NLP parser; regex path still works without it).

## Why
Railway trial expired (#169). Backend was migrated to Fly.io two weeks ago and frontend `.env.local` already points at `money-flow-backend.fly.dev`, but the deployment config was missing from git so re-deploys / contributors had no source of truth.

## Test plan
- [x] `yarn build` passes (tsc clean)
- [x] `curl https://money-flow-backend.fly.dev/health` → `{"status":"ok"}` HTTP 200
- [x] `POST /auth/login` with bad creds → 401 `{"error":"Invalid email or password"}` (route alive)
- [ ] Playwright UAT: register + login from localhost:3002 against Fly backend
- [ ] No regressions on production frontend (money-flow-frontend-ten.vercel.app)

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)