### PR TITLE
security: stop leaking raw err.message in 50 route catch blocks (#180)

### DIFF
--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -15,8 +15,8 @@ router.get('/', async (req: AuthRequest, res: Response) => {
       .lean();
     res.json({ accounts });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to fetch accounts';
-    res.status(500).json({ error: message });
+    console.error('accounts.ts:1 failed:', err);
+    res.status(500).json({ error: 'Failed to fetch accounts' });
   }
 });
 
@@ -53,8 +53,8 @@ router.post(
       });
       res.status(201).json({ account });
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to create account';
-      res.status(500).json({ error: message });
+      console.error('accounts.ts:2 failed:', err);
+      res.status(500).json({ error: 'Failed to create account' });
     }
   }
 );
@@ -91,8 +91,8 @@ router.put(
       }
       res.json({ account });
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to update account';
-      res.status(500).json({ error: message });
+      console.error('accounts.ts:3 failed:', err);
+      res.status(500).json({ error: 'Failed to update account' });
     }
   }
 );

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -80,8 +80,8 @@ router.post(
       const token = signToken(user.id as string);
       res.status(201).json({ token });
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Registration failed';
-      res.status(500).json({ error: message });
+      console.error('auth.ts:1 failed:', err);
+      res.status(500).json({ error: 'Registration failed' });
     }
   }
 );
@@ -111,8 +111,8 @@ router.post(
       const token = signToken(user.id as string);
       res.json({ token });
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Login failed';
-      res.status(500).json({ error: message });
+      console.error('auth.ts:2 failed:', err);
+      res.status(500).json({ error: 'Login failed' });
     }
   }
 );
@@ -172,8 +172,8 @@ router.post(
       const token = signToken(user.id as string);
       res.json({ token });
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Google authentication failed';
-      res.status(401).json({ error: message });
+      console.error('auth.ts:3 failed:', err);
+      res.status(401).json({ error: 'Google authentication failed' });
     }
   }
 );
@@ -227,8 +227,8 @@ router.post(
       const token = signToken(user.id as string);
       res.json({ token });
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Apple authentication failed';
-      res.status(401).json({ error: message });
+      console.error('auth.ts:4 failed:', err);
+      res.status(401).json({ error: 'Apple authentication failed' });
     }
   }
 );
@@ -292,8 +292,8 @@ router.delete(
 
       res.json({ message: 'Account and all data deleted' });
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Account deletion failed';
-      res.status(500).json({ error: message });
+      console.error('auth.ts:5 failed:', err);
+      res.status(500).json({ error: 'Account deletion failed' });
     }
   }
 );

--- a/src/routes/budgets.ts
+++ b/src/routes/budgets.ts
@@ -18,8 +18,8 @@ router.get('/', async (req: AuthRequest, res: Response) => {
     }
     res.json({ budgets: user.budgets || [] });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to fetch budgets';
-    res.status(500).json({ error: message });
+    console.error('budgets.ts:1 failed:', err);
+    res.status(500).json({ error: 'Failed to fetch budgets' });
   }
 });
 
@@ -80,8 +80,8 @@ router.get('/summary', async (req: AuthRequest, res: Response) => {
 
     res.json({ summary });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to fetch budget summary';
-    res.status(500).json({ error: message });
+    console.error('budgets.ts:2 failed:', err);
+    res.status(500).json({ error: 'Failed to fetch budget summary' });
   }
 });
 
@@ -116,8 +116,8 @@ router.post('/:category/alerts', [
 
     res.json({ message: `Alerts ${enable_alerts ? 'enabled' : 'disabled'} for ${category}` });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to update alert settings';
-    res.status(500).json({ error: message });
+    console.error('budgets.ts:3 failed:', err);
+    res.status(500).json({ error: 'Failed to update alert settings' });
   }
 });
 
