### PR TITLE
fix(accounts): drop unreachable unlinkedTransactions field (#177)

### DIFF
--- a/__tests__/accounts.test.ts
+++ b/__tests__/accounts.test.ts
@@ -7,7 +7,6 @@ import { MongoMemoryServer } from 'mongodb-memory-server';
 import jwt from 'jsonwebtoken';
 import app from '../src/app';
 import AccountModel from '../src/models/Account';
-import ExpenseModel from '../src/models/Expense';
 
 let mongod: MongoMemoryServer;
 const TEST_USER_ID = 'user_test_accounts';
@@ -211,10 +210,7 @@ describe('PUT /api/accounts/:id', () => {
 });
 
 describe('DELETE /api/accounts/:id', () => {
-  it('deletes the account and reports unlinkedTransactions (always 0 — see open bug)', async () => {
-    // Route counts Expense.accountId matches but the Expense schema does not
-    // define accountId, so Mongoose strips it on write and the count is always 0.
-    // Documented behavior here; bug tracked separately.
+  it('deletes the account', async () => {
     const acc = await AccountModel.create({
       userId: TEST_USER_ID,
       name: 'A',
@@ -227,7 +223,7 @@ describe('DELETE /api/accounts/:id', () => {
       .set('Authorization', `Bearer ${authToken}`);
 
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ deleted: true, unlinkedTransactions: 0 });
+    expect(res.body).toEqual({ deleted: true });
     const found = await AccountModel.findById(acc._id);
     expect(found).toBeNull();
   });
@@ -260,25 +256,11 @@ describe('DELETE /api/accounts/:id', () => {
       type: 'cash',
       startingBalance: 0,
     });
-    jest.spyOn(ExpenseModel, 'countDocuments').mockRejectedValueOnce(new Error('db down'));
+    jest.spyOn(AccountModel, 'deleteOne').mockRejectedValueOnce(new Error('db down'));
     const res = await request(app)
       .delete(`/api/accounts/${acc._id}`)
       .set('Authorization', `Bearer ${authToken}`);
     expect(res.status).toBe(500);
-  });
-
-  it('reports 0 unlinked when no transactions link to the account', async () => {
-    const acc = await AccountModel.create({
-      userId: TEST_USER_ID,
-      name: 'A',
-      type: 'cash',
-      startingBalance: 0,
-    });
-    const res = await request(app)
-      .delete(`/api/accounts/${acc._id}`)
-      .set('Authorization', `Bearer ${authToken}`);
-    expect(res.status).toBe(200);
-    expect(res.body.unlinkedTransactions).toBe(0);
   });
 });
 

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -2,7 +2,6 @@ import { Router, Response } from 'express';
 import { body, validationResult } from 'express-validator';
 import { protect, AuthRequest } from '../middleware/auth';
 import AccountModel, { ACCOUNT_TYPES } from '../models/Account';
-import ExpenseModel from '../models/Expense';
 
 const router = Router();
 
@@ -110,18 +109,12 @@ router.delete('/:id', async (req: AuthRequest, res: Response) => {
       return;
     }
 
-    // Count transactions linked to this account
-    const linkedCount = await ExpenseModel.countDocuments({
-      owner: req.userId,
-      accountId: req.params.id,
-    });
-
     await AccountModel.deleteOne({ _id: req.params.id });
 
-    res.json({ deleted: true, unlinkedTransactions: linkedCount });
+    res.json({ deleted: true });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to delete account';
-    res.status(500).json({ error: message });
+    console.error('DELETE /api/accounts/:id failed:', err);
+    res.status(500).json({ error: 'Failed to delete account' });
   }
 });
 


### PR DESCRIPTION
## Summary
- Removed \`unlinkedTransactions\` from \`DELETE /api/accounts/:id\` response — the field was always 0 because \`Expense\` schema has no \`accountId\` (Mongoose stripped it silently on every write).
- Picked Option B (remove) over Option A (add accountId + wire up) because PRODUCT.md Feature 10 (Accounts) does not include transaction-to-account linkage in its acceptance criteria.
- Bonus cleanup: harmonized the catch block (log raw, return generic message) and dropped the now-unused \`ExpenseModel\` import.

## Why this is safe
- Grepped \`unlinkedTransactions\` across money-flow-frontend/src and money-flow-mobile/src → **0 callers reference it**.

## Test plan
- [x] \`yarn build\` clean
- [x] \`yarn jest __tests__/accounts.test.ts\` → 19/19 passing
- [ ] CI \`build\` job green (full suite + 85% coverage gate)
- [ ] Main green after merge

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)