### PR TITLE
ops: add Fly.io auto-deploy on push to main (#176)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,13 @@
+name: Deploy to Fly.io
+on:
+  push:
+    branches: [main]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deploy.yml` that runs `flyctl deploy --remote-only` on every push to `main`
- Triggered only on `main` pushes — no effect on PRs or other branches
- Uses `superfly/flyctl-actions/setup-flyctl@master` (official Fly.io action)

## Prerequisite
`FLY_API_TOKEN` must be set as a GitHub repository secret before this workflow will deploy successfully.

Get the token: `flyctl auth token` on the CLI, then add it at:
Settings → Secrets and variables → Actions → New repository secret

Closes #176