@@ -148,8 +148,8 @@ router.put(
       await UserModel.findByIdAndUpdate(req.userId, { $set: { budgets } });
       res.json({ budgets });
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to update budgets';
-      res.status(500).json({ error: message });
+      console.error('budgets.ts:4 failed:', err);
+      res.status(500).json({ error: 'Failed to update budgets' });
     }
   }
 );

--- a/src/routes/exchange-rates.ts
+++ b/src/routes/exchange-rates.ts
@@ -13,8 +13,8 @@ router.get('/', async (req: AuthRequest, res: Response) => {
     const data = await getExchangeRates(base);
     res.json(data);
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to fetch exchange rates';
-    res.status(500).json({ error: message });
+    console.error('exchange-rates.ts:1 failed:', err);
+    res.status(500).json({ error: 'Failed to fetch exchange rates' });
   }
 });
 

--- a/src/routes/expenses.ts
+++ b/src/routes/expenses.ts
@@ -97,8 +97,8 @@ router.get('/last-amounts', async (req: AuthRequest, res: Response) => {
     }
     res.json(map);
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to fetch last amounts';
-    res.status(500).json({ error: message });
+    console.error('expenses.ts:1 failed:', err);
+    res.status(500).json({ error: 'Failed to fetch last amounts' });
   }
 });
 
@@ -131,8 +131,8 @@ router.get('/price-history/:item', async (req: AuthRequest, res: Response) => {
 
     res.json({ item: itemName, history: results, stats });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to fetch price history';
-    res.status(500).json({ error: message });
+    console.error('expenses.ts:2 failed:', err);
+    res.status(500).json({ error: 'Failed to fetch price history' });
   }
 });
 
@@ -228,8 +228,8 @@ router.get('/analytics', async (req: AuthRequest, res: Response) => {
 
     res.json({ totalIncome, totalExpense, netBalance, categoryBreakdown, dailyTotals });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to fetch analytics';
-    res.status(500).json({ error: message });
+    console.error('expenses.ts:3 failed:', err);
+    res.status(500).json({ error: 'Failed to fetch analytics' });
   }
 });
 
@@ -284,8 +284,8 @@ router.get('/', async (req: AuthRequest, res: Response) => {
       total, page, pages: totalPages,
     });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to fetch expenses';
-    res.status(500).json({ error: message });
+    console.error('expenses.ts:4 failed:', err);
+    res.status(500).json({ error: 'Failed to fetch expenses' });
   }
 });
 
@@ -299,8 +299,8 @@ router.get('/:id', async (req: AuthRequest, res: Response) => {
     }
     res.json(expense);
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to fetch expense';
-    res.status(500).json({ error: message });
+    console.error('expenses.ts:5 failed:', err);
+    res.status(500).json({ error: 'Failed to fetch expense' });
   }
 });
 
@@ -358,8 +358,8 @@ router.post('/', expenseValidation, async (req: AuthRequest, res: Response) => {
       });
     }
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to create expense';
-    res.status(400).json({ error: message });
+    console.error('expenses.ts:6 failed:', err);
+    res.status(400).json({ error: 'Failed to create expense' });
   }
 });
 
@@ -423,8 +423,8 @@ router.put('/:id', [...expenseValidation, tagsValidation], async (req: AuthReque
     await expense.save();
     res.json(expense.toObject());
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to update expense';
-    res.status(400).json({ error: message });
+    console.error('expenses.ts:7 failed:', err);
+    res.status(400).json({ error: 'Failed to update expense' });
   }
 });
 
@@ -438,8 +438,8 @@ router.delete('/:id', async (req: AuthRequest, res: Response) => {
     }
     res.json({ message: 'Deleted' });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to delete expense';
-    res.status(500).json({ error: message });
+    console.error('expenses.ts:8 failed:', err);
+    res.status(500).json({ error: 'Failed to delete expense' });
   }
 });
 

--- a/src/routes/friends.ts
+++ b/src/routes/friends.ts
@@ -69,8 +69,8 @@ router.post(
 
       res.status(201).json({ id: friendship._id, status: 'pending', email });
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to send friend request';
-      res.status(500).json({ error: message });
+      console.error('friends.ts:1 failed:', err);
+      res.status(500).json({ error: 'Failed to send friend request' });
     }
   }
 );
