### PR TITLE
chore(ci): remove dead Railway deploy step + README Fly refs (#173)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,21 +40,13 @@ jobs:
           echo "Coverage ${COVERAGE}% meets 75% floor."
       - name: TypeScript compile
         run: yarn build
-      - name: Deploy to Railway
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        continue-on-error: true
-        run: |
-          npm install -g @railway/cli
-          railway up --detach
-        env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
       - name: Notify Telegram on success
         if: success()
         continue-on-error: true
         run: |
           curl -sf -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
             -d chat_id="${{ secrets.TELEGRAM_CHAT_ID }}" \
-            -d text="CI passed + deployed: money-flow-backend (${{ github.ref_name }})" || true
+            -d text="CI passed: money-flow-backend (${{ github.ref_name }})" || true
       - name: Notify Telegram on failure
         if: failure()
         continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Sentry is wired up via `src/instrument.ts` and activates when `SENTRY_DSN` is se
 **Setup:**
 1. Create a Node.js project at [sentry.io](https://sentry.io)
 2. Copy the DSN from Project Settings > Client Keys
-3. Add `SENTRY_DSN` to Railway environment variables
+3. Add `SENTRY_DSN` as a Fly secret (`flyctl secrets set SENTRY_DSN=… -a money-flow-backend`)
 4. Deploy and hit `GET /debug-sentry` to trigger a test error
 5. Confirm the error appears in the Sentry dashboard
 6. Remove or restrict `/debug-sentry` once verified (it is unprotected)
@@ -84,7 +84,7 @@ The `/health` endpoint returns `{"status":"ok"}` and is used for uptime monitori
 1. Sign up at [uptimerobot.com](https://uptimerobot.com) (free, no card needed)
 2. Add a new monitor:
    - Type: **HTTPS**
-   - URL: `https://money-flow-backend-production.up.railway.app/health`
+   - URL: `https://money-flow-backend.fly.dev/health`
    - Interval: **5 minutes**
    - Alert contact: your email or Telegram
 3. Optionally add `/api/health` as a second monitor (checks DB connectivity too)


### PR DESCRIPTION
## Summary
- Removed the \`Deploy to Railway\` step from \`ci.yml\` — it has been silently failing on every CI run since the Fly migration (#169), hidden by \`continue-on-error: true\`.
- Fixed the Telegram success message: "CI passed + deployed" → "CI passed" (CI no longer triggers a deploy).
- Updated README — Sentry/UptimeRobot sections now reference Fly (\`flyctl secrets set\`, \`money-flow-backend.fly.dev\`).

## Note for you
- The \`RAILWAY_TOKEN\` GH secret can now be revoked from repo Settings → Secrets (no workflow references it).
- Backend deploys are currently **manual** (\`flyctl deploy -a money-flow-backend\`). Adding auto-deploy needs a \`FLY_API_TOKEN\` secret — filed as a follow-up so you can decide if you want it.

## Test plan
- [x] \`yarn test\` still passes (670/670)
- [x] \`yarn build\` clean
- [ ] CI build job green on this PR
- [ ] No regressions on main after merge

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)