### PR TITLE
feat: AI money assistant endpoint (#185)

### DIFF
--- a/__tests__/chat.test.ts
+++ b/__tests__/chat.test.ts
@@ -1,0 +1,234 @@
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+process.env.GROQ_API_KEY = 'test-groq-key';
+jest.setTimeout(30000);
+
+const mockCreate = jest.fn();
+
+jest.mock('groq-sdk', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    chat: { completions: { create: mockCreate } },
+  })),
+}));
+
+import request from 'supertest';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import jwt from 'jsonwebtoken';
+import app from '../src/app';
+import UserModel from '../src/models/User';
+import ExpenseModel from '../src/models/Expense';
+
+let mongod: MongoMemoryServer;
+let testUserId: string;
+let authToken: string;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri(), {
+    connectTimeoutMS: 10000,
+    serverSelectionTimeoutMS: 10000,
+  });
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongod.stop();
+});
+
+beforeEach(async () => {
+  const user = await UserModel.create({
+    email: `chat-test-${Date.now()}@example.com`,
+    password: 'password123',
+    budgets: [{ category: 'Food', limit: 2000 }],
+  });
+  testUserId = (user._id as mongoose.Types.ObjectId).toString();
+  authToken = jwt.sign({ userId: testUserId }, 'test-secret', { expiresIn: '1h' });
+
+  mockCreate.mockReset();
+  mockCreate.mockResolvedValue({
+    choices: [{ message: { content: 'You spent 500 on food this month.' } }],
+  });
+});
+
+afterEach(async () => {
+  await UserModel.deleteMany({});
+  await ExpenseModel.deleteMany({});
+});
+
+describe('POST /api/chat/money-assistant', () => {
+  it('returns 401 without auth token', async () => {
+    const res = await request(app)
+      .post('/api/chat/money-assistant')
+      .send({ message: 'How much did I spend on food?' });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for empty message', async () => {
+    const res = await request(app)
+      .post('/api/chat/money-assistant')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ message: '' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.errors).toBeDefined();
+  });
+
+  it('returns 400 for missing message field', async () => {
+    const res = await request(app)
+      .post('/api/chat/money-assistant')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({});
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for message exceeding 500 characters', async () => {
+    const res = await request(app)
+      .post('/api/chat/money-assistant')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ message: 'a'.repeat(501) });
+
+    expect(res.status).toBe(400);
+    expect(res.body.errors).toBeDefined();
+  });
+
+  it('accepts message of exactly 500 characters', async () => {
+    const res = await request(app)
+      .post('/api/chat/money-assistant')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ message: 'a'.repeat(500) });
+
+    expect(res.status).toBe(200);
+    expect(res.body.reply).toBe('You spent 500 on food this month.');
+  });
+
+  it('returns reply from Groq on valid request', async () => {
+    const res = await request(app)
+      .post('/api/chat/money-assistant')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ message: 'How much did I spend on food?' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.reply).toBe('You spent 500 on food this month.');
+  });
+
+  it('includes expense data in context sent to Groq', async () => {
+    const recentDate = new Date();
+    recentDate.setDate(recentDate.getDate() - 10);
+
+    await ExpenseModel.create({
+      owner: testUserId,
+      type: 'expense',
+      category: 'Food',
+      amount: 150,
+      item: "McDonald's",
+      date: recentDate,
+    });
+
+    await request(app)
+      .post('/api/chat/money-assistant')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ message: 'What did I spend on food?' });
+
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    const callArgs = mockCreate.mock.calls[0][0];
+    const systemMessage = callArgs.messages[0].content as string;
+    expect(systemMessage).toContain('Food');
+    expect(systemMessage).toContain('150');
+  });
+
+  it('includes budget vs actual in context sent to Groq', async () => {
+    const now = new Date();
+    await ExpenseModel.create({
+      owner: testUserId,
+      type: 'expense',
+      category: 'Food',
+      amount: 800,
+      date: new Date(now.getFullYear(), now.getMonth(), 5),
+    });
+
+    await request(app)
+      .post('/api/chat/money-assistant')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ message: 'How is my food budget?' });
+
+    const callArgs = mockCreate.mock.calls[0][0];
+    const systemMessage = callArgs.messages[0].content as string;
+    expect(systemMessage).toContain('2000');
+    expect(systemMessage).toContain('800');
+  });
+
+  it('returns fallback reply when Groq throws an error', async () => {
+    mockCreate.mockRejectedValue(new Error('Groq API unavailable'));
+
+    const res = await request(app)
+      .post('/api/chat/money-assistant')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ message: 'How much did I spend?' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.reply).toBe("I couldn't analyse your data right now. Try again in a moment.");
+  });
+
+  it('returns fallback reply when Groq returns empty content', async () => {
+    mockCreate.mockResolvedValue({
+      choices: [{ message: { content: '' } }],
+    });
+
+    const res = await request(app)
+      .post('/api/chat/money-assistant')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ message: 'How much did I spend?' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.reply).toBe("I couldn't analyse your data right now. Try again in a moment.");
+  });
+
+  it('excludes expenses older than 90 days from context', async () => {
+    const oldDate = new Date();
+    oldDate.setDate(oldDate.getDate() - 100);
+
+    await ExpenseModel.create([
+      {
+        owner: testUserId,
+        type: 'expense',
+        category: 'Shopping',
+        amount: 9999,
+        date: oldDate,
+      },
+      {
+        owner: testUserId,
+        type: 'expense',
+        category: 'Food',
+        amount: 100,
+        date: new Date(),
+      },
+    ]);
+
+    await request(app)
+      .post('/api/chat/money-assistant')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ message: 'What did I spend?' });
+
+    const callArgs = mockCreate.mock.calls[0][0];
+    const systemMessage = callArgs.messages[0].content as string;
+    expect(systemMessage).not.toContain('9999');
+    expect(systemMessage).toContain('Food');
+  });
+
+  it('passes user message to Groq as user role', async () => {
+    const userMessage = 'Where am I overspending?';
+
+    await request(app)
+      .post('/api/chat/money-assistant')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ message: userMessage });
+
+    const callArgs = mockCreate.mock.calls[0][0];
+    const userMsg = callArgs.messages.find((m: { role: string }) => m.role === 'user');
+    expect(userMsg?.content).toBe(userMessage);
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -26,6 +26,7 @@ import goalRoutes from './routes/goals';
 import transactionRoutes from './routes/transactions';
 import notificationRoutes from './routes/notifications';
 import tagRoutes from './routes/tags';