@@ -99,8 +99,8 @@ router.get('/', async (req: AuthRequest, res: Response) => {
 
     res.json({ friends });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to fetch friends';
-    res.status(500).json({ error: message });
+    console.error('friends.ts:2 failed:', err);
+    res.status(500).json({ error: 'Failed to fetch friends' });
   }
 });
 
@@ -124,8 +124,8 @@ router.get('/pending', async (req: AuthRequest, res: Response) => {
 
     res.json({ requests });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to fetch pending requests';
-    res.status(500).json({ error: message });
+    console.error('friends.ts:3 failed:', err);
+    res.status(500).json({ error: 'Failed to fetch pending requests' });
   }
 });
 
@@ -147,8 +147,8 @@ router.post('/:id/accept', async (req: AuthRequest, res: Response) => {
     await friendship.save();
     res.json({ status: 'accepted' });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to accept request';
-    res.status(500).json({ error: message });
+    console.error('friends.ts:4 failed:', err);
+    res.status(500).json({ error: 'Failed to accept request' });
   }
 });
 
@@ -169,8 +169,8 @@ router.post('/:id/reject', async (req: AuthRequest, res: Response) => {
     await friendship.deleteOne();
     res.json({ status: 'removed' });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to reject request';
-    res.status(500).json({ error: message });
+    console.error('friends.ts:5 failed:', err);
+    res.status(500).json({ error: 'Failed to reject request' });
   }
 });
 
@@ -191,8 +191,8 @@ router.delete('/:id', async (req: AuthRequest, res: Response) => {
     await friendship.deleteOne();
     res.json({ status: 'removed' });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to remove friend';
-    res.status(500).json({ error: message });
+    console.error('friends.ts:6 failed:', err);
+    res.status(500).json({ error: 'Failed to remove friend' });
   }
 });
 

--- a/src/routes/goals.ts
+++ b/src/routes/goals.ts
@@ -15,8 +15,8 @@ router.get('/', async (req: AuthRequest, res: Response) => {
       .lean();
     res.json({ goals });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to fetch goals';
-    res.status(500).json({ error: message });
+    console.error('goals.ts:1 failed:', err);
+    res.status(500).json({ error: 'Failed to fetch goals' });
   }
 });
 
@@ -66,8 +66,8 @@ router.post(
       });
       res.status(201).json({ goal });
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to create goal';
-      res.status(500).json({ error: message });
+      console.error('goals.ts:2 failed:', err);
+      res.status(500).json({ error: 'Failed to create goal' });
     }
   }
 );
@@ -112,8 +112,8 @@ router.put(
       }
       res.json({ goal });
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to update goal';
-      res.status(500).json({ error: message });
+      console.error('goals.ts:3 failed:', err);
+      res.status(500).json({ error: 'Failed to update goal' });
     }
   }
 );
@@ -131,8 +131,8 @@ router.delete('/:id', async (req: AuthRequest, res: Response) => {
     }
     res.json({ deleted: true });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to delete goal';
-    res.status(500).json({ error: message });
+    console.error('goals.ts:4 failed:', err);
+    res.status(500).json({ error: 'Failed to delete goal' });
   }
 });
 

--- a/src/routes/import.ts
+++ b/src/routes/import.ts
@@ -349,8 +349,8 @@ router.post('/statement', statementUpload.single('file'), async (req: AuthReques
     const { matched, missing, discrepancies } = await reconcile(req.userId!, extracted);
     res.json({ extracted, matched, missing, discrepancies });
   } catch (err) {
-    const msg = err instanceof Error ? err.message : 'Scan failed';
-    res.status(500).json({ error: msg });
+    console.error('import.ts:scan failed:', err);
+    res.status(500).json({ error: 'Scan failed' });
   }
 });
 

--- a/src/routes/receipts.ts
+++ b/src/routes/receipts.ts
@@ -160,8 +160,8 @@ router.post('/scan', (req: Request, res: Response, next: NextFunction) => {
     if (!jsonMatch) throw new Error('No JSON found');
     extracted = JSON.parse(jsonMatch[0]);
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Could not extract data from receipt';
-    res.status(422).json({ error: message });
+    console.error('receipts.ts:extract failed:', err);
+    res.status(422).json({ error: 'Could not extract data from receipt' });
     return;
   }
 

--- a/src/routes/recurring.ts
+++ b/src/routes/recurring.ts
@@ -51,8 +51,8 @@ router.get('/', async (req: AuthRequest, res: Response) => {
     });
     res.json({ recurring });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to fetch recurring expenses';
-    res.status(500).json({ error: message });
+    console.error('recurring.ts:1 failed:', err);
+    res.status(500).json({ error: 'Failed to fetch recurring expenses' });
   }
 });
 
@@ -114,8 +114,8 @@ router.get('/:id', async (req: AuthRequest, res: Response) => {
 
     res.json(recurring.toObject());
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to fetch recurring expense';
-    res.status(500).json({ error: message });
+    console.error('recurring.ts:2 failed:', err);
+    res.status(500).json({ error: 'Failed to fetch recurring expense' });
   }
 });
 
@@ -185,8 +185,8 @@ router.delete('/:id', async (req: AuthRequest, res: Response) => {
 
     res.json({ message: 'Recurring expense deleted' });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to delete recurring expense';
-    res.status(500).json({ error: message });
+    console.error('recurring.ts:3 failed:', err);
+    res.status(500).json({ error: 'Failed to delete recurring expense' });
   }
 });
 

--- a/src/routes/reports.ts
+++ b/src/routes/reports.ts
@@ -74,8 +74,8 @@ router.get('/monthly', async (req: AuthRequest, res: Response) => {
 
     res.json({ data, baseCurrency });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to fetch monthly report';
-    res.status(500).json({ error: message });
+    console.error('reports.ts:1 failed:', err);
+    res.status(500).json({ error: 'Failed to fetch monthly report' });
   }
 });
 
@@ -147,8 +147,8 @@ router.get('/budget-summary', async (req: AuthRequest, res: Response) => {
 
     res.json({ data, totalBudgeted, totalSpent, totalRemaining, baseCurrency });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to fetch budget summary';
-    res.status(500).json({ error: message });
+    console.error('reports.ts:2 failed:', err);
+    res.status(500).json({ error: 'Failed to fetch budget summary' });
   }
 });
 
@@ -160,8 +160,8 @@ router.post('/weekly-digest', async (req: AuthRequest, res: Response) => {
     const sent = await sendWeeklyDigestForUser(userId);
     res.json({ sent, digest: data, message });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to generate weekly digest';
-    res.status(500).json({ error: message });
+    console.error('reports.ts:3 failed:', err);
+    res.status(500).json({ error: 'Failed to generate weekly digest' });
   }
 });
 

--- a/src/routes/tags.ts
+++ b/src/routes/tags.ts
@@ -30,8 +30,8 @@ router.get('/', async (req: AuthRequest, res: Response) => {
     const tags = await TagModel.find({ owner: req.userId }).sort({ name: 1 }).lean();
     res.json(tags);
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to fetch tags';
-    res.status(500).json({ error: message });
+    console.error('tags.ts:1 failed:', err);
+    res.status(500).json({ error: 'Failed to fetch tags' });
   }
 });
 
@@ -67,8 +67,8 @@ router.post('/', [nameValidation, colorValidation], async (req: AuthRequest, res
     const tag = await TagModel.create({ name, color, owner: req.userId });
     res.status(201).json(tag);
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to create tag';
-    res.status(400).json({ error: message });
+    console.error('tags.ts:2 failed:', err);
+    res.status(400).json({ error: 'Failed to create tag' });
   }
 });
 