+import chatRoutes from './routes/chat';
 import { startAlertScheduler } from './jobs/processAlerts';
 import { startBudgetAlertPushScheduler } from './jobs/budgetAlertPush';
 import { startWeeklySummaryPushScheduler } from './jobs/weeklySummaryPush';
@@ -96,6 +97,7 @@ app.use('/api/goals', goalRoutes);
 app.use('/api/transactions', transactionRoutes);
 app.use('/api/notifications', notificationRoutes);
 app.use('/api/tags', tagRoutes);
+app.use('/api/chat', chatRoutes);
 
 Sentry.setupExpressErrorHandler(app);
 

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -1,0 +1,123 @@
+import { Router, Response } from 'express';
+import { body, validationResult } from 'express-validator';
+import Groq from 'groq-sdk';
+import ExpenseModel from '../models/Expense';
+import UserModel from '../models/User';
+import { protect, AuthRequest } from '../middleware/auth';
+
+const router = Router();
+router.use(protect);
+
+const FALLBACK_REPLY = "I couldn't analyse your data right now. Try again in a moment.";
+
+function buildFinanceContext(
+  expenses: Array<{ category?: string; amount: number; item?: string; description?: string; date?: Date }>,
+  budgets: Array<{ category: string; limit: number }>,
+  monthExpenses: Array<{ category?: string; amount: number }>,
+): string {
+  const categoryTotals: Record<string, number> = {};
+  const merchantTotals: Record<string, number> = {};
+
+  for (const e of expenses) {
+    const cat = e.category || 'Other';
+    categoryTotals[cat] = (categoryTotals[cat] || 0) + e.amount;
+
+    const merchant = e.item || e.description;
+    if (merchant) {
+      merchantTotals[merchant] = (merchantTotals[merchant] || 0) + e.amount;
+    }
+  }
+
+  const topMerchants = Object.entries(merchantTotals)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5)
+    .map(([name, amount]) => ({ name, amount: Math.round(amount) }));
+
+  const monthCategorySpend: Record<string, number> = {};
+  for (const e of monthExpenses) {
+    const cat = e.category || 'Other';
+    monthCategorySpend[cat] = (monthCategorySpend[cat] || 0) + e.amount;
+  }
+
+  const budgetVsActual = budgets.map((b) => ({
+    category: b.category,
+    limit: b.limit,
+    spent: Math.round(monthCategorySpend[b.category] || 0),
+  }));
+
+  const categoryBreakdown = Object.entries(categoryTotals)
+    .sort((a, b) => b[1] - a[1])
+    .map(([cat, amt]) => ({ category: cat, total: Math.round(amt) }));
+
+  return JSON.stringify({
+    period: 'last 90 days',
+    categoryTotals: categoryBreakdown,
+    topMerchants,
+    currentMonthBudgets: budgetVsActual,
+  });
+}
+
+router.post(
+  '/money-assistant',
+  [
+    body('message')
+      .isString()
+      .trim()
+      .notEmpty()
+      .withMessage('message is required')
+      .isLength({ max: 500 })
+      .withMessage('message must be at most 500 characters'),
+  ],
+  async (req: AuthRequest, res: Response): Promise<void> => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({ errors: errors.array() });
+      return;
+    }
+
+    const { message } = req.body as { message: string };
+
+    const now = new Date();
+    const ninetyDaysAgo = new Date(now);
+    ninetyDaysAgo.setDate(ninetyDaysAgo.getDate() - 90);
+    const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+
+    try {
+      const [expenses, monthExpenses, user] = await Promise.all([
+        ExpenseModel.find(
+          { owner: req.userId, type: 'expense', date: { $gte: ninetyDaysAgo } },
+          { category: 1, amount: 1, item: 1, description: 1, date: 1 },
+        ).lean(),
+        ExpenseModel.find(
+          { owner: req.userId, type: 'expense', date: { $gte: monthStart } },
+          { category: 1, amount: 1 },
+        ).lean(),
+        UserModel.findById(req.userId, { budgets: 1 }).lean(),
+      ]);
+
+      const budgets = user?.budgets ?? [];
+      const context = buildFinanceContext(expenses, budgets, monthExpenses);
+
+      const systemPrompt = `You are a personal finance assistant. The user's spending data: ${context}. Answer the user's question concisely in 2-3 sentences using only the data provided.`;
+
+      const groq = new Groq({ apiKey: process.env.GROQ_API_KEY });
+
+      const completion = await groq.chat.completions.create({
+        model: 'llama-3.3-70b-versatile',
+        messages: [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: message },
+        ],
+        temperature: 0.3,
+        max_tokens: 256,
+      });
+
+      const reply = completion.choices[0]?.message?.content?.trim() || FALLBACK_REPLY;
+      res.json({ reply });
+    } catch {
+      res.json({ reply: FALLBACK_REPLY });
+    }
+  },
+);
+
+export default router;


### PR DESCRIPTION
## What
`POST /api/chat/money-assistant` — auth-protected endpoint that fetches last 90 days of transactions and current month budgets, builds compact context (category totals, top 5 merchants, budget vs actual), and calls Groq LLaMA 3.3 70B to return a grounded 2–3 sentence reply.

## Why
Closes #185

## Acceptance Criteria
- [x] `POST /api/chat/money-assistant` accepts `{ message: string }`, returns `{ reply: string }`
- [x] Auth-protected (JWT middleware — same `protect` pattern as all other routes)
- [x] Fetches last 90 days of transactions + current month budgets for the authenticated user
- [x] Builds compact context (category totals, top merchants, budget vs actual) and sends to Groq
- [x] Handles Groq errors gracefully — returns a helpful fallback string (never 500)
- [x] Validates input: rejects empty or >500 char messages with 400
- [x] Unit tests for the route (mock Groq + DB calls) — 12 tests, all passing
- [x] `tsc --noEmit` passes

## Test Plan
1. `POST /api/chat/money-assistant` with no auth → 401
2. `POST /api/chat/money-assistant` with auth, `message: ""` → 400
3. `POST /api/chat/money-assistant` with auth, message >500 chars → 400
4. `POST /api/chat/money-assistant` with auth, valid message → 200 `{ reply: "..." }`
5. Simulate Groq failure → 200 with fallback string, never 500