@@ -112,8 +112,8 @@ router.put('/:id', [nameValidation, colorValidation], async (req: AuthRequest, r
     await tag.save();
     res.json(tag.toObject());
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to update tag';
-    res.status(400).json({ error: message });
+    console.error('tags.ts:3 failed:', err);
+    res.status(400).json({ error: 'Failed to update tag' });
   }
 });
 
@@ -142,8 +142,8 @@ router.delete('/:id', async (req: AuthRequest, res: Response) => {
 
     res.json({ message: 'Tag deleted' });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to delete tag';
-    res.status(500).json({ error: message });
+    console.error('tags.ts:4 failed:', err);
+    res.status(500).json({ error: 'Failed to delete tag' });
   }
 });
 

--- a/src/routes/templates.ts
+++ b/src/routes/templates.ts
@@ -26,8 +26,8 @@ router.get('/', async (req: AuthRequest, res: Response) => {
     });
     res.json({ templates });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to fetch templates';
-    res.status(500).json({ error: message });
+    console.error('templates.ts:1 failed:', err);
+    res.status(500).json({ error: 'Failed to fetch templates' });
   }
 });
 
@@ -73,8 +73,8 @@ router.get('/:id', async (req: AuthRequest, res: Response) => {
 
     res.json(template.toObject());
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to fetch template';
-    res.status(500).json({ error: message });
+    console.error('templates.ts:2 failed:', err);
+    res.status(500).json({ error: 'Failed to fetch template' });
   }
 });
 
@@ -129,8 +129,8 @@ router.delete('/:id', async (req: AuthRequest, res: Response) => {
 
     res.json({ message: 'Template deleted' });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to delete template';
-    res.status(500).json({ error: message });
+    console.error('templates.ts:3 failed:', err);
+    res.status(500).json({ error: 'Failed to delete template' });
   }
 });
 

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -17,8 +17,8 @@ router.get('/me', async (req: AuthRequest, res: Response) => {
     }
     res.json({ user });
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to fetch user';
-    res.status(500).json({ error: message });
+    console.error('users.ts:1 failed:', err);
+    res.status(500).json({ error: 'Failed to fetch user' });
   }
 });
 
@@ -57,8 +57,8 @@ router.patch(
 
       res.json({ user });
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to update profile';
-      res.status(500).json({ error: message });
+      console.error('users.ts:2 failed:', err);
+      res.status(500).json({ error: 'Failed to update profile' });
     }
   }
 );
@@ -96,8 +96,8 @@ router.patch(
 
       res.json({ user });
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to update preferences';
-      res.status(500).json({ error: message });
+      console.error('users.ts:3 failed:', err);
+      res.status(500).json({ error: 'Failed to update preferences' });
     }
   }
 );
@@ -148,8 +148,8 @@ router.patch(
 
       res.json({ message: 'Password updated' });
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to update password';
-      res.status(500).json({ error: message });
+      console.error('users.ts:4 failed:', err);
+      res.status(500).json({ error: 'Failed to update password' });
     }
   }
 );


### PR DESCRIPTION
## Summary
- Sweep across **14 route files / 50 catch blocks** to stop leaking internal error text (DB driver messages, mongoose validation strings, stack hints) to API clients.
- Now logs raw error server-side via \`console.error('FILE:N failed:', err)\` and returns the static \`Failed to …\` message that was previously unreachable as a fallback.

## Files touched
accounts, auth, budgets, exchange-rates, expenses, friends, goals, import, receipts, recurring, reports, tags, templates, users (route files only — jobs/utils already use the safe pattern).

## Why the existing tests don't break
None of the 753 tests asserted the leaky raw-error shape — they only checked for status codes + presence of an \`error\` field. So no test updates needed.

## Test plan
- [x] \`grep -r "err instanceof Error ? err.message" src/\` → 0 results
- [x] \`yarn build\` clean
- [x] \`yarn test --runInBand\` → **753/753 passing**
- [x] Coverage still ≥85% (86.64%)
- [ ] CI \`build\` job green
- [ ] Main green after merge

